### PR TITLE
use default docker repo

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -28,7 +28,6 @@ products:
             cp -R ./server/templates ${DIST_WORK_DIR}
             cp -R ./build/static ${DIST_WORK_DIR}
     docker:
-      repository: hub.docker.com
       docker-builders:
         policy-bot:
           type: default


### PR DESCRIPTION
due to a bug in the godel config, 1.2.0 was published manually. this should fix it