### PR TITLE
Fix status auditing and improve post status API

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -79,7 +79,7 @@ func (b *Base) PostStatus(ctx context.Context, client *github.Client, pr *github
 	sha := pr.GetHead().GetSHA()
 
 	publicURL := strings.TrimSuffix(b.BaseConfig.PublicURL, "/")
-	detailsURL := fmt.Sprintf("%s/details/%s/%d", publicURL, pr.GetBase().GetRepo().GetFullName(), pr.GetNumber())
+	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, pr.GetNumber())
 
 	contextWithBranch := fmt.Sprintf("%s: %s", b.PullOpts.StatusCheckContext, pr.GetBase().GetLabel())
 	status := &github.RepoStatus{

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -108,10 +108,7 @@ func (h *IssueComment) detectAndLogTampering(ctx context.Context, client *github
 		msg := fmt.Sprintf("Entity %s edited approval comment by %s", eventAuthor, commentAuthor)
 		logger.Warn().Str(LogKeyAudit, "issue_comment").Msg(msg)
 
-		repo := pr.GetBase().GetRepo()
-		srcSHA := pr.GetHead().GetSHA()
-
-		err := h.PostStatus(ctx, client, repo.GetOwner().GetLogin(), repo.GetName(), srcSHA, "failure", msg, nil)
+		err := h.PostStatus(ctx, client, pr, "failure", msg)
 		return true, err
 	}
 

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -72,6 +72,9 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 		)
 		logger.Warn().Str(LogKeyAudit, eventType).Msg(auditMessage)
 
+		// unlike in other code, use a single context here because we want to
+		// replace a forged context with a failure, not post a general status
+		// if multiple contexts are forged, we will handle multiple events
 		status := &github.RepoStatus{
 			Context:     event.Context,
 			State:       github.String("failure"),

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/palantir/go-githubapp/githubapp"
@@ -50,8 +51,8 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
 
-	// Ignore contexts that are not ours
-	if event.GetContext() != h.PullOpts.StatusCheckContext {
+	// ignore contexts that are not ours
+	if !strings.HasPrefix(event.GetContext(), h.PullOpts.StatusCheckContext) {
 		logger.Debug().Msgf("Ignoring context event for '%s'", event.GetContext())
 		return nil
 	}
@@ -60,10 +61,24 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	commitSHA := event.GetCommit().GetSHA()
 
 	if sender.GetLogin() != h.PullOpts.AppName+"[bot]" {
-		auditMessage := fmt.Sprintf("Entity '%s' overwrote status check '%s' on ref=%s to status='%s' description='%s' targetURL='%s'", sender.GetLogin(), h.PullOpts.StatusCheckContext, commitSHA, event.GetState(), event.GetDescription(), event.GetTargetURL())
+		auditMessage := fmt.Sprintf(
+			"Entity '%s' overwrote status check '%s' on ref=%s to status='%s' description='%s' targetURL='%s'",
+			sender.GetLogin(),
+			event.GetContext(),
+			commitSHA,
+			event.GetState(),
+			event.GetDescription(),
+			event.GetTargetURL(),
+		)
 		logger.Warn().Str(LogKeyAudit, eventType).Msg(auditMessage)
 
-		err := h.PostStatus(ctx, client, ownerName, repoName, commitSHA, "failure", auditMessage, nil)
+		status := &github.RepoStatus{
+			Context:     event.Context,
+			State:       github.String("failure"),
+			Description: &auditMessage,
+		}
+
+		_, _, err := client.Repositories.CreateStatus(ctx, ownerName, repoName, commitSHA, status)
 		return err
 	}
 


### PR DESCRIPTION
Fixes an NPE and a bad comparison when posting statuses for failed
status audits. Because the status audit code now mirrors the bad context
(to avoid looking up PR information), the base PostStatus method can
take fewer arguments and require a pull request.