### PR TITLE
Correctly handle dismissed GitHub reviews

### DIFF
--- a/pull/context.go
+++ b/pull/context.go
@@ -125,4 +125,7 @@ type Review struct {
 	Author    string
 	State     ReviewState
 	Body      string
+
+	// ID is the GitHub node ID of the review, used to resolve dismissals
+	ID string
 }

--- a/pull/context.go
+++ b/pull/context.go
@@ -114,10 +114,10 @@ type ReviewState string
 
 const (
 	ReviewApproved         ReviewState = "approved"
-	ReviewChangesRequested             = "changes_requested"
-	ReviewCommented                    = "commented"
-	ReviewDismissed                    = "dismissed"
-	ReviewPending                      = "pending"
+	ReviewChangesRequested ReviewState = "changes_requested"
+	ReviewCommented        ReviewState = "commented"
+	ReviewDismissed        ReviewState = "dismissed"
+	ReviewPending          ReviewState = "pending"
 )
 
 type Review struct {

--- a/pull/github.go
+++ b/pull/github.go
@@ -250,10 +250,9 @@ func (ghc *GitHubContext) loadTimeline() error {
 				ID:        event.PullRequestReview.ID,
 			})
 		case "ReviewDismissedEvent":
-			for i, r := range ghc.reviews {
+			for _, r := range ghc.reviews {
 				if r.ID == event.ReviewDismissedEvent.Review.ID {
-					ghc.reviews = append(ghc.reviews[:i], ghc.reviews[i+1:]...)
-					break
+					r.State = ReviewDismissed
 				}
 			}
 		case "IssueComment":

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -129,22 +129,27 @@ func TestReviews(t *testing.T) {
 	reviews, err := ctx.Reviews()
 	require.NoError(t, err)
 
-	require.Len(t, reviews, 1, "incorrect number of reviews")
+	require.Len(t, reviews, 2, "incorrect number of reviews")
 	assert.Equal(t, 1, timelineRule.Count, "no http request was made")
 
 	expectedTime, err := time.Parse(time.RFC3339, "2018-06-27T20:33:26Z")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "bkeyes", reviews[0].Author)
+	assert.Equal(t, "mhaypenny", reviews[0].Author)
 	assert.Equal(t, expectedTime, reviews[0].CreatedAt)
-	assert.Equal(t, ReviewApproved, reviews[0].State)
-	assert.Equal(t, "the body", reviews[0].Body)
+	assert.Equal(t, ReviewDismissed, reviews[0].State)
+	assert.Equal(t, "", reviews[0].Body)
+
+	assert.Equal(t, "bkeyes", reviews[1].Author)
+	assert.Equal(t, expectedTime.Add(time.Second), reviews[1].CreatedAt)
+	assert.Equal(t, ReviewApproved, reviews[1].State)
+	assert.Equal(t, "the body", reviews[1].Body)
 
 	// verify that the review list is cached
 	reviews, err = ctx.Reviews()
 	require.NoError(t, err)
 
-	require.Len(t, reviews, 1, "incorrect number of reviews")
+	require.Len(t, reviews, 2, "incorrect number of reviews")
 	assert.Equal(t, 1, timelineRule.Count, "cached reviews were not used")
 }
 

--- a/pull/testdata/responses/timeline_review.yml
+++ b/pull/testdata/responses/timeline_review.yml
@@ -19,7 +19,7 @@
                   },
                   "state": "CHANGED_REQUESTED",
                   "body": "",
-                  "submittedAt": "2018-06-27T20:30:00Z"
+                  "submittedAt": "2018-06-27T20:33:26Z"
                 },
                 {
                   "__typename": "PullRequestReview",
@@ -29,7 +29,7 @@
                   },
                   "state": "APPROVED",
                   "body": "the body",
-                  "submittedAt": "2018-06-27T20:33:26Z"
+                  "submittedAt": "2018-06-27T20:33:27Z"
                 },
                 {
                   "__typename": "ReviewDismissedEvent",

--- a/pull/testdata/responses/timeline_review.yml
+++ b/pull/testdata/responses/timeline_review.yml
@@ -13,12 +13,30 @@
               "nodes": [
                 {
                   "__typename": "PullRequestReview",
+                  "id": "12345",
+                  "author": {
+                    "login": "mhaypenny"
+                  },
+                  "state": "CHANGED_REQUESTED",
+                  "body": "",
+                  "submittedAt": "2018-06-27T20:30:00Z"
+                },
+                {
+                  "__typename": "PullRequestReview",
+                  "id": "12347",
                   "author": {
                     "login": "bkeyes"
                   },
                   "state": "APPROVED",
                   "body": "the body",
                   "submittedAt": "2018-06-27T20:33:26Z"
+                },
+                {
+                  "__typename": "ReviewDismissedEvent",
+                  "createdAt": "2018-06-27T20:37:15Z",
+                  "review": {
+                    "id": "12345"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
When a review is dismissed, remove it from the review list as though it
never happened. This should be equivalent to a user deleting an approval
comment, although unlike in that case, we don't audit for this event.
Because GitHub provides the ability to restrict review dismissal, this
seems safe.

Fixes #28.