### PR TITLE
Add IgnoreUpdateMerges option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ UI to view the detailed approval status of any pull request.
     - [Disapproval is Disabled by Default](#disapproval-is-disabled-by-default)
     - [`or`, `and`, and `if` (Rule Predicates)](#or-and-and-if-rule-predicates)
     - [Cross-organization Membership Tests](#cross-organization-membership-tests)
+    - [Update Merges](#update-merges)
 * [Deployment](#deployment)
 * [Development](#development)
 * [Contributing](#contributing)
@@ -163,6 +164,13 @@ options:
   # approvals for this rule. False by default.
   invalidate_on_push: false
 
+  # If true, "update merges" do not invalidate approval (if invalidate_on_push
+  # is enabled) and their authors/committers do not count as contributors. An
+  # "update merge" is a merge commit that was created in the UI or via the API
+  # and merges the target branch into the pull request branch. These are
+  # commonly created by using the "Update branch" button in the UI.
+  ignore_update_merges: false
+
   # "methods" defines how users may express approval. The defaults are below.
   methods:
     comments:
@@ -293,6 +301,24 @@ Effectively, skipped rules are treated as if they don't exist.
 `policy-bot` allows approval rules to reference organizations and teams that are
 not in the organization that owns the repository where the rules appear. In
 this case, `policy-bot` must be installed on all referenced organizations.
+
+#### Update Merges
+
+For a commit on a branch to count as an "update merge" for the purpose of the
+`ignore_update_merges` option, the following must be true:
+
+1. The commit must have exactly two parents
+2. The commit must have the `committedViaWeb` property set to `true`
+3. One parent must exist in the last 100 commits on the target branch of the
+   pull request
+
+These will all be true after updating a branch using the UI, but historic
+merges on long-running branches or merges created with the API may not be
+ignored. If this happens, you will need to reapprove the pull request.
+
+Note that `policy-bot` cannot detect if an update merge contains any merge
+conflict resolutions. If you enable this option, users _may_ be able to merge
+unapproved code by exploiting the conflict editor.
 
 ## Deployment
 

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -34,84 +34,100 @@ func TestIsApproved(t *testing.T) {
 	ctx := logger.WithContext(context.Background())
 
 	now := time.Now()
-	prctx := &pulltest.Context{
-		AuthorValue: "mhaypenny",
-		CommentsValue: []*pull.Comment{
-			{
-				CreatedAt: now.Add(10 * time.Second),
-				Author:    "other-user",
-				Body:      "Why did you do this?",
+	basePullContext := func() *pulltest.Context {
+		return &pulltest.Context{
+			AuthorValue: "mhaypenny",
+			CommentsValue: []*pull.Comment{
+				{
+					CreatedAt: now.Add(10 * time.Second),
+					Author:    "other-user",
+					Body:      "Why did you do this?",
+				},
+				{
+					CreatedAt: now.Add(20 * time.Second),
+					Author:    "comment-approver",
+					Body:      "LGTM :+1: :shipit:",
+				},
+				{
+					CreatedAt: now.Add(30 * time.Second),
+					Author:    "disapprover",
+					Body:      "I don't like things! :-1:",
+				},
+				{
+					CreatedAt: now.Add(40 * time.Second),
+					Author:    "mhaypenny",
+					Body:      ":+1: my stuff is cool",
+				},
+				{
+					CreatedAt: now.Add(50 * time.Second),
+					Author:    "contributor-author",
+					Body:      ":+1: I added to this PR",
+				},
+				{
+					CreatedAt: now.Add(60 * time.Second),
+					Author:    "contributor-committer",
+					Body:      ":+1: I also added to this PR",
+				},
 			},
-			{
-				CreatedAt: now.Add(20 * time.Second),
-				Author:    "comment-approver",
-				Body:      "LGTM :+1: :shipit:",
+			ReviewsValue: []*pull.Review{
+				{
+					CreatedAt: now.Add(70 * time.Second),
+					Author:    "disapprover",
+					State:     pull.ReviewChangesRequested,
+					Body:      "I _really_ don't like things!",
+				},
+				{
+					CreatedAt: now.Add(80 * time.Second),
+					Author:    "review-approver",
+					State:     pull.ReviewApproved,
+					Body:      "I LIKE THIS",
+				},
 			},
-			{
-				CreatedAt: now.Add(30 * time.Second),
-				Author:    "disapprover",
-				Body:      "I don't like things! :-1:",
+			CommitsValue: []*pull.Commit{
+				{
+					CreatedAt: now.Add(5 * time.Second),
+					SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
+					Author:    "mhaypenny",
+					Committer: "mhaypenny",
+				},
+				{
+					CreatedAt: now.Add(15 * time.Second),
+					SHA:       "674832587eaaf416371b30f5bc5a47e377f534ec",
+					Author:    "contributor-author",
+					Committer: "mhaypenny",
+				},
+				{
+					CreatedAt: now.Add(45 * time.Second),
+					SHA:       "97d5ea26da319a987d80f6db0b7ef759f2f2e441",
+					Author:    "mhaypenny",
+					Committer: "contributor-committer",
+				},
 			},
-			{
-				CreatedAt: now.Add(40 * time.Second),
-				Author:    "mhaypenny",
-				Body:      ":+1: my stuff is cool",
+			TargetCommitsValue: []*pull.Commit{
+				{
+					CreatedAt: now.Add(5 * time.Second),
+					SHA:       "dc594ff5aca4133070a76f9006568b656a251770",
+					Author:    "developer",
+					Committer: "developer",
+				},
+				{
+					CreatedAt: now.Add(0 * time.Second),
+					SHA:       "2e1b0bb6ab144bf7a1b7a1df9d3bdcb0fe85a206",
+					Author:    "developer",
+					Committer: "developer",
+				},
 			},
-			{
-				CreatedAt: now.Add(50 * time.Second),
-				Author:    "contributor-author",
-				Body:      ":+1: I added to this PR",
+			OrgMemberships: map[string][]string{
+				"mhaypenny":             {"everyone"},
+				"contributor-author":    {"everyone"},
+				"contributor-committer": {"everyone"},
+				"comment-approver":      {"everyone", "cool-org"},
+				"review-approver":       {"everyone", "even-cooler-org"},
 			},
-			{
-				CreatedAt: now.Add(60 * time.Second),
-				Author:    "contributor-committer",
-				Body:      ":+1: I also added to this PR",
-			},
-		},
-		ReviewsValue: []*pull.Review{
-			{
-				CreatedAt: now.Add(70 * time.Second),
-				Author:    "disapprover",
-				State:     pull.ReviewChangesRequested,
-				Body:      "I _really_ don't like things!",
-			},
-			{
-				CreatedAt: now.Add(80 * time.Second),
-				Author:    "review-approver",
-				State:     pull.ReviewApproved,
-				Body:      "I LIKE THIS",
-			},
-		},
-		CommitsValue: []*pull.Commit{
-			{
-				CreatedAt: now.Add(90 * time.Second),
-				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
-				Author:    "mhaypenny",
-				Committer: "mhaypenny",
-			},
-			{
-				CreatedAt: now.Add(100 * time.Second),
-				SHA:       "674832587eaaf416371b30f5bc5a47e377f534ec",
-				Author:    "contributor-author",
-				Committer: "mhaypenny",
-			},
-			{
-				CreatedAt: now.Add(110 * time.Second),
-				SHA:       "97d5ea26da319a987d80f6db0b7ef759f2f2e441",
-				Author:    "mhaypenny",
-				Committer: "contributor-committer",
-			},
-		},
-		OrgMemberships: map[string][]string{
-			"mhaypenny":             {"everyone"},
-			"contributor-author":    {"everyone"},
-			"contributor-committer": {"everyone"},
-			"comment-approver":      {"everyone", "cool-org"},
-			"review-approver":       {"everyone", "even-cooler-org"},
-		},
+		}
 	}
 
-	assertApproved := func(t *testing.T, r *Rule, expected string) {
+	assertApproved := func(t *testing.T, prctx pull.Context, r *Rule, expected string) {
 		approved, msg, err := r.IsApproved(ctx, prctx)
 		require.NoError(t, err)
 
@@ -120,7 +136,7 @@ func TestIsApproved(t *testing.T) {
 		}
 	}
 
-	assertPending := func(t *testing.T, r *Rule, expected string) {
+	assertPending := func(t *testing.T, prctx pull.Context, r *Rule, expected string) {
 		approved, msg, err := r.IsApproved(ctx, prctx)
 		require.NoError(t, err)
 
@@ -130,20 +146,23 @@ func TestIsApproved(t *testing.T) {
 	}
 
 	t.Run("noApprovalRequired", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{}
-		assertApproved(t, r, "No approval required")
+		assertApproved(t, prctx, r, "No approval required")
 	})
 
 	t.Run("singleApprovalRequired", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Requires: Requires{
 				Count: 1,
 			},
 		}
-		assertPending(t, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
 	})
 
 	t.Run("authorCannotApprove", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
 				AllowAuthor: false,
@@ -155,10 +174,11 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver, review-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver, review-approver")
 	})
 
 	t.Run("contributorsCannotApprove", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
 				AllowContributor: false,
@@ -170,10 +190,11 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver, review-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver, review-approver")
 	})
 
 	t.Run("contributorsCanApprove", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
 				AllowContributor: true,
@@ -185,10 +206,11 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver, mhaypenny, contributor-author, contributor-committer, review-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver, mhaypenny, contributor-author, contributor-committer, review-approver")
 	})
 
 	t.Run("specificUserApproves", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Requires: Requires{
 				Count: 1,
@@ -197,7 +219,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r = &Rule{
 			Requires: Requires{
@@ -207,10 +229,11 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
 	})
 
 	t.Run("specificOrgApproves", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Requires: Requires{
 				Count: 1,
@@ -219,7 +242,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r = &Rule{
 			Requires: Requires{
@@ -229,10 +252,11 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 5 approvals from disqualified users")
 	})
 
 	t.Run("specificOrgsOrUserApproves", func(t *testing.T) {
+		prctx := basePullContext()
 		r := &Rule{
 			Requires: Requires{
 				Count: 2,
@@ -242,12 +266,14 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertApproved(t, r, "Approved by comment-approver, review-approver")
+		assertApproved(t, prctx, r, "Approved by comment-approver, review-approver")
 	})
 
-	t.Run("invalidateOnPush_comment", func(t *testing.T) {
+	t.Run("invalidateCommentOnPush", func(t *testing.T) {
+		prctx := basePullContext()
 		prctx.CommitsValue = []*pull.Commit{
 			{
+				CreatedAt: now.Add(25 * time.Second),
 				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
 				Author:    "mhaypenny",
 				Committer: "mhaypenny",
@@ -261,23 +287,18 @@ func TestIsApproved(t *testing.T) {
 					Users: []string{"comment-approver"},
 				},
 			},
-			Options: Options{
-				InvalidateOnPush: true,
-			},
 		}
+		assertApproved(t, prctx, r, "Approved by comment-approver")
 
-		// set the commit after the comment
-		prctx.CommitsValue[0].CreatedAt = now.Add(25 * time.Second)
-		assertPending(t, r, "0/1 approvals required. Ignored 4 approvals from disqualified users")
-
-		// set the commit before the comment
-		prctx.CommitsValue[0].CreatedAt = now.Add(15 * time.Second)
-		assertApproved(t, r, "Approved by comment-approver")
+		r.Options.InvalidateOnPush = true
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 4 approvals from disqualified users")
 	})
 
-	t.Run("invalidateOnPush_review", func(t *testing.T) {
+	t.Run("invalidateReviewOnPush", func(t *testing.T) {
+		prctx := basePullContext()
 		prctx.CommitsValue = []*pull.Commit{
 			{
+				CreatedAt: now.Add(85 * time.Second),
 				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
 				Author:    "mhaypenny",
 				Committer: "mhaypenny",
@@ -291,17 +312,72 @@ func TestIsApproved(t *testing.T) {
 					Users: []string{"review-approver"},
 				},
 			},
+		}
+		assertApproved(t, prctx, r, "Approved by review-approver")
+
+		r.Options.InvalidateOnPush = true
+		assertPending(t, prctx, r, "0/1 approvals required")
+	})
+
+	t.Run("ignoreUpdateMergeAfterReview", func(t *testing.T) {
+		prctx := basePullContext()
+		prctx.CommitsValue = append(prctx.CommitsValue[:1], &pull.Commit{
+			CreatedAt:       now.Add(25 * time.Second),
+			SHA:             "647c5078288f0ea9de27b5c280f25edaf2089045",
+			CommittedViaWeb: true,
+			Parents: []string{
+				"c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
+				"2e1b0bb6ab144bf7a1b7a1df9d3bdcb0fe85a206",
+			},
+			Author: "merge-committer",
+		})
+
+		r := &Rule{
+			Requires: Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Users: []string{"comment-approver"},
+				},
+			},
 			Options: Options{
 				InvalidateOnPush: true,
 			},
 		}
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 4 approvals from disqualified users")
 
-		// set the commit after the review
-		prctx.CommitsValue[0].CreatedAt = now.Add(85 * time.Second)
-		assertPending(t, r, "0/1 approvals required")
+		r.Options.IgnoreUpdateMerges = true
+		assertApproved(t, prctx, r, "Approved by comment-approver")
+	})
 
-		// set the commit before the review
-		prctx.CommitsValue[0].CreatedAt = now.Add(75 * time.Second)
-		assertApproved(t, r, "Approved by review-approver")
+	t.Run("ignoreUpdateMergeContributor", func(t *testing.T) {
+		prctx := basePullContext()
+		prctx.CommitsValue = append(prctx.CommitsValue[:1], &pull.Commit{
+			CreatedAt:       now.Add(25 * time.Second),
+			SHA:             "647c5078288f0ea9de27b5c280f25edaf2089045",
+			CommittedViaWeb: true,
+			Parents: []string{
+				"c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
+				"2e1b0bb6ab144bf7a1b7a1df9d3bdcb0fe85a206",
+			},
+			Author: "merge-committer",
+		})
+		prctx.CommentsValue = append(prctx.CommentsValue, &pull.Comment{
+			CreatedAt: now.Add(100 * time.Second),
+			Author:    "merge-committer",
+			Body:      ":+1:",
+		})
+
+		r := &Rule{
+			Requires: Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Users: []string{"merge-committer"},
+				},
+			},
+		}
+		assertPending(t, prctx, r, "0/1 approvals required. Ignored 6 approvals from disqualified users")
+
+		r.Options.IgnoreUpdateMerges = true
+		assertApproved(t, prctx, r, "Approved by merge-committer")
 	})
 }

--- a/pull/context.go
+++ b/pull/context.go
@@ -62,6 +62,10 @@ type Context interface {
 	// branches in forks are prefixed with the owner of the fork and a colon.
 	// The base branch will always be unprefixed.
 	Branches() (base string, head string, err error)
+
+	// TargetCommits returns recent commits on the target branch of the pull
+	// request. The exact number of commits is an implementation detail.
+	TargetCommits() ([]*Commit, error)
 }
 
 type FileStatus int
@@ -80,8 +84,10 @@ type File struct {
 }
 
 type Commit struct {
-	CreatedAt time.Time
-	SHA       string
+	CreatedAt       time.Time
+	SHA             string
+	Parents         []string
+	CommittedViaWeb bool
 
 	// Author is the login name of the author. It is empty if the author is not
 	// a real user.

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -45,6 +45,9 @@ type Context struct {
 	BranchBaseName string
 	BranchHeadName string
 	BranchesError  error
+
+	TargetCommitsValue []*pull.Commit
+	TargetCommitsError error
 }
 
 func (c *Context) Locator() string {
@@ -102,6 +105,10 @@ func (c *Context) Reviews() ([]*pull.Review, error) {
 
 func (c *Context) Branches() (base string, head string, err error) {
 	return c.BranchBaseName, c.BranchHeadName, c.BranchesError
+}
+
+func (c *Context) TargetCommits() ([]*pull.Commit, error) {
+	return c.TargetCommitsValue, c.TargetCommitsError
 }
 
 // assert that the test object implements the full interface


### PR DESCRIPTION
When this option is true, a commit on the PR branch is ignored if it meets these conditions:
    
1. Has two parents (i.e. is a simple merge commit)
2. Was created via the UI or the API
3. Has one parent in the last 100 commits on the target branch
    
An ignored commit does not invalidate approvals and the author/committer do not count as contributors.

Closes #12. See that issue for background on the problem and this solution.

This PR also refactors some of the test code to avoid destructively modifying the default test data.