### PR TITLE
Add a link to the policy file from the detail UI

### DIFF
--- a/server/assets/css/main.css
+++ b/server/assets/css/main.css
@@ -3,7 +3,7 @@
 
 /* custom components */
 
-a, a:visited {
+a {
   color: config('colors.blue3');
 }
 

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -32,6 +32,7 @@ type FetchedConfig struct {
 	Owner  string
 	Repo   string
 	Ref    string
+	Path   string
 	Config *policy.Config
 	Error  error
 }
@@ -75,6 +76,7 @@ func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, client *github.Client,
 		Owner: pr.GetBase().GetRepo().GetOwner().GetLogin(),
 		Repo:  pr.GetBase().GetRepo().GetName(),
 		Ref:   pr.GetBase().GetRef(),
+		Path:  cf.PolicyPath,
 	}
 
 	configBytes, err := cf.fetchConfig(ctx, client, fc.Owner, fc.Repo, fc.Ref)

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -4,11 +4,13 @@
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
 {{define "body"}}
   <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">
-    <span class="px-2 py-1 text-xs text-dark-gray3 bg-light-gray3 border border-light-gray2 rounded-sm truncate max-w-full">
-      {{.PullRequest.GetBase.GetRepo.GetFullName}}
-    </span>
+    <a href="{{.PolicyURL}}" title="View the policy definition on GitHub"
+       class="px-2 py-1 text-xs text-dark-gray3 bg-light-gray3 border border-light-gray2 rounded-sm truncate max-w-full hover:bg-light-gray2 no-underline">
+      {{.PullRequest.GetBase.GetRepo.GetFullName}}: {{.PullRequest.GetBase.GetRef}}
+    </a>
     <h1 class="text-xl font-normal tracking-tight text-center">
-      <a class="text-blue3 hover:text-blue4 no-underline" href="{{.PullRequest.GetHTMLURL}}">#{{.PullRequest.GetNumber}}</a>:
+      <a href="{{.PullRequest.GetHTMLURL}}" title="View the pull request on GitHub" class="text-blue3 hover:text-blue4 no-underline">
+        #{{.PullRequest.GetNumber}}</a>:
       {{.PullRequest.GetTitle}}
     </h1>
     <span class="text-xs text-dark-gray3 truncate max-w-full">


### PR DESCRIPTION
The repository badge in the upper left corner now includes the target
branch name and is a link to the policy file.

Note that this does not resolve references: it always links to the `policy.yml` in your repository, not the one that defines the actual rules. While resolving references shows the actual policy definition, it may not be obvious that the current repository uses a reference if we link directly to the referenced file.

Here's a preview of the new button:

![policy-definition-link](https://user-images.githubusercontent.com/1745813/49901249-87bed900-fe15-11e8-9061-6b57c9fffe2b.png)