### PR TITLE
GitHub checks functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ that terminates TLS connections.
 | Repository metadata | Read-only | Basic repository data |
 | Pull requests | Read-only| Receive pull request events, read metadata |
 | Commit status | Read & write | Post commit statuses |
+| Checks | Read & write | Post check run results |
 | Organization members | Read-only | Determine organization and team membership |
 
 It should be subscribed to the following events:
@@ -354,6 +355,7 @@ It should be subscribed to the following events:
 * Pull request
 * Status
 * Pull request review
+* Check run
 
 There is a [`logo.png`](https://github.com/palantir/policy-bot/blob/develop/logo.png)
 provided if you'd like to use it as the GitHub application logo. The background

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -46,7 +46,10 @@ options:
   status_check_context: policy-bot
   # The name of the application as registered with GitHub
   app_name: policy-bot
-
+  # Disable the traditional way of post status updates for a Pull Request
+  disable_github_status_updates: false
+  # Enable status update via GitHub checks. Requires `checks:write` permission
+  enable_github_check_runs: false
 # Options for frontend assets
 files:
   # The filesystem path to static CSS and JS assets

--- a/godel/config/check-plugin.yml
+++ b/godel/config/check-plugin.yml
@@ -9,3 +9,9 @@ checks:
   errcheck:
     filters:
     - value: "Client\\.(Count|Gauge)"
+    config:
+      exclude:
+        - (*strings.Builder).Write
+        - (*strings.Builder).WriteByte
+        - (*strings.Builder).WriteRune
+        - (*strings.Builder).WriteString

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -141,10 +141,11 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 	case "skipped":
 		conclusion = "neutral"
 	case "disapproved":
+		conclusion = "failure"
 	case "unknown":
 		conclusion = "failure"
 	case "pending":
-		conclusion = "action_required"
+		conclusion = "failure"
 	}
 
 	var builder strings.Builder

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -116,17 +116,9 @@ func (b *Base) PostCheckResults(ctx context.Context, client *github.Client, pr *
 	sha := pr.GetHead().GetSHA()
 	owner := pr.GetBase().GetRepo().GetOwner().GetLogin()
 	repo := pr.GetBase().GetRepo().GetName()
-	checkRunsRequest := &github.ListCheckRunsOptions{}
 
-	existingChecks, _, err := client.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, checkRunsRequest)
-	if err != nil {
+	if err := b.createGitHubRepoCheck(ctx, client, pr, owner, repo, sha, evaluationResult); err != nil {
 		return err
-	}
-
-	if existingChecks.GetTotal() >= 0 {
-		if err := b.createGitHubRepoCheck(ctx, client, pr, owner, repo, sha, evaluationResult); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -160,11 +160,11 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 
 	var builder strings.Builder
 	if len(evaluationResult.Children) == 0 {
-		_, _ = builder.WriteString(evaluationResult.Description)
+		builder.WriteString(evaluationResult.Description)
 	}
 
 	childSummaries := b.generateCheckRunSummary(evaluationResult.Children, 0)
-	_, _ = builder.WriteString(childSummaries)
+	builder.WriteString(childSummaries)
 	summary := builder.String()
 	checkName := fmt.Sprintf("%s: %ss - %s", b.PullOpts.StatusCheckContext, evaluationResult.Name, pr.GetBase().GetRef())
 
@@ -192,12 +192,12 @@ func (b *Base) generateCheckRunSummary(results []*common.Result, level int) stri
 	indentValue := strings.Repeat(" ", 2*level)
 
 	for _, childResult := range results {
-		_, _ = summaryBuilder.WriteString("\n")
-		_, _ = summaryBuilder.WriteString(fmt.Sprintf("%s- %s %s (%s)", indentValue, headerValue, strings.Title(childResult.Name), childResult.Status.String()))
-		_, _ = summaryBuilder.WriteString("\n")
-		_, _ = summaryBuilder.WriteString(fmt.Sprintf("  %s%s", indentValue, childResult.Description))
+		summaryBuilder.WriteString("\n")
+		summaryBuilder.WriteString(fmt.Sprintf("%s- %s %s (%s)", indentValue, headerValue, strings.Title(childResult.Name), childResult.Status.String()))
+		summaryBuilder.WriteString("\n")
+		summaryBuilder.WriteString(fmt.Sprintf("  %s%s", indentValue, childResult.Description))
 		childSummaries := b.generateCheckRunSummary(childResult.Children, level+1)
-		_, _ = summaryBuilder.WriteString(childSummaries)
+		summaryBuilder.WriteString(childSummaries)
 	}
 
 	return summaryBuilder.String()

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -166,9 +166,10 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 	childSummaries := b.generateCheckRunSummary(evaluationResult.Children, 0)
 	_, _ = builder.WriteString(childSummaries)
 	summary := builder.String()
+	checkName := fmt.Sprintf("%s: %ss - %s", b.PullOpts.StatusCheckContext, evaluationResult.Name, pr.GetBase().GetRef())
 
 	status := &github.CreateCheckRunOptions{
-		Name:       strings.Title(evaluationResult.Name + "s"),
+		Name:       checkName,
 		DetailsURL: &detailsURL,
 		Status:     &defaultStatus,
 		Output: &github.CheckRunOutput{

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -155,7 +155,7 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 	case "unknown":
 		conclusion = "failure"
 	case "pending":
-		conclusion = "failure"
+		conclusion = "action_required"
 	}
 
 	var builder strings.Builder

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -160,11 +160,11 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 
 	var builder strings.Builder
 	if len(evaluationResult.Children) == 0 {
-		builder.WriteString(evaluationResult.Description)
+		_, _ = builder.WriteString(evaluationResult.Description)
 	}
 
 	childSummaries := b.generateCheckRunSummary(evaluationResult.Children, 0)
-	builder.WriteString(childSummaries)
+	_, _ = builder.WriteString(childSummaries)
 	summary := builder.String()
 
 	status := &github.CreateCheckRunOptions{
@@ -191,12 +191,12 @@ func (b *Base) generateCheckRunSummary(results []*common.Result, level int) stri
 	indentValue := strings.Repeat(" ", 2*level)
 
 	for _, childResult := range results {
-		summaryBuilder.WriteString("\n")
-		summaryBuilder.WriteString(fmt.Sprintf("%s- %s %s (%s)", indentValue, headerValue, strings.Title(childResult.Name), childResult.Status.String()))
-		summaryBuilder.WriteString("\n")
-		summaryBuilder.WriteString(fmt.Sprintf("  %s%s", indentValue, childResult.Description))
+		_, _ = summaryBuilder.WriteString("\n")
+		_, _ = summaryBuilder.WriteString(fmt.Sprintf("%s- %s %s (%s)", indentValue, headerValue, strings.Title(childResult.Name), childResult.Status.String()))
+		_, _ = summaryBuilder.WriteString("\n")
+		_, _ = summaryBuilder.WriteString(fmt.Sprintf("  %s%s", indentValue, childResult.Description))
 		childSummaries := b.generateCheckRunSummary(childResult.Children, level+1)
-		summaryBuilder.WriteString(childSummaries)
+		_, _ = summaryBuilder.WriteString(childSummaries)
 	}
 
 	return summaryBuilder.String()

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -168,34 +168,34 @@ func (b *Base) createGitHubRepoCheck(ctx context.Context, client *github.Client,
 	summary := builder.String()
 
 	status := &github.CreateCheckRunOptions{
-		Name: strings.Title(evaluationResult.Name + "s"),
+		Name:       strings.Title(evaluationResult.Name + "s"),
 		DetailsURL: &detailsURL,
-		Status: &defaultStatus,
+		Status:     &defaultStatus,
 		Output: &github.CheckRunOutput{
-			Title: &evaluationResult.Description,
+			Title:   &evaluationResult.Description,
 			Summary: &summary,
 		},
-		StartedAt: &time,
+		StartedAt:   &time,
 		CompletedAt: &time,
-		Conclusion: &conclusion,
-		HeadSHA: sha,
+		Conclusion:  &conclusion,
+		HeadSHA:     sha,
 	}
 
 	_, _, err := client.Checks.CreateCheckRun(ctx, owner, repo, *status)
 	return err
 }
 
-func (b *Base) generateCheckRunSummary(results[] *common.Result, level int) string {
+func (b *Base) generateCheckRunSummary(results []*common.Result, level int) string {
 	var summaryBuilder strings.Builder
-	headerValue := strings.Repeat("#", 3 + level)
-	indentValue := strings.Repeat(" ", 2 * level)
+	headerValue := strings.Repeat("#", 3+level)
+	indentValue := strings.Repeat(" ", 2*level)
 
 	for _, childResult := range results {
 		summaryBuilder.WriteString("\n")
 		summaryBuilder.WriteString(fmt.Sprintf("%s- %s %s (%s)", indentValue, headerValue, strings.Title(childResult.Name), childResult.Status.String()))
 		summaryBuilder.WriteString("\n")
 		summaryBuilder.WriteString(fmt.Sprintf("  %s%s", indentValue, childResult.Description))
-		childSummaries := b.generateCheckRunSummary(childResult.Children, level + 1)
+		childSummaries := b.generateCheckRunSummary(childResult.Children, level+1)
 		summaryBuilder.WriteString(childSummaries)
 	}
 

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -26,7 +26,7 @@ type CheckRun struct {
 	Base
 }
 
-func (h CheckRun) Handles() []string { return []string {"check_run"} }
+func (h CheckRun) Handles() []string { return []string{"check_run"} }
 
 // Handle check_run
 // https://developer.github.com/v3/activity/events/types/#checkrunevent

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/google/go-github/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
@@ -36,14 +37,14 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		return errors.Wrap(err, "failed to parse check run event payload")
 	}
 
-	installationId := githubapp.GetInstallationIDFromEvent(&event)
+	installationID := githubapp.GetInstallationIDFromEvent(&event)
 
-	client, err := h.NewInstallationClient(installationId)
+	client, err := h.NewInstallationClient(installationID)
 	if err != nil {
 		return err
 	}
 
-	v4client, err := h.NewInstallationV4Client(installationId)
+	v4client, err := h.NewInstallationV4Client(installationID)
 	if err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 	switch event.GetAction() {
 	case "rerequested":
 		for _, pullRequest := range event.GetCheckRun().PullRequests {
-			ctx, _ = githubapp.PreparePRContext(ctx, installationId, event.GetRepo(), pullRequest.GetNumber())
+			ctx, _ = githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), pullRequest.GetNumber())
 
 			// HACK: This gets around a lack of context from the PR associated with a check run. As the API might
 			// change later, this should be re-evaluated at a later date

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/google/go-github/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+)
+
+type CheckRun struct {
+	Base
+}
+
+func (h CheckRun) Handles() []string { return []string {"check_run"} }
+
+// Handle check_run
+// https://developer.github.com/v3/activity/events/types/#checkrunevent
+func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.CheckRunEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse check run event payload")
+	}
+
+	installationId := githubapp.GetInstallationIDFromEvent(&event)
+
+	client, err := h.NewInstallationClient(installationId)
+	if err != nil {
+		return err
+	}
+
+	v4client, err := h.NewInstallationV4Client(installationId)
+	if err != nil {
+		return err
+	}
+
+	switch event.GetAction() {
+	case "rerequested":
+		for _, pullRequest := range event.GetCheckRun().PullRequests {
+			ctx, _ = githubapp.PreparePRContext(ctx, installationId, event.GetRepo(), pullRequest.GetNumber())
+
+			// HACK: This gets around a lack of context from the PR associated with a check run. As the API might
+			// change later, this should be re-evaluated at a later date
+			pullRequest.Base.Repo = event.GetRepo()
+			mbrCtx := NewCrossOrgMembershipContext(ctx, client, event.GetRepo().GetOwner().GetLogin(), h.Installations, h.ClientCreator)
+			return h.Evaluate(ctx, mbrCtx, client, v4client, pullRequest)
+		}
+	}
+
+	return nil
+}

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -51,15 +51,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 
 	switch event.GetAction() {
 	case "rerequested":
-		for _, pullRequest := range event.GetCheckRun().PullRequests {
-			ctx, _ = githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), pullRequest.GetNumber())
-
-			// HACK: This gets around a lack of context from the PR associated with a check run. As the API might
-			// change later, this should be re-evaluated at a later date
-			pullRequest.Base.Repo = event.GetRepo()
-			mbrCtx := NewCrossOrgMembershipContext(ctx, client, event.GetRepo().GetOwner().GetLogin(), h.Installations, h.ClientCreator)
-			return h.Evaluate(ctx, mbrCtx, client, v4client, pullRequest)
-		}
+		h.ProcessChecksRerequests(ctx, installationID, client, v4client, *event.GetRepo(), event.GetCheckRun().PullRequests)
 	}
 
 	return nil

--- a/server/handler/check_suite.go
+++ b/server/handler/check_suite.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/go-github/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+)
+
+type CheckSuite struct {
+	Base
+}
+
+func (h CheckSuite) Handles() []string { return []string{"check_suite"} }
+
+// Handle check_run
+// https://developer.github.com/v3/activity/events/types/#checksuiteevent
+func (h *CheckSuite) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.CheckSuiteEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse check suite event payload")
+	}
+
+	installationID := githubapp.GetInstallationIDFromEvent(&event)
+
+	client, err := h.NewInstallationClient(installationID)
+	if err != nil {
+		return err
+	}
+
+	v4client, err := h.NewInstallationV4Client(installationID)
+	if err != nil {
+		return err
+	}
+
+	switch event.GetAction() {
+	case "rerequested":
+		for _, pullRequest := range event.GetCheckSuite().PullRequests {
+			ctx, _ = githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), pullRequest.GetNumber())
+
+			// HACK: This gets around a lack of context from the PR associated with a check run. As the API might
+			// change later, this should be re-evaluated at a later date
+			pullRequest.Base.Repo = event.GetRepo()
+			mbrCtx := NewCrossOrgMembershipContext(ctx, client, event.GetRepo().GetOwner().GetLogin(), h.Installations, h.ClientCreator)
+			return h.Evaluate(ctx, mbrCtx, client, v4client, pullRequest)
+		}
+	}
+
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,7 @@ func New(c *Config) (*Server, error) {
 		&handler.IssueComment{Base: basePolicyHandler},
 		&handler.Status{Base: basePolicyHandler},
 		&handler.CheckRun{Base: basePolicyHandler},
+		&handler.CheckSuite{Base: basePolicyHandler},
 	)
 
 	templates, err := handler.LoadTemplates(&c.Files)

--- a/server/server.go
+++ b/server/server.go
@@ -113,6 +113,7 @@ func New(c *Config) (*Server, error) {
 		&handler.PullRequestReview{Base: basePolicyHandler},
 		&handler.IssueComment{Base: basePolicyHandler},
 		&handler.Status{Base: basePolicyHandler},
+		&handler.CheckRun{Base: basePolicyHandler},
 	)
 
 	templates, err := handler.LoadTemplates(&c.Files)


### PR DESCRIPTION
This integrates the ability to use the GitHub Checks API to post the results of the policies. This means the results will be included in the GH UI instead of jumping to a different UI, although you can still jump to the old view at the bottom of the checks page.

Here is an example of what this would look like on the PR:

![screen shot 2018-12-21 at 16 16 43](https://user-images.githubusercontent.com/380725/50766825-99f43180-1272-11e9-886a-9a9f315bd100.png)

And on the checks page:
 
![screen shot 2018-12-21 at 14 45 39](https://user-images.githubusercontent.com/380725/50766833-a2e50300-1272-11e9-894a-46e02c1f5bac.png)

Replaces #45 