### PR TITLE
Verify that the pull request head commit exists

### DIFF
--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -31,7 +31,7 @@ func TestAuthor(t *testing.T) {
 	rp := &ResponsePlayer{}
 	pullsRule := rp.AddRule(
 		ExactPathMatcher("/repos/testorg/testrepo/pulls/123"),
-		"testdata/responses/pull_author.yml",
+		"testdata/responses/pull.yml",
 	)
 
 	ctx := makeContext(rp)
@@ -84,6 +84,10 @@ func TestChangedFiles(t *testing.T) {
 
 func TestCommits(t *testing.T) {
 	rp := &ResponsePlayer{}
+	rp.AddRule(
+		ExactPathMatcher("/repos/testorg/testrepo/pulls/123"),
+		"testdata/responses/pull.yml",
+	)
 	dataRule := rp.AddRule(
 		GraphQLNodePrefixMatcher("repository.pullRequest.commits"),
 		"testdata/responses/pull_data_commits.yml",
@@ -253,6 +257,10 @@ func TestIsTeamMember(t *testing.T) {
 
 func TestMixedPaging(t *testing.T) {
 	rp := &ResponsePlayer{}
+	rp.AddRule(
+		ExactPathMatcher("/repos/testorg/testrepo/pulls/123"),
+		"testdata/responses/pull.yml",
+	)
 	dataRule := rp.AddRule(
 		GraphQLNodePrefixMatcher("repository.pullRequest"),
 		"testdata/responses/pull_data_mixed.yml",
@@ -271,8 +279,8 @@ func TestMixedPaging(t *testing.T) {
 
 	assert.Equal(t, 3, dataRule.Count, "cached values were not used")
 	assert.Len(t, comments, 2, "incorrect number of comments")
-	assert.Len(t, reviews, 3, "incorrect number of reviews")
-	assert.Len(t, commits, 2, "incorrect number of commits")
+	assert.Len(t, reviews, 2, "incorrect number of reviews")
+	assert.Len(t, commits, 3, "incorrect number of commits")
 }
 
 func TestIsOrgMember(t *testing.T) {
@@ -323,15 +331,13 @@ func makeContext(rp *ResponsePlayer) Context {
 		pr = &github.PullRequest{}
 	}
 
-	// insert the values needed for the context
-	repoOwner, repoName, prNum := "testorg", "testrepo", 123
-	pr.Number = &prNum
+	pr.Number = github.Int(123)
 	pr.Base = &github.PullRequestBranch{
 		Repo: &github.Repository{
 			Owner: &github.User{
-				Login: &repoOwner,
+				Login: github.String("testorg"),
 			},
-			Name: &repoName,
+			Name: github.String("testrepo"),
 		},
 	}
 

--- a/pull/testdata/responses/pull.yml
+++ b/pull/testdata/responses/pull.yml
@@ -1,0 +1,31 @@
+- status: 200
+  body: |
+    {
+      "number": 123,
+      "user": {
+        "login": "mhaypenny"
+      },
+      "head": {
+        "label": "testorg:test-branch",
+        "ref": "test-branch",
+        "sha": "e05fcae367230ee709313dd2720da527d178ce43",
+        "repo": {
+          "name": "testrepo",
+          "full_name": "testorg/testrepo",
+          "owner": {
+            "login": "testorg"
+          }
+        }
+      },
+      "base": {
+        "label": "testorg:develop",
+        "ref": "develop",
+        "repo": {
+          "name": "testrepo",
+          "full_name": "testorg/testrepo",
+          "owner": {
+            "login": "testorg"
+          }
+        }
+      }
+    }

--- a/pull/testdata/responses/pull_author.yml
+++ b/pull/testdata/responses/pull_author.yml
@@ -1,7 +1,0 @@
-- status: 200
-  body: |
-    {
-      "user": {
-        "login": "mhaypenny"
-      } 
-    }

--- a/pull/testdata/responses/pull_data_mixed.yml
+++ b/pull/testdata/responses/pull_data_mixed.yml
@@ -63,7 +63,7 @@
                   "author": {
                     "login": "mhaypenny"
                   },
-                  "state": "APPROVED",
+                  "state": "CHANGES_REQUESTED",
                   "body": "",
                   "submittedAt": "2018-06-27T20:33:26Z"
                 }
@@ -90,7 +90,7 @@
             "commits": {
               "pageInfo": {
                 "endCursor": "3",
-                "hasNextPage": false
+                "hasNextPage": true
               },
               "nodes": [
                 {
@@ -114,16 +114,16 @@
             "reviews": {
               "pageInfo": {
                 "endCursor": "3",
-                "hasNextPage": true
+                "hasNextPage": false
               },
               "nodes": [
                 {
                   "author": {
-                    "login": "ttest"
+                    "login": "bkeyes"
                   },
-                  "state": "CHANGES_REQUESTED",
-                  "body": "",
-                  "submittedAt": "2018-06-27T20:44:26Z"
+                  "state": "APPROVED",
+                  "body": "the body",
+                  "submittedAt": "2018-06-27T20:33:27Z"
                 }
               ]
             }
@@ -147,26 +147,34 @@
             },
             "commits": {
               "pageInfo": {
-                "endCursor": null,
-                "hasNextPage": false
-              },
-              "nodes": []
-            },
-            "reviews": {
-              "pageInfo": {
                 "endCursor": "4",
                 "hasNextPage": false
               },
               "nodes": [
                 {
-                  "author": {
-                    "login": "bkeyes"
-                  },
-                  "state": "CHANGES_REQUESTED",
-                  "body": "",
-                  "submittedAt": "2018-06-27T20:55:26Z"
+                  "commit": {
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": "2018-12-06T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "ttest"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    }
+                  }
                 }
               ]
+            },
+            "reviews": {
+              "pageInfo": {
+                "endCursor": null,
+                "hasNextPage": false
+              },
+              "nodes": []
             }
           }
         }


### PR DESCRIPTION
Some GitHub APIs have a delay propagating information about new commits, particularly when the commits come from forks. While I believe the APIs we currently use are safe, if they are not, the policy should fail closed with an error instead of potentially failing open, as it does currently.

Also reorganize some test data so that it is more consistent, making it easier for tests to pass this new check.

Fixes #47.