### PR TITLE
Fix commit ordering

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -212,11 +212,14 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 	return false, msg, nil
 }
 
+// filteredCommits returns relevant commits ordered from oldest to newest.
 func (r *Rule) filteredCommits(prctx pull.Context) ([]*pull.Commit, error) {
 	commits, err := prctx.Commits()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list commits")
 	}
+
+	sort.Stable(pull.CommitsByCreationTime(commits))
 
 	needsFiltering := r.Options.IgnoreUpdateMerges
 	if !needsFiltering {

--- a/pull/context.go
+++ b/pull/context.go
@@ -57,13 +57,16 @@ type Context interface {
 	// ChangedFiles returns the files that were changed in this pull request.
 	ChangedFiles() ([]*File, error)
 
-	// Commits returns the commits that are part of this pull request.
+	// Commits returns the commits that are part of this pull request. The
+	// commit order is implementation dependent.
 	Commits() ([]*Commit, error)
 
-	// Comments lists all comments on a Pull Request
+	// Comments lists all comments on a Pull Request. The comment order is
+	// implementation dependent.
 	Comments() ([]*Comment, error)
 
-	// Reviews lists all reviews on a Pull Request
+	// Reviews lists all reviews on a Pull Request. The review order is
+	// implementation dependent.
 	Reviews() ([]*Review, error)
 
 	// Branches returns the base (also known as target) and head branch names
@@ -117,6 +120,14 @@ func (c *Commit) Users() []string {
 		users = append(users, c.Committer)
 	}
 	return users
+}
+
+type CommitsByCreationTime []*Commit
+
+func (cs CommitsByCreationTime) Len() int      { return len(cs) }
+func (cs CommitsByCreationTime) Swap(i, j int) { cs[i], cs[j] = cs[j], cs[i] }
+func (cs CommitsByCreationTime) Less(i, j int) bool {
+	return cs[i].CreatedAt.Before(cs[j].CreatedAt)
 }
 
 type Comment struct {

--- a/pull/github.go
+++ b/pull/github.go
@@ -161,8 +161,8 @@ func (ghc *GitHubContext) Commits() ([]*Commit, error) {
 	// verify that the head of the PR being evaluated exists in commit list
 	// some GitHub APIs have a delay propagating commit information
 	headSHA := ghc.pr.GetHead().GetSHA()
-	for i := len(ghc.commits) - 1; i >= 0; i-- {
-		if headSHA == ghc.commits[i].SHA {
+	for _, c := range ghc.commits {
+		if headSHA == c.SHA {
 			return ghc.commits, nil
 		}
 	}
@@ -411,14 +411,15 @@ func (c *v4Commit) ToCommit() *Commit {
 
 // backfillPushedDate copies the push date from the HEAD commit in a batch push
 // to all other commits in that batch. It assumes the commits slice is in
-// ascending chronologic order (latest commit at the end).
+// descending chronologic order (latest commit at the start), which is the
+// default for `git log` and most GitHub APIs.
 func backfillPushedDate(commits []*v4Commit) {
 	var lastPushed *time.Time
-	for i := len(commits) - 1; i >= 0; i-- {
-		if commits[i].PushedDate != nil {
-			lastPushed = commits[i].PushedDate
+	for _, c := range commits {
+		if c.PushedDate != nil {
+			lastPushed = c.PushedDate
 		} else {
-			commits[i].PushedDate = lastPushed
+			c.PushedDate = lastPushed
 		}
 	}
 }

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -101,17 +101,23 @@ func TestCommits(t *testing.T) {
 	require.Len(t, commits, 3, "incorrect number of commits")
 	assert.Equal(t, 2, dataRule.Count, "no http request was made")
 
-	assert.Equal(t, "a6f3f69b64eaafece5a0d854eb4af11c0d64394c", commits[0].SHA)
-	assert.Equal(t, "mhaypenny", commits[0].Author)
+	expectedTime, err := time.Parse(time.RFC3339, "2018-12-06T12:34:56Z")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "e05fcae367230ee709313dd2720da527d178ce43", commits[0].SHA)
+	assert.Equal(t, "ttest", commits[0].Author)
 	assert.Equal(t, "mhaypenny", commits[0].Committer)
+	assert.Equal(t, expectedTime, commits[0].CreatedAt)
 
 	assert.Equal(t, "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9", commits[1].SHA)
 	assert.Equal(t, "mhaypenny", commits[1].Author)
 	assert.Equal(t, "mhaypenny", commits[1].Committer)
+	assert.Equal(t, expectedTime.Add(-48*time.Hour), commits[1].CreatedAt)
 
-	assert.Equal(t, "e05fcae367230ee709313dd2720da527d178ce43", commits[2].SHA)
-	assert.Equal(t, "ttest", commits[2].Author)
+	assert.Equal(t, "a6f3f69b64eaafece5a0d854eb4af11c0d64394c", commits[2].SHA)
+	assert.Equal(t, "mhaypenny", commits[2].Author)
 	assert.Equal(t, "mhaypenny", commits[2].Committer)
+	assert.Equal(t, expectedTime.Add(-48*time.Hour), commits[2].CreatedAt)
 
 	// verify that the commit list is cached
 	commits, err = ctx.Commits()

--- a/pull/testdata/responses/pull_data_commits.yml
+++ b/pull/testdata/responses/pull_data_commits.yml
@@ -13,11 +13,11 @@
               "nodes": [
                 {
                   "commit": {
-                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
-                    "pushedDate": null,
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": "2018-12-06T12:34:56Z",
                     "author": {
                       "user": {
-                        "login": "mhaypenny"
+                        "login": "ttest"
                       }
                     },
                     "committer": {
@@ -64,11 +64,11 @@
               "nodes": [
                 {
                   "commit": {
-                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
-                    "pushedDate": "2018-12-06T12:34:56Z",
+                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
+                    "pushedDate": null,
                     "author": {
                       "user": {
-                        "login": "ttest"
+                        "login": "mhaypenny"
                       }
                     },
                     "committer": {

--- a/pull/testdata/responses/pull_data_mixed.yml
+++ b/pull/testdata/responses/pull_data_mixed.yml
@@ -37,11 +37,11 @@
               "nodes": [
                 {
                   "commit": {
-                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
-                    "pushedDate": null,
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": "2018-12-06T12:34:56Z",
                     "author": {
                       "user": {
-                        "login": "mhaypenny"
+                        "login": "ttest"
                       }
                     },
                     "committer": {
@@ -153,11 +153,11 @@
               "nodes": [
                 {
                   "commit": {
-                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
-                    "pushedDate": "2018-12-06T12:34:56Z",
+                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
+                    "pushedDate": null,
                     "author": {
                       "user": {
-                        "login": "ttest"
+                        "login": "mhaypenny"
                       }
                     },
                     "committer": {


### PR DESCRIPTION
The timeline API returned commits from oldest to newest, while the other
APIs do the reverse. Fix pushed date backfilling for the swapped order,
document that the order is arbitrary, and explicitly sort commits when
the order is important for evaluation.