### PR TITLE
Improve logging of commit information

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -128,15 +129,20 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 		if err != nil {
 			return false, "", err
 		}
-
-		lastCommitTime := commits[len(commits)-1].CreatedAt
+		lastCommit := commits[len(commits)-1]
 
 		var allowedCandidates []*common.Candidate
 		for _, candidate := range candidates {
-			if candidate.CreatedAt.After(lastCommitTime) {
+			if candidate.CreatedAt.After(lastCommit.CreatedAt) {
 				allowedCandidates = append(allowedCandidates, candidate)
 			}
 		}
+
+		log.Debug().Msgf("discarded %d candidates invalidated by push of %s at %s",
+			len(candidates)-len(allowedCandidates),
+			lastCommit.SHA,
+			lastCommit.CreatedAt.Format(time.RFC3339))
+
 		candidates = allowedCandidates
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -24,7 +24,6 @@ import (
 	"github.com/alexedwards/scs"
 	"github.com/bluekeyes/templatetree"
 	"github.com/google/go-github/github"
-	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"goji.io/pat"
 
@@ -107,7 +106,7 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	data.PullRequest = pr
 	data.User = user
 
-	ctx, _ = githubapp.PreparePRContext(ctx, installation.ID, pr.GetBase().GetRepo(), number)
+	ctx, _ = h.PreparePRContext(ctx, installation.ID, pr)
 
 	config, err := h.ConfigFetcher.ConfigForPR(ctx, client, pr)
 	data.PolicyURL = getPolicyURL(pr, config)

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -46,10 +46,8 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	number := event.GetIssue().GetNumber()
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 
-	ctx, logger := githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), number)
-
 	if !event.GetIssue().IsPullRequest() {
-		logger.Debug().Msg("Issue comment event is not for a pull request")
+		zerolog.Ctx(ctx).Debug().Msg("Issue comment event is not for a pull request")
 		return nil
 	}
 
@@ -67,6 +65,8 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", repo.GetOwner().GetLogin(), repo.GetName(), number)
 	}
+
+	ctx, logger := h.PreparePRContext(ctx, installationID, pr)
 
 	fetchedConfig, err := h.ConfigFetcher.ConfigForPR(ctx, client, pr)
 	if err != nil {

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -49,7 +49,7 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 		return err
 	}
 
-	ctx, _ = githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), event.GetNumber())
+	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
 	switch event.GetAction() {
 	case "opened", "reopened", "synchronize", "edited":

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -49,7 +49,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 		return err
 	}
 
-	ctx, _ = githubapp.PreparePRContext(ctx, installationID, event.GetRepo(), event.GetPullRequest().GetNumber())
+	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
 	mbrCtx := NewCrossOrgMembershipContext(ctx, client, event.GetRepo().GetOwner().GetLogin(), h.Installations, h.ClientCreator)
 	return h.Evaluate(ctx, mbrCtx, client, v4client, event.GetPullRequest())


### PR DESCRIPTION
Attach the head SHA of the pull request being evaluated to log messages,
log when candidates are removed due to a pushed commit, and log the
target ref when posting a commit status.