### PR TITLE
Fix repository content permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ that terminates TLS connections.
 
 | Permission | Access | Reason |
 | ---------- | ------ | ------ |
-| Repository contents | Read & write | Read configuration, perform merges |
+| Repository contents | Read-only | Read configuration and commit metadata |
 | Issues | Read-only | Read pull request comments |
 | Repository metadata | Read-only | Basic repository data |
 | Pull requests | Read-only| Receive pull request events, read metadata |


### PR DESCRIPTION
When the table was copied from palantir/bulldozer, I missed fixing the
repository content permission, which should be read-only. This is
because we read commit metadata to support invalidate_on_push and
author/contributor checks.