### PR TITLE
Fix comment/review cache when there are none

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -277,7 +277,7 @@ func (ghc *GitHubContext) TargetCommits() ([]*Commit, error) {
 }
 
 func (ghc *GitHubContext) loadCommentsAndReviews() error {
-	// this is a minor optimization: we make max(r, c) requests instead of r + c
+	// this is a minor optimization: we make max(r,c) requests instead of r+c
 	var q struct {
 		Repository struct {
 			PullRequest struct {
@@ -302,8 +302,8 @@ func (ghc *GitHubContext) loadCommentsAndReviews() error {
 		"reviewCursor":  (*githubv4.String)(nil),
 	}
 
-	var reviews []*Review
-	var comments []*Comment
+	reviews := []*Review{}
+	comments := []*Comment{}
 	for {
 		complete := 0
 		if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -139,6 +139,27 @@ func TestReviews(t *testing.T) {
 	assert.Equal(t, 2, dataRule.Count, "cached reviews were not used")
 }
 
+func TestNoReviews(t *testing.T) {
+	rp := &ResponsePlayer{}
+	dataRule := rp.AddRule(
+		GraphQLNodePrefixMatcher("repository.pullRequest.reviews"),
+		"testdata/responses/pull_no_reviews.yml",
+	)
+
+	ctx := makeContext(rp, nil)
+
+	reviews, err := ctx.Reviews()
+	require.NoError(t, err)
+	require.Empty(t, reviews, "incorrect number of reviews")
+
+	// verify that the review list is cached
+	reviews, err = ctx.Reviews()
+	require.NoError(t, err)
+
+	assert.Empty(t, reviews, "incorrect number of reviews")
+	assert.Equal(t, 1, dataRule.Count, "cached reviews were not used")
+}
+
 func TestComments(t *testing.T) {
 	rp := &ResponsePlayer{}
 	dataRule := rp.AddRule(
@@ -171,6 +192,27 @@ func TestComments(t *testing.T) {
 
 	require.Len(t, comments, 2, "incorrect number of comments")
 	assert.Equal(t, 2, dataRule.Count, "cached comments were not used")
+}
+
+func TestNoComments(t *testing.T) {
+	rp := &ResponsePlayer{}
+	dataRule := rp.AddRule(
+		GraphQLNodePrefixMatcher("repository.pullRequest.comments"),
+		"testdata/responses/pull_no_comments.yml",
+	)
+
+	ctx := makeContext(rp, nil)
+
+	comments, err := ctx.Comments()
+	require.NoError(t, err)
+	require.Empty(t, comments, "incorrect number of comments")
+
+	// verify that the commit list is cached
+	comments, err = ctx.Comments()
+	require.NoError(t, err)
+
+	assert.Empty(t, comments, "incorrect number of comments")
+	assert.Equal(t, 1, dataRule.Count, "cached comments were not used")
 }
 
 func TestIsTeamMember(t *testing.T) {

--- a/pull/testdata/responses/pull_no_comments.yml
+++ b/pull/testdata/responses/pull_no_comments.yml
@@ -1,0 +1,19 @@
+- status: 200
+  body: |
+    {
+      "errors": [],
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "comments": {
+              "pageInfo": {
+                "endCursor": null,
+                "hasNextPage": false
+              },
+              "nodes": [
+              ]
+            }
+          }
+        }
+      }
+    }

--- a/pull/testdata/responses/pull_no_reviews.yml
+++ b/pull/testdata/responses/pull_no_reviews.yml
@@ -1,0 +1,19 @@
+- status: 200
+  body: |
+    {
+      "errors": [],
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "reviews": {
+              "pageInfo": {
+                "endCursor": null,
+                "hasNextPage": false
+              },
+              "nodes": [
+              ]
+            }
+          }
+        }
+      }
+    }


### PR DESCRIPTION
When refactoring commit loading, I unintentionally changed the comment
and review slices to remain nil if there were no comments or reviews.
They are now correctly set to empty slices and I added new tests to
check this behavior.