### PR TITLE
Fix data race using default approval methods

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -28,16 +28,6 @@ import (
 	"github.com/palantir/policy-bot/pull"
 )
 
-var (
-	DefaultApproveMethods = common.Methods{
-		Comments: []string{
-			":+1:",
-			"👍",
-		},
-		GithubReview: true,
-	}
-)
-
 type Rule struct {
 	Name       string     `yaml:"name"`
 	Predicates Predicates `yaml:"if"`
@@ -57,7 +47,13 @@ type Options struct {
 func (opts *Options) GetMethods() *common.Methods {
 	methods := opts.Methods
 	if methods == nil {
-		methods = &DefaultApproveMethods
+		methods = &common.Methods{
+			Comments: []string{
+				":+1:",
+				"👍",
+			},
+			GithubReview: true,
+		}
 	}
 
 	methods.GithubReviewState = pull.ReviewApproved

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -26,24 +26,6 @@ import (
 	"github.com/palantir/policy-bot/pull"
 )
 
-var (
-	DefaultDisapproveMethods = common.Methods{
-		Comments: []string{
-			":-1:",
-			"👎",
-		},
-		GithubReview: true,
-	}
-
-	DefaultRevokeMethods = common.Methods{
-		Comments: []string{
-			":+1:",
-			"👍",
-		},
-		GithubReview: true,
-	}
-)
-
 type Policy struct {
 	Options  Options  `yaml:"options"`
 	Requires Requires `yaml:"requires"`
@@ -61,7 +43,13 @@ type Methods struct {
 func (opts *Options) GetDisapproveMethods() *common.Methods {
 	m := opts.Methods.Disapprove
 	if m == nil {
-		m = &DefaultDisapproveMethods
+		m = &common.Methods{
+			Comments: []string{
+				":-1:",
+				"👎",
+			},
+			GithubReview: true,
+		}
 	}
 
 	m.GithubReviewState = pull.ReviewChangesRequested
@@ -71,7 +59,13 @@ func (opts *Options) GetDisapproveMethods() *common.Methods {
 func (opts *Options) GetRevokeMethods() *common.Methods {
 	m := opts.Methods.Revoke
 	if m == nil {
-		m = &DefaultRevokeMethods
+		m = &common.Methods{
+			Comments: []string{
+				":+1:",
+				"👍",
+			},
+			GithubReview: true,
+		}
 	}
 
 	m.GithubReviewState = pull.ReviewApproved


### PR DESCRIPTION
The default approval and disapproval methods were stored as global
variables but then modified by other methods. While the written data was
always the same and it seemed to work fine historically, we started
seeing memory corruption errors in the 1.7.0 release and the race
detector caught this problem.