### PR TITLE
Load full PR if it is missing required fields

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -147,16 +147,12 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 
 	log.Debug().Msgf("found %d candidates for approval", len(candidates))
 
-	author, err := prctx.Author()
-	if err != nil {
-		return false, "", err
-	}
-
 	// collect users "banned" by approval options
 	banned := make(map[string]bool)
 
 	// "author" is the user who opened the PR
 	// if contributors are allowed, the author counts as a contributor
+	author := prctx.Author()
 	if !r.Options.AllowAuthor && !r.Options.AllowContributor {
 		banned[author] = true
 	}

--- a/policy/predicate/author.go
+++ b/policy/predicate/author.go
@@ -31,10 +31,7 @@ type HasAuthorIn struct {
 var _ Predicate = &HasAuthorIn{}
 
 func (pred *HasAuthorIn) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
-	author, err := prctx.Author()
-	if err != nil {
-		return false, "", errors.Wrap(err, "failed to get author")
-	}
+	author := prctx.Author()
 
 	result, err := pred.IsActor(ctx, prctx, author)
 	desc := ""
@@ -58,13 +55,8 @@ func (pred *HasContributorIn) Evaluate(ctx context.Context, prctx pull.Context) 
 		return false, "", errors.Wrap(err, "failed to get commits")
 	}
 
-	author, err := prctx.Author()
-	if err != nil {
-		return false, "", errors.Wrap(err, "failed to get author")
-	}
-
 	users := make(map[string]struct{})
-	users[author] = struct{}{}
+	users[prctx.Author()] = struct{}{}
 
 	for _, c := range commits {
 		for _, u := range c.Users() {

--- a/policy/predicate/branch.go
+++ b/policy/predicate/branch.go
@@ -36,11 +36,7 @@ func (pred *TargetsBranch) Evaluate(ctx context.Context, prctx pull.Context) (bo
 		return false, "", errors.Wrap(err, "failed to compile the target regex")
 	}
 
-	targetName, _, err := prctx.Branches()
-	if err != nil {
-		return false, "", err
-	}
-
+	targetName, _ := prctx.Branches()
 	matches := pattern.MatchString(targetName)
 
 	desc := ""

--- a/pull/context.go
+++ b/pull/context.go
@@ -41,18 +41,26 @@ type MembershipContext interface {
 type Context interface {
 	MembershipContext
 
-	// Locator returns a locator string for the pull request. The locator
-	// string is formated as "<owner>/<repository>#<number>"
-	Locator() string
-
 	// RepositoryOwner returns the owner of the repo that the pull request targets.
 	RepositoryOwner() string
 
 	// RepositoryName returns the repo that the pull request targets.
 	RepositoryName() string
 
+	// Number returns the number of the pull request.
+	Number() int
+
 	// Author returns the username of the user who opened the pull request.
-	Author() (string, error)
+	Author() string
+
+	// HeadSHA returns the SHA of the head commit of the pull request.
+	HeadSHA() string
+
+	// Branches returns the base (also known as target) and head branch names
+	// of this pull request. Branches in this repository have no prefix, while
+	// branches in forks are prefixed with the owner of the fork and a colon.
+	// The base branch will always be unprefixed.
+	Branches() (base string, head string)
 
 	// ChangedFiles returns the files that were changed in this pull request.
 	ChangedFiles() ([]*File, error)
@@ -68,12 +76,6 @@ type Context interface {
 	// Reviews lists all reviews on a Pull Request. The review order is
 	// implementation dependent.
 	Reviews() ([]*Review, error)
-
-	// Branches returns the base (also known as target) and head branch names
-	// of this pull request. Branches in this repository have no prefix, while
-	// branches in forks are prefixed with the owner of the fork and a colon.
-	// The base branch will always be unprefixed.
-	Branches() (base string, head string, err error)
 
 	// TargetCommits returns recent commits on the target branch of the pull
 	// request. The exact number of commits is an implementation detail.

--- a/pull/github.go
+++ b/pull/github.go
@@ -16,7 +16,6 @@ package pull
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -41,20 +40,82 @@ const (
 	MaxPageSize = 100
 )
 
+// Locator identifies a pull request and optionally contains a full or partial
+// pull request object.
+type Locator struct {
+	Owner  string
+	Repo   string
+	Number int
+
+	Value *github.PullRequest
+}
+
+// IsComplete returns true if the locator contains a pull request object with
+// all required fields.
+func (loc Locator) IsComplete() bool {
+	switch {
+	case loc.Value == nil:
+	case loc.Value.GetUser().GetLogin() == "":
+	case loc.Value.Commits == nil:
+	case loc.Value.GetBase().GetRef() == "":
+	case loc.Value.GetBase().GetRepo().GetID() == 0:
+	case loc.Value.GetHead().GetSHA() == "":
+	case loc.Value.GetHead().GetRef() == "":
+	case loc.Value.GetHead().GetRepo().GetID() == 0:
+	case loc.Value.GetHead().GetRepo().GetName() == "":
+	case loc.Value.GetHead().GetRepo().GetOwner().GetLogin() == "":
+	default:
+		return true
+	}
+	return false
+}
+
+// toV4 returns a v4PullRequest, loading data from the API if the locator is not complete.
+func (loc Locator) toV4(ctx context.Context, client *githubv4.Client) (*v4PullRequest, error) {
+	if !loc.IsComplete() {
+		var q struct {
+			Repository struct {
+				PullRequest v4PullRequest `graphql:"pullRequest(number: $number)"`
+			} `graphql:"repository(owner: $owner, name: $name)"`
+		}
+		qvars := map[string]interface{}{
+			"owner":  githubv4.String(loc.Owner),
+			"name":   githubv4.String(loc.Repo),
+			"number": githubv4.Int(loc.Number),
+		}
+		if err := client.Query(ctx, &q, qvars); err != nil {
+			return nil, errors.Wrap(err, "failed to load pull request details")
+		}
+		return &q.Repository.PullRequest, nil
+	}
+
+	var v4 v4PullRequest
+	v4.Author.Login = loc.Value.GetUser().GetLogin()
+	v4.Commits.TotalCount = loc.Value.GetCommits()
+	v4.IsCrossRepository = loc.Value.GetHead().GetRepo().GetID() != loc.Value.GetBase().GetRepo().GetID()
+	v4.HeadRefOID = loc.Value.GetHead().GetSHA()
+	v4.HeadRefName = loc.Value.GetHead().GetRef()
+	v4.HeadRepository.Name = loc.Value.GetHead().GetRepo().GetName()
+	v4.HeadRepository.Owner.Login = loc.Value.GetHead().GetRepo().GetOwner().GetLogin()
+	v4.BaseRefName = loc.Value.GetBase().GetRef()
+	return &v4, nil
+}
+
 // GitHubContext is a Context implementation that gets information from GitHub.
 // A new instance must be created for each request.
 type GitHubContext struct {
+	MembershipContext
+
 	ctx      context.Context
 	client   *github.Client
 	v4client *githubv4.Client
-	mbrCtx   MembershipContext
 
 	owner  string
 	repo   string
 	number int
+	pr     *v4PullRequest
 
 	// cached fields
-	pr            *v4PullRequest
 	files         []*File
 	commits       []*Commit
 	targetCommits []*Commit
@@ -68,62 +129,28 @@ type GitHubContext struct {
 // obtain information. It caches responses for the lifetime of the context. The
 // pull request passed to the context must contain at least the base repository
 // and the number or the function panics.
-func NewGitHubContext(ctx context.Context, mbrCtx MembershipContext, client *github.Client, v4client *githubv4.Client, pr *github.PullRequest) Context {
-	owner := pr.GetBase().GetRepo().GetOwner().GetLogin()
-	repo := pr.GetBase().GetRepo().GetName()
-	number := pr.GetNumber()
-
-	if owner == "" || repo == "" || number == 0 {
+func NewGitHubContext(ctx context.Context, mbrCtx MembershipContext, client *github.Client, v4client *githubv4.Client, loc Locator) (Context, error) {
+	if loc.Owner == "" || loc.Repo == "" || loc.Number == 0 {
 		panic("pull request object does not contain full identifying information")
 	}
 
+	pr, err := loc.toV4(ctx, v4client)
+	if err != nil {
+		return nil, err
+	}
+
 	return &GitHubContext{
+		MembershipContext: mbrCtx,
+
 		ctx:      ctx,
 		client:   client,
 		v4client: v4client,
-		mbrCtx:   mbrCtx,
 
-		owner:  owner,
-		repo:   repo,
-		number: number,
-		pr:     v3PullRequestToV4(pr),
-	}
-}
-
-func (ghc *GitHubContext) get() (*v4PullRequest, error) {
-	if ghc.pr == nil {
-		var q struct {
-			Repository struct {
-				PullRequest v4PullRequest `graphql:"pullRequest(number: $number)"`
-			} `graphql:"repository(owner: $owner, name: $name)"`
-		}
-		qvars := map[string]interface{}{
-			"owner":  githubv4.String(ghc.owner),
-			"name":   githubv4.String(ghc.repo),
-			"number": githubv4.Int(ghc.number),
-		}
-		if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {
-			return nil, errors.Wrap(err, "failed to load pull request details")
-		}
-		ghc.pr = &q.Repository.PullRequest
-	}
-	return ghc.pr, nil
-}
-
-func (ghc *GitHubContext) IsTeamMember(team, user string) (bool, error) {
-	return ghc.mbrCtx.IsTeamMember(team, user)
-}
-
-func (ghc *GitHubContext) IsOrgMember(org, user string) (bool, error) {
-	return ghc.mbrCtx.IsOrgMember(org, user)
-}
-
-func (ghc *GitHubContext) IsCollaborator(org, repo, user, desiredPerm string) (bool, error) {
-	return ghc.mbrCtx.IsCollaborator(org, repo, user, desiredPerm)
-}
-
-func (ghc *GitHubContext) Locator() string {
-	return fmt.Sprintf("%s/%s#%d", ghc.owner, ghc.repo, ghc.number)
+		owner:  loc.Owner,
+		repo:   loc.Repo,
+		number: loc.Number,
+		pr:     pr,
+	}, nil
 }
 
 func (ghc *GitHubContext) RepositoryOwner() string {
@@ -134,12 +161,28 @@ func (ghc *GitHubContext) RepositoryName() string {
 	return ghc.repo
 }
 
-func (ghc *GitHubContext) Author() (string, error) {
-	pr, err := ghc.get()
-	if err != nil {
-		return "", err
+func (ghc *GitHubContext) Number() int {
+	return ghc.number
+}
+
+func (ghc *GitHubContext) Author() string {
+	return ghc.pr.Author.Login
+}
+
+func (ghc *GitHubContext) HeadSHA() string {
+	return ghc.pr.HeadRefOID
+}
+
+// Branches returns the names of the base and head branch. If the head branch
+// is from another repository (it is a fork) then the branch name is
+// `owner:branchName`.
+func (ghc *GitHubContext) Branches() (base string, head string) {
+	base = ghc.pr.BaseRefName
+	head = ghc.pr.HeadRefName
+	if ghc.pr.IsCrossRepository {
+		head = ghc.pr.HeadRepository.Owner.Login + ":" + head
 	}
-	return pr.Author.Login, nil
+	return
 }
 
 func (ghc *GitHubContext) ChangedFiles() ([]*File, error) {
@@ -185,11 +228,6 @@ func (ghc *GitHubContext) ChangedFiles() ([]*File, error) {
 
 func (ghc *GitHubContext) Commits() ([]*Commit, error) {
 	if ghc.commits == nil {
-		pr, err := ghc.get()
-		if err != nil {
-			return nil, err
-		}
-
 		totalCommits := ghc.pr.Commits.TotalCount
 
 		var q struct {
@@ -207,9 +245,9 @@ func (ghc *GitHubContext) Commits() ([]*Commit, error) {
 		qvars := map[string]interface{}{
 			// always list commits from the head repository
 			// some commit details do not propagate from forks to the upstream
-			"owner":  githubv4.String(pr.HeadRepository.Owner.Login),
-			"name":   githubv4.String(pr.HeadRepository.Name),
-			"oid":    githubv4.GitObjectID(pr.HeadRefOID),
+			"owner":  githubv4.String(ghc.pr.HeadRepository.Owner.Login),
+			"name":   githubv4.String(ghc.pr.HeadRepository.Name),
+			"oid":    githubv4.GitObjectID(ghc.pr.HeadRefOID),
 			"cursor": (*githubv4.String)(nil),
 		}
 
@@ -265,30 +303,8 @@ func (ghc *GitHubContext) Reviews() ([]*Review, error) {
 	return ghc.reviews, nil
 }
 
-// Branches returns the names of the base and head branch. If the head branch
-// is from another repository (it is a fork) then the branch name is
-// `owner:branchName`.
-func (ghc *GitHubContext) Branches() (base string, head string, err error) {
-	pr, err := ghc.get()
-	if err != nil {
-		return "", "", err
-	}
-
-	base = pr.BaseRefName
-	head = pr.HeadRefName
-	if pr.IsCrossRepository {
-		head = pr.HeadRepository.Owner.Login + ":" + head
-	}
-	return
-}
-
 func (ghc *GitHubContext) TargetCommits() ([]*Commit, error) {
 	if ghc.targetCommits == nil {
-		pr, err := ghc.get()
-		if err != nil {
-			return nil, err
-		}
-
 		var q struct {
 			Repository struct {
 				Ref struct {
@@ -305,7 +321,7 @@ func (ghc *GitHubContext) TargetCommits() ([]*Commit, error) {
 		qvars := map[string]interface{}{
 			"owner": githubv4.String(ghc.owner),
 			"name":  githubv4.String(ghc.repo),
-			"ref":   githubv4.String(pr.BaseRefName),
+			"ref":   githubv4.String(ghc.pr.BaseRefName),
 			"limit": githubv4.Int(TargetCommitLimit),
 		}
 
@@ -382,7 +398,7 @@ func (ghc *GitHubContext) loadCommentsAndReviews() error {
 	return nil
 }
 
-// if adding new fields to this struct, modify v3PullRequestToV4() as well!
+// if adding new fields to this struct, modify Locator#toV4() as well
 type v4PullRequest struct {
 	Author  v4Actor
 	Commits struct {
@@ -399,42 +415,6 @@ type v4PullRequest struct {
 	}
 
 	BaseRefName string
-}
-
-// v3PullRequestToV4 creates a v4PullRequest from the v3 version if and only if
-// all necessary fields are present. It returns nil otherwise.
-func v3PullRequestToV4(v3 *github.PullRequest) *v4PullRequest {
-	switch {
-	case v3 == nil:
-
-	case v3.GetUser().GetLogin() == "":
-	case v3.Commits == nil:
-
-	case v3.GetBase().GetRef() == "":
-	case v3.GetBase().GetRepo().GetID() == 0:
-
-	case v3.GetHead().GetSHA() == "":
-	case v3.GetHead().GetRef() == "":
-	case v3.GetHead().GetRepo().GetID() == 0:
-	case v3.GetHead().GetRepo().GetName() == "":
-	case v3.GetHead().GetRepo().GetOwner().GetLogin() == "":
-
-	default:
-		var v4 v4PullRequest
-		v4.Author.Login = v3.GetUser().GetLogin()
-		v4.Commits.TotalCount = v3.GetCommits()
-
-		v4.IsCrossRepository = v3.GetHead().GetRepo().GetID() != v3.GetBase().GetRepo().GetID()
-
-		v4.HeadRefOID = v3.GetHead().GetSHA()
-		v4.HeadRefName = v3.GetHead().GetRef()
-		v4.HeadRepository.Name = v3.GetHead().GetRepo().GetName()
-		v4.HeadRepository.Owner.Login = v3.GetHead().GetRepo().GetOwner().GetLogin()
-
-		v4.BaseRefName = v3.GetBase().GetRef()
-		return &v4
-	}
-	return nil
 }
 
 type v4PageInfo struct {

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -358,10 +358,10 @@ func defaultTestPR() *github.PullRequest {
 			Login: github.String("mhaypenny"),
 		},
 		Head: &github.PullRequestBranch{
-			Label: github.String("testorg:test-branch"),
-			Ref:   github.String("test-branch"),
-			SHA:   github.String("e05fcae367230ee709313dd2720da527d178ce43"),
+			Ref: github.String("test-branch"),
+			SHA: github.String("e05fcae367230ee709313dd2720da527d178ce43"),
 			Repo: &github.Repository{
+				ID: github.Int64(1234),
 				Owner: &github.User{
 					Login: github.String("testorg"),
 				},
@@ -369,14 +369,15 @@ func defaultTestPR() *github.PullRequest {
 			},
 		},
 		Base: &github.PullRequestBranch{
-			Label: github.String("testorg:develop"),
-			Ref:   github.String("develop"),
+			Ref: github.String("develop"),
 			Repo: &github.Repository{
+				ID: github.Int64(1234),
 				Owner: &github.User{
 					Login: github.String("testorg"),
 				},
 				Name: github.String("testrepo"),
 			},
 		},
+		Commits: github.Int(1),
 	}
 }

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -19,12 +19,15 @@ import (
 )
 
 type Context struct {
-	LocatorValue string
-	OwnerValue   string
-	RepoValue    string
+	OwnerValue  string
+	RepoValue   string
+	NumberValue int
 
-	AuthorValue string
-	AuthorError error
+	AuthorValue  string
+	HeadSHAValue string
+
+	BranchBaseName string
+	BranchHeadName string
 
 	ChangedFilesValue []*pull.File
 	ChangedFilesError error
@@ -47,19 +50,8 @@ type Context struct {
 	CollaboratorMemberships     map[string][]string
 	CollaboratorMembershipError error
 
-	BranchBaseName string
-	BranchHeadName string
-	BranchesError  error
-
 	TargetCommitsValue []*pull.Commit
 	TargetCommitsError error
-}
-
-func (c *Context) Locator() string {
-	if c.LocatorValue != "" {
-		return c.LocatorValue
-	}
-	return "pulltest/context#1"
 }
 
 func (c *Context) RepositoryOwner() string {
@@ -76,8 +68,23 @@ func (c *Context) RepositoryName() string {
 	return "context"
 }
 
-func (c *Context) Author() (string, error) {
-	return c.AuthorValue, c.AuthorError
+func (c *Context) Number() int {
+	if c.NumberValue > 0 {
+		return c.NumberValue
+	}
+	return 1
+}
+
+func (c *Context) Author() string {
+	return c.AuthorValue
+}
+
+func (c *Context) HeadSHA() string {
+	return c.HeadSHAValue
+}
+
+func (c *Context) Branches() (base string, head string) {
+	return c.BranchBaseName, c.BranchHeadName
 }
 
 func (c *Context) ChangedFiles() ([]*pull.File, error) {
@@ -133,10 +140,6 @@ func (c *Context) Comments() ([]*pull.Comment, error) {
 
 func (c *Context) Reviews() ([]*pull.Review, error) {
 	return c.ReviewsValue, c.ReviewsError
-}
-
-func (c *Context) Branches() (base string, head string, err error) {
-	return c.BranchBaseName, c.BranchHeadName, c.BranchesError
 }
 
 func (c *Context) TargetCommits() ([]*pull.Commit, error) {

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/palantir/policy-bot/policy"
+	"github.com/palantir/policy-bot/pull"
 )
 
 type FetchedConfig struct {
@@ -71,11 +72,12 @@ type ConfigFetcher struct {
 // only if the existence of the policy could not be determined. If the policy
 // does not exist or is invalid, the returned error is nil and the appropriate
 // fields are set on the FetchedConfig.
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, client *github.Client, pr *github.PullRequest) (FetchedConfig, error) {
+func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) (FetchedConfig, error) {
+	base, _ := prctx.Branches()
 	fc := FetchedConfig{
-		Owner: pr.GetBase().GetRepo().GetOwner().GetLogin(),
-		Repo:  pr.GetBase().GetRepo().GetName(),
-		Ref:   pr.GetBase().GetRef(),
+		Owner: prctx.RepositoryOwner(),
+		Repo:  prctx.RepositoryName(),
+		Ref:   base,
 		Path:  cf.PolicyPath,
 	}
 

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -21,6 +21,8 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
+
+	"github.com/palantir/policy-bot/pull"
 )
 
 type PullRequest struct {
@@ -38,23 +40,16 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	}
 
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
-
-	client, err := h.NewInstallationClient(installationID)
-	if err != nil {
-		return err
-	}
-
-	v4client, err := h.NewInstallationV4Client(installationID)
-	if err != nil {
-		return err
-	}
-
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
 	switch event.GetAction() {
 	case "opened", "reopened", "synchronize", "edited":
-		mbrCtx := NewCrossOrgMembershipContext(ctx, client, event.GetRepo().GetOwner().GetLogin(), h.Installations, h.ClientCreator)
-		return h.Evaluate(ctx, mbrCtx, client, v4client, event.GetPullRequest())
+		return h.Evaluate(ctx, installationID, pull.Locator{
+			Owner:  event.GetRepo().GetOwner().GetLogin(),
+			Repo:   event.GetRepo().GetName(),
+			Number: event.GetPullRequest().GetNumber(),
+			Value:  event.GetPullRequest(),
+		})
 	}
 
 	return nil


### PR DESCRIPTION
The PR objects included in webhook payloads are oddly inconsistent: the
pull_request_review payload does not include the "commits" field, which
is require for policy-bot to function. Instead of loading PRs in each
handler, modify the context to load the PR if the one it was given is
missing any required fields. To make this harder to mess up, use a new
pull request object internally based on the GraphQL query.

Fixes #63.