### PR TITLE
Do not panic if a pull request has no commits

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -125,21 +125,24 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 		if err != nil {
 			return false, "", err
 		}
-		lastCommit := commits[len(commits)-1]
 
-		var allowedCandidates []*common.Candidate
-		for _, candidate := range candidates {
-			if candidate.CreatedAt.After(lastCommit.CreatedAt) {
-				allowedCandidates = append(allowedCandidates, candidate)
+		if len(commits) > 0 {
+			lastCommit := commits[len(commits)-1]
+
+			var allowedCandidates []*common.Candidate
+			for _, candidate := range candidates {
+				if candidate.CreatedAt.After(lastCommit.CreatedAt) {
+					allowedCandidates = append(allowedCandidates, candidate)
+				}
 			}
+
+			log.Debug().Msgf("discarded %d candidates invalidated by push of %s at %s",
+				len(candidates)-len(allowedCandidates),
+				lastCommit.SHA,
+				lastCommit.CreatedAt.Format(time.RFC3339))
+
+			candidates = allowedCandidates
 		}
-
-		log.Debug().Msgf("discarded %d candidates invalidated by push of %s at %s",
-			len(candidates)-len(allowedCandidates),
-			lastCommit.SHA,
-			lastCommit.CreatedAt.Format(time.RFC3339))
-
-		candidates = allowedCandidates
 	}
 
 	log.Debug().Msgf("found %d candidates for approval", len(candidates))


### PR DESCRIPTION
While uncommon, this can happen in some situations. GitHub generally
detects this and closes or merges the PR as appropriate, but policy-bot
should not crash if it receives an event before this happens or if
someone manually views the PR in the details page.