### PR TITLE
Add modified_lines predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,18 @@ if:
     organizations: ["org1", "org2", ...]
     teams: ["org1/team1", "org2/team2", ...]
 
-  # "targets_branch" is satisfied if the target branch on the pull request
+  # "targets_branch" is satisfied if the target branch of the pull request
   # matches the regular expression
   targets_branch:
     pattern: "^(master|regexPattern)$"
+
+  # "modified_lines" is satisfied if the number of lines added or deleted by
+  # the pull request matches any of the listed conditions. Each expression is
+  # an operator (one of '<' or '>'), an optional space, and a number.
+  modified_lines:
+    additions: "> 100"
+    deletion: "> 100"
+    total: "> 200"
 
 # "options" specifies a set of restrictions on approvals. If the block does not
 # exist, the default values are used.

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -24,6 +24,7 @@ type Predicates struct {
 	HasAuthorIn      *predicate.HasAuthorIn      `yaml:"has_author_in"`
 	HasContributorIn *predicate.HasContributorIn `yaml:"has_contributor_in"`
 	TargetsBranch    *predicate.TargetsBranch    `yaml:"targets_branch"`
+	ModifiedLines    *predicate.ModifiedLines    `yaml:"modified_lines"`
 }
 
 func (p *Predicates) Predicates() []predicate.Predicate {
@@ -43,6 +44,9 @@ func (p *Predicates) Predicates() []predicate.Predicate {
 	}
 	if p.TargetsBranch != nil {
 		ps = append(ps, predicate.Predicate(p.TargetsBranch))
+	}
+	if p.ModifiedLines != nil {
+		ps = append(ps, predicate.Predicate(p.ModifiedLines))
 	}
 
 	return ps

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -121,7 +121,7 @@ func (exp ComparisonExpr) Evaluate(n int64) (bool, error) {
 	case ">":
 		return n > v, nil
 	}
-	return false, errors.Errorf("invalid comparsion expression: %q", exp)
+	return false, errors.Errorf("invalid comparison expression: %q", exp)
 }
 
 func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -106,7 +106,7 @@ func (exp ComparisonExpr) IsEmpty() bool {
 func (exp ComparisonExpr) Evaluate(n int64) (bool, error) {
 	match := numCompRegexp.FindStringSubmatch(string(exp))
 	if match == nil {
-		return false, errors.Errorf("invalid comparsion expression: %q", exp)
+		return false, errors.Errorf("invalid comparison expression: %q", exp)
 	}
 
 	op := match[1]


### PR DESCRIPTION
Allows enabling rules based on the number of lines added or deleted by a
pull request. Each property takes simple expression representing a
comparison and the predicate is satisfied if any expression is matched.

Fixes #70.