### PR TITLE
Fix long descriptions in audit statuses

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -34,6 +34,8 @@ const (
 	DefaultPolicyPath         = ".policy.yml"
 	DefaultStatusCheckContext = "policy-bot"
 	DefaultAppName            = "policy-bot"
+
+	GitHubSHAKey = "github_sha"
 )
 
 type Base struct {
@@ -114,7 +116,7 @@ func (b *Base) postGitHubRepoStatus(ctx context.Context, client *github.Client, 
 func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *github.PullRequest) (context.Context, zerolog.Logger) {
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, pr.GetBase().GetRepo(), pr.GetNumber())
 
-	logger = logger.With().Str("github_sha", pr.GetHead().GetSHA()).Logger()
+	logger = logger.With().Str(GitHubSHAKey, pr.GetHead().GetSHA()).Logger()
 	ctx = logger.WithContext(ctx)
 
 	return ctx, logger

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -35,7 +35,7 @@ const (
 	DefaultStatusCheckContext = "policy-bot"
 	DefaultAppName            = "policy-bot"
 
-	GitHubSHAKey = "github_sha"
+	LogKeyGitHubSHA = "github_sha"
 )
 
 type Base struct {
@@ -116,7 +116,7 @@ func (b *Base) postGitHubRepoStatus(ctx context.Context, client *github.Client, 
 func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *github.PullRequest) (context.Context, zerolog.Logger) {
 	ctx, logger := githubapp.PreparePRContext(ctx, installationID, pr.GetBase().GetRepo(), pr.GetNumber())
 
-	logger = logger.With().Str(GitHubSHAKey, pr.GetHead().GetSHA()).Logger()
+	logger = logger.With().Str(LogKeyGitHubSHA, pr.GetHead().GetSHA()).Logger()
 	ctx = logger.WithContext(ctx)
 
 	return ctx, logger

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -61,16 +61,20 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	commitSHA := event.GetCommit().GetSHA()
 
 	if sender.GetLogin() != h.PullOpts.AppName+"[bot]" {
-		auditMessage := fmt.Sprintf(
-			"Entity '%s' overwrote status check '%s' on ref=%s to status='%s' description='%s' targetURL='%s'",
-			sender.GetLogin(),
-			event.GetContext(),
-			commitSHA,
-			event.GetState(),
-			event.GetDescription(),
-			event.GetTargetURL(),
-		)
-		logger.Warn().Str(LogKeyAudit, eventType).Msg(auditMessage)
+		logger.Warn().
+			Str(LogKeyAudit, eventType).
+			Str(GitHubSHAKey, commitSHA).
+			Msgf(
+				"Entity '%s' overwrote status check '%s' to state='%s' description='%s' targetURL='%s'",
+				sender.GetLogin(),
+				event.GetContext(),
+				event.GetState(),
+				event.GetDescription(),
+				event.GetTargetURL(),
+			)
+
+		// must be less than 140 characters to satisfy GitHub API
+		desc := fmt.Sprintf("'%s' overwrote status to '%s'", sender.GetLogin(), event.GetState())
 
 		// unlike in other code, use a single context here because we want to
 		// replace a forged context with a failure, not post a general status
@@ -78,7 +82,7 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 		status := &github.RepoStatus{
 			Context:     event.Context,
 			State:       github.String("failure"),
-			Description: &auditMessage,
+			Description: &desc,
 		}
 
 		_, _, err := client.Repositories.CreateStatus(ctx, ownerName, repoName, commitSHA, status)

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -63,7 +63,7 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 	if sender.GetLogin() != h.PullOpts.AppName+"[bot]" {
 		logger.Warn().
 			Str(LogKeyAudit, eventType).
-			Str(GitHubSHAKey, commitSHA).
+			Str(LogKeyGitHubSHA, commitSHA).
 			Msgf(
 				"Entity '%s' overwrote status check '%s' to state='%s' description='%s' targetURL='%s'",
 				sender.GetLogin(),


### PR DESCRIPTION
The GitHub API limits status descriptions to 140 characters, but the
status we posted when detecting an overwrite could be longer than that,
depending on the formatted values. Update the audit code to log the full
message but post an abbreviated message that is under the character
limit.

Fixes #72.