### PR TITLE
Return to loading commits from the pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ For a commit on a branch to count as an "update merge" for the purpose of the
 
 1. The commit must have exactly two parents
 2. The commit must have the `committedViaWeb` property set to `true`
-3. One parent must exist in the last 100 commits on the target branch of the
-   pull request
+3. The first parent must exist in the pull request while the second parent
+   must not exist in the pull request (meaning it is on the target branch)
 
 These will all be true after updating a branch using the UI, but historic
 merges on long-running branches or merges created with the API may not be

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -252,12 +252,9 @@ func isUpdateMerge(commits []*pull.Commit, c *pull.Commit) bool {
 		shas[c.SHA] = true
 	}
 
-	// first parent must exist: it is another commit on the head branch
-	// second parent must not: it is already included in the base branch
-	if shas[c.Parents[0]] && !shas[c.Parents[1]] {
-		return true
-	}
-	return false
+	// first parent must exist: it is a commit on the head branch
+	// second parent must not exist: it is already in the base branch
+	return shas[c.Parents[0]] && !shas[c.Parents[1]]
 }
 
 func findLastPushed(commits []*pull.Commit) *pull.Commit {

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -126,23 +126,24 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 			return false, "", err
 		}
 
-		if len(commits) > 0 {
-			lastCommit := commits[len(commits)-1]
-
-			var allowedCandidates []*common.Candidate
-			for _, candidate := range candidates {
-				if candidate.CreatedAt.After(lastCommit.CreatedAt) {
-					allowedCandidates = append(allowedCandidates, candidate)
-				}
-			}
-
-			log.Debug().Msgf("discarded %d candidates invalidated by push of %s at %s",
-				len(candidates)-len(allowedCandidates),
-				lastCommit.SHA,
-				lastCommit.CreatedAt.Format(time.RFC3339))
-
-			candidates = allowedCandidates
+		last := findLastPushed(commits)
+		if last == nil {
+			return false, "", errors.New("no commit contained a push date")
 		}
+
+		var allowedCandidates []*common.Candidate
+		for _, candidate := range candidates {
+			if candidate.CreatedAt.After(*last.PushedAt) {
+				allowedCandidates = append(allowedCandidates, candidate)
+			}
+		}
+
+		log.Debug().Msgf("discarded %d candidates invalidated by push of %s at %s",
+			len(candidates)-len(allowedCandidates),
+			last.SHA,
+			last.PushedAt.Format(time.RFC3339))
+
+		candidates = allowedCandidates
 	}
 
 	log.Debug().Msgf("found %d candidates for approval", len(candidates))
@@ -213,14 +214,11 @@ func (r *Rule) IsApproved(ctx context.Context, prctx pull.Context) (bool, string
 	return false, msg, nil
 }
 
-// filteredCommits returns relevant commits ordered from oldest to newest.
 func (r *Rule) filteredCommits(prctx pull.Context) ([]*pull.Commit, error) {
 	commits, err := prctx.Commits()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list commits")
 	}
-
-	sort.Stable(pull.CommitsByCreationTime(commits))
 
 	needsFiltering := r.Options.IgnoreUpdateMerges
 	if !needsFiltering {
@@ -229,13 +227,8 @@ func (r *Rule) filteredCommits(prctx pull.Context) ([]*pull.Commit, error) {
 
 	var filtered []*pull.Commit
 	for _, c := range commits {
-		isUpdate, err := isUpdateMerge(prctx, c)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to detemine update merge status")
-		}
-
 		switch {
-		case isUpdate:
+		case isUpdateMerge(commits, c):
 		default:
 			filtered = append(filtered, c)
 		}
@@ -243,29 +236,38 @@ func (r *Rule) filteredCommits(prctx pull.Context) ([]*pull.Commit, error) {
 	return filtered, nil
 }
 
-func isUpdateMerge(prctx pull.Context, c *pull.Commit) (bool, error) {
+func isUpdateMerge(commits []*pull.Commit, c *pull.Commit) bool {
 	// must be a simple merge commit (exactly 2 parents)
 	if len(c.Parents) != 2 {
-		return false, nil
+		return false
 	}
 
 	// must be created via the UI or the API (no local merges)
 	if !c.CommittedViaWeb {
-		return false, nil
+		return false
 	}
 
-	// one parent must exist in recent history on the target branch
-	targets, err := prctx.TargetCommits()
-	if err != nil {
-		return false, err
+	shas := make(map[string]bool)
+	for _, c := range commits {
+		shas[c.SHA] = true
 	}
-	for _, target := range targets {
-		if c.Parents[0] == target.SHA || c.Parents[1] == target.SHA {
-			return true, nil
+
+	// first parent must exist: it is another commit on the head branch
+	// second parent must not: it is already included in the base branch
+	if shas[c.Parents[0]] && !shas[c.Parents[1]] {
+		return true
+	}
+	return false
+}
+
+func findLastPushed(commits []*pull.Commit) *pull.Commit {
+	var last *pull.Commit
+	for _, c := range commits {
+		if c.PushedAt != nil && (last == nil || c.PushedAt.After(*last.PushedAt)) {
+			last = c
 		}
 	}
-
-	return false, nil
+	return last
 }
 
 func numberOfApprovals(count int) string {

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -85,36 +85,22 @@ func TestIsApproved(t *testing.T) {
 			},
 			CommitsValue: []*pull.Commit{
 				{
-					CreatedAt: now.Add(5 * time.Second),
+					PushedAt:  newTime(now.Add(5 * time.Second)),
 					SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
 					Author:    "mhaypenny",
 					Committer: "mhaypenny",
 				},
 				{
-					CreatedAt: now.Add(15 * time.Second),
+					PushedAt:  newTime(now.Add(15 * time.Second)),
 					SHA:       "674832587eaaf416371b30f5bc5a47e377f534ec",
 					Author:    "contributor-author",
 					Committer: "mhaypenny",
 				},
 				{
-					CreatedAt: now.Add(45 * time.Second),
+					PushedAt:  newTime(now.Add(45 * time.Second)),
 					SHA:       "97d5ea26da319a987d80f6db0b7ef759f2f2e441",
 					Author:    "mhaypenny",
 					Committer: "contributor-committer",
-				},
-			},
-			TargetCommitsValue: []*pull.Commit{
-				{
-					CreatedAt: now.Add(5 * time.Second),
-					SHA:       "dc594ff5aca4133070a76f9006568b656a251770",
-					Author:    "developer",
-					Committer: "developer",
-				},
-				{
-					CreatedAt: now.Add(0 * time.Second),
-					SHA:       "2e1b0bb6ab144bf7a1b7a1df9d3bdcb0fe85a206",
-					Author:    "developer",
-					Committer: "developer",
 				},
 			},
 			OrgMemberships: map[string][]string{
@@ -273,7 +259,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		prctx.CommitsValue = []*pull.Commit{
 			{
-				CreatedAt: now.Add(25 * time.Second),
+				PushedAt:  newTime(now.Add(25 * time.Second)),
 				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
 				Author:    "mhaypenny",
 				Committer: "mhaypenny",
@@ -298,7 +284,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		prctx.CommitsValue = []*pull.Commit{
 			{
-				CreatedAt: now.Add(85 * time.Second),
+				PushedAt:  newTime(now.Add(85 * time.Second)),
 				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
 				Author:    "mhaypenny",
 				Committer: "mhaypenny",
@@ -322,7 +308,7 @@ func TestIsApproved(t *testing.T) {
 	t.Run("ignoreUpdateMergeAfterReview", func(t *testing.T) {
 		prctx := basePullContext()
 		prctx.CommitsValue = append(prctx.CommitsValue[:1], &pull.Commit{
-			CreatedAt:       now.Add(25 * time.Second),
+			PushedAt:        newTime(now.Add(25 * time.Second)),
 			SHA:             "647c5078288f0ea9de27b5c280f25edaf2089045",
 			CommittedViaWeb: true,
 			Parents: []string{
@@ -352,7 +338,7 @@ func TestIsApproved(t *testing.T) {
 	t.Run("ignoreUpdateMergeContributor", func(t *testing.T) {
 		prctx := basePullContext()
 		prctx.CommitsValue = append(prctx.CommitsValue[:1], &pull.Commit{
-			CreatedAt:       now.Add(25 * time.Second),
+			PushedAt:        newTime(now.Add(25 * time.Second)),
 			SHA:             "647c5078288f0ea9de27b5c280f25edaf2089045",
 			CommittedViaWeb: true,
 			Parents: []string{
@@ -380,4 +366,8 @@ func TestIsApproved(t *testing.T) {
 		r.Options.IgnoreUpdateMerges = true
 		assertApproved(t, prctx, r, "Approved by merge-committer")
 	})
+}
+
+func newTime(t time.Time) *time.Time {
+	return &t
 }

--- a/pull/context.go
+++ b/pull/context.go
@@ -76,10 +76,6 @@ type Context interface {
 	// Reviews lists all reviews on a Pull Request. The review order is
 	// implementation dependent.
 	Reviews() ([]*Review, error)
-
-	// TargetCommits returns recent commits on the target branch of the pull
-	// request. The exact number of commits is an implementation detail.
-	TargetCommits() ([]*Commit, error)
 }
 
 type FileStatus int
@@ -98,7 +94,6 @@ type File struct {
 }
 
 type Commit struct {
-	CreatedAt       time.Time
 	SHA             string
 	Parents         []string
 	CommittedViaWeb bool
@@ -110,6 +105,10 @@ type Commit struct {
 	// Commiter is the login name of the committer. It is empty if the
 	// committer is not a real user.
 	Committer string
+
+	// PushedAt is the timestamp when the commit was pushed. It is nil if that
+	// information is not available for this commit.
+	PushedAt *time.Time
 }
 
 // Users returns the login names of the users associated with this commit.
@@ -122,14 +121,6 @@ func (c *Commit) Users() []string {
 		users = append(users, c.Committer)
 	}
 	return users
-}
-
-type CommitsByCreationTime []*Commit
-
-func (cs CommitsByCreationTime) Len() int      { return len(cs) }
-func (cs CommitsByCreationTime) Swap(i, j int) { cs[i], cs[j] = cs[j], cs[i] }
-func (cs CommitsByCreationTime) Less(i, j int) bool {
-	return cs[i].CreatedAt.Before(cs[j].CreatedAt)
 }
 
 type Comment struct {

--- a/pull/github.go
+++ b/pull/github.go
@@ -328,9 +328,9 @@ func (ghc *GitHubContext) loadPagedData() error {
 		return err
 	}
 
+	ghc.commits = commits
 	ghc.comments = comments
 	ghc.reviews = reviews
-	ghc.commits = commits
 	return nil
 }
 

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -62,7 +62,7 @@ func TestChangedFiles(t *testing.T) {
 func TestCommits(t *testing.T) {
 	rp := &ResponsePlayer{}
 	dataRule := rp.AddRule(
-		GraphQLNodePrefixMatcher("repository.object"),
+		GraphQLNodePrefixMatcher("repository.pullRequest.commits"),
 		"testdata/responses/pull_commits.yml",
 	)
 
@@ -77,23 +77,23 @@ func TestCommits(t *testing.T) {
 	require.Len(t, commits, 3, "incorrect number of commits")
 	assert.Equal(t, 2, dataRule.Count, "no http request was made")
 
-	expectedTime, err := time.Parse(time.RFC3339, "2018-12-06T12:34:56Z")
+	expectedTime, err := time.Parse(time.RFC3339, "2018-12-04T12:34:56Z")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "e05fcae367230ee709313dd2720da527d178ce43", commits[0].SHA)
-	assert.Equal(t, "ttest", commits[0].Author)
+	assert.Equal(t, "a6f3f69b64eaafece5a0d854eb4af11c0d64394c", commits[0].SHA)
+	assert.Equal(t, "mhaypenny", commits[0].Author)
 	assert.Equal(t, "mhaypenny", commits[0].Committer)
-	assert.Equal(t, expectedTime, commits[0].CreatedAt)
+	assert.Equal(t, newTime(expectedTime), commits[0].PushedAt)
 
 	assert.Equal(t, "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9", commits[1].SHA)
 	assert.Equal(t, "mhaypenny", commits[1].Author)
 	assert.Equal(t, "mhaypenny", commits[1].Committer)
-	assert.Equal(t, expectedTime.Add(-48*time.Hour), commits[1].CreatedAt)
+	assert.Equal(t, newTime(expectedTime), commits[1].PushedAt)
 
-	assert.Equal(t, "a6f3f69b64eaafece5a0d854eb4af11c0d64394c", commits[2].SHA)
-	assert.Equal(t, "mhaypenny", commits[2].Author)
+	assert.Equal(t, "e05fcae367230ee709313dd2720da527d178ce43", commits[2].SHA)
+	assert.Equal(t, "ttest", commits[2].Author)
 	assert.Equal(t, "mhaypenny", commits[2].Committer)
-	assert.Equal(t, expectedTime.Add(-48*time.Hour), commits[2].CreatedAt)
+	assert.Equal(t, newTime(expectedTime.Add(48*time.Hour)), commits[2].PushedAt)
 
 	// verify that the commit list is cached
 	commits, err = ctx.Commits()
@@ -387,6 +387,9 @@ func defaultTestPR() *github.PullRequest {
 				Name: github.String("testrepo"),
 			},
 		},
-		Commits: github.Int(1),
 	}
+}
+
+func newTime(t time.Time) *time.Time {
+	return &t
 }

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -49,9 +49,6 @@ type Context struct {
 
 	CollaboratorMemberships     map[string][]string
 	CollaboratorMembershipError error
-
-	TargetCommitsValue []*pull.Commit
-	TargetCommitsError error
 }
 
 func (c *Context) RepositoryOwner() string {
@@ -140,10 +137,6 @@ func (c *Context) Comments() ([]*pull.Comment, error) {
 
 func (c *Context) Reviews() ([]*pull.Review, error) {
 	return c.ReviewsValue, c.ReviewsError
-}
-
-func (c *Context) TargetCommits() ([]*pull.Commit, error) {
-	return c.TargetCommitsValue, c.TargetCommitsError
 }
 
 // assert that the test object implements the full interface

--- a/pull/testdata/responses/pull_commits.yml
+++ b/pull/testdata/responses/pull_commits.yml
@@ -4,38 +4,56 @@
       "errors": [],
       "data": {
         "repository": {
-          "object": {
-            "history": {
+          "pullRequest": {
+            "commits": {
               "pageInfo": {
                 "endCursor": "2",
                 "hasNextPage": true
               },
               "nodes": [
                 {
-                  "oid": "e05fcae367230ee709313dd2720da527d178ce43",
-                  "pushedDate": "2018-12-06T12:34:56Z",
-                  "author": {
-                    "user": {
-                      "login": "ttest"
-                    }
-                  },
-                  "committer": {
-                    "user": {
-                      "login": "mhaypenny"
+                  "commit": {
+                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
+                    "pushedDate": null,
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "0492883704e64bb53834c7c5fbd5fc22d44dedda"
+                        }
+                      ]
                     }
                   }
                 },
                 {
-                  "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9",
-                  "pushedDate": "2018-12-04T12:34:56Z",
-                  "author": {
-                    "user": {
-                      "login": "mhaypenny"
-                    }
-                  },
-                  "committer": {
-                    "user": {
-                      "login": "mhaypenny"
+                  "commit": {
+                    "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9",
+                    "pushedDate": "2018-12-04T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c"
+                        }
+                      ]
                     }
                   }
                 }
@@ -51,57 +69,33 @@
       "errors": [],
       "data": {
         "repository": {
-          "object": {
-            "history": {
+          "pullRequest": {
+            "commits": {
               "pageInfo": {
                 "endCursor": "3",
-                "hasNextPage": true
-              },
-              "nodes": [
-                {
-                  "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
-                  "pushedDate": null,
-                  "author": {
-                    "user": {
-                      "login": "mhaypenny"
-                    }
-                  },
-                  "committer": {
-                    "user": {
-                      "login": "mhaypenny"
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      }
-    }
-- status: 200
-  body: |
-    {
-      "errors": [],
-      "data": {
-        "repository": {
-          "object": {
-            "history": {
-              "pageInfo": {
-                "endCursor": "4",
                 "hasNextPage": false
               },
               "nodes": [
                 {
-                  "oid": "87bea13a7933ae45bd54a9a7f9014f0911992a0b",
-                  "pushedDate": "2018-12-01T12:34:56Z",
-                  "author": {
-                    "user": {
-                      "login": "mhaypenny"
-                    }
-                  },
-                  "committer": {
-                    "user": {
-                      "login": "mhaypenny"
+                  "commit": {
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": "2018-12-06T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "ttest"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9"
+                        }
+                      ]
                     }
                   }
                 }


### PR DESCRIPTION
This is the only way to get only the commits included in the PR without
performing our own comparisons against the commits on the target branch.
This property is important to correctly handle merge commits.

In order to load pushedDate values from fork commits, conditionally make
a second query listing commit history and match these commits with the
ones in the pull request.

To avoid additional hazards of commit loading, simplify the detection of
update merges by relying on the principle that GitHub will automatically
exclude any commits already on the target branch from the PR listing.
This removes the need to load target branch commits.

Finally, change the pushed date backfill logic to walk the parent commit
chain instead of using a specific order that differs between APIs.

Fixes #75. 