### PR TITLE
Retry commit loading if data is missing

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -33,10 +33,11 @@ const (
 	// MaxPullRequestCommits is the max number of commits returned by GitHub
 	// https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
 	MaxPullRequestCommits = 250
+)
 
-	// MaxCommitLoadAttempts is the maximum number of times to attempt loading
-	// commit data if the GitHub reposnse is missing data.
-	MaxCommitLoadAttempts = 3
+var (
+	commitLoadMaxAttempts = 3
+	commitLoadBaseDelay   = time.Second
 )
 
 // Locator identifies a pull request and optionally contains a full or partial
@@ -349,7 +350,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 		}
 
 		attempts++
-		if attempts >= MaxCommitLoadAttempts {
+		if attempts >= commitLoadMaxAttempts {
 			msg := "missing"
 			if head != nil {
 				msg += " pushed date"
@@ -357,7 +358,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 			return nil, errors.Errorf("head commit %.10s is %s; this is probably a bug", ghc.pr.HeadRefOID, msg)
 		}
 
-		time.Sleep(time.Duration(attempts) * time.Second)
+		time.Sleep(time.Duration(attempts) * commitLoadBaseDelay)
 	}
 }
 

--- a/pull/testdata/responses/pull_commits_retry.yml
+++ b/pull/testdata/responses/pull_commits_retry.yml
@@ -1,0 +1,176 @@
+- status: 200
+  body: |
+    {
+      "errors": [],
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "commits": {
+              "pageInfo": {
+                "endCursor": "2",
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "commit": {
+                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
+                    "pushedDate": null,
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "0492883704e64bb53834c7c5fbd5fc22d44dedda"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "commit": {
+                    "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9",
+                    "pushedDate": "2018-12-04T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "commit": {
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": null,
+                    "author": {
+                      "user": {
+                        "login": "ttest"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+- status: 200
+  body: |
+    {
+      "errors": [],
+      "data": {
+        "repository": {
+          "pullRequest": {
+            "commits": {
+              "pageInfo": {
+                "endCursor": "2",
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "commit": {
+                    "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c",
+                    "pushedDate": null,
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "0492883704e64bb53834c7c5fbd5fc22d44dedda"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "commit": {
+                    "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9",
+                    "pushedDate": "2018-12-04T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "a6f3f69b64eaafece5a0d854eb4af11c0d64394c"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "commit": {
+                    "oid": "e05fcae367230ee709313dd2720da527d178ce43",
+                    "pushedDate": "2018-12-06T12:34:56Z",
+                    "author": {
+                      "user": {
+                        "login": "ttest"
+                      }
+                    },
+                    "committer": {
+                      "user": {
+                        "login": "mhaypenny"
+                      }
+                    },
+                    "parents": {
+                      "nodes": [
+                        {
+                          "oid": "1fc89f1cedf8e3f3ce516ab75b5952295c8ea5e9"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }


### PR DESCRIPTION
GitHub seems to be missing the head commit or the pushed date for the
head commit on when making API calls immediately after a PR is created
or updated. Later evaluations return the expected information, so if
we're missing the required data, try reloading after a few seconds.