### PR TITLE
Clarify error messages when listing commits

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -341,8 +341,8 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 			return nil, errors.Errorf("head commit %.10s is missing, probably due to a force-push", ghc.pr.HeadRefOID)
 		}
 
-		// as of 2019-05-01, the GitHub API does return pushed date for
-		// commits from forks, so we must load that separately
+		// as of 2019-05-01, the GitHub API does not return pushed date
+		// for commits from forks, so we must load that separately
 		if ghc.pr.IsCrossRepository && head.PushedAt == nil {
 			if err := ghc.loadPushedAt(commits); err != nil {
 				return nil, err

--- a/pull/github.go
+++ b/pull/github.go
@@ -336,28 +336,27 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 			commits = append(commits, c)
 		}
 
-		if head != nil {
-			// as of 2019-05-01, the GitHub API does return pushed date for
-			// commits from forks, so we must load that separately
-			if ghc.pr.IsCrossRepository && head.PushedAt == nil {
-				if err := ghc.loadPushedAt(commits); err != nil {
-					return nil, err
-				}
+		// if head is missing from the pull request, retrying won't find it
+		if head == nil {
+			return nil, errors.Errorf("head commit %.10s is missing, probably due to a force-push", ghc.pr.HeadRefOID)
+		}
+
+		// as of 2019-05-01, the GitHub API does return pushed date for
+		// commits from forks, so we must load that separately
+		if ghc.pr.IsCrossRepository && head.PushedAt == nil {
+			if err := ghc.loadPushedAt(commits); err != nil {
+				return nil, err
 			}
-			if head.PushedAt != nil {
-				return commits, nil
-			}
+		}
+
+		if head.PushedAt != nil {
+			return commits, nil
 		}
 
 		attempts++
 		if attempts >= commitLoadMaxAttempts {
-			msg := "missing"
-			if head != nil {
-				msg += " pushed date"
-			}
-			return nil, errors.Errorf("head commit %.10s is %s; this is probably a bug", ghc.pr.HeadRefOID, msg)
+			return nil, errors.Errorf("head commit %.10s is missing pushed date; this is probably a bug", ghc.pr.HeadRefOID)
 		}
-
 		time.Sleep(time.Duration(attempts) * commitLoadBaseDelay)
 	}
 }


### PR DESCRIPTION
After observation, the head commit is only missing when the pull request
is updated by a force-push immediately after some other event. The first
event includes a payload with the old commit information, but only the
new commit is available by the time the server lists the pull request
commits from the API. Still return an error in this case (since we can't
correctly evaluate the PR as requested), but avoid retrying and clarify
the error message. In practice, this error won't appear to users because
the failed commit was removed from the pull request.