### PR TITLE
Support policy files up to 100 MB

### DIFF
--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -152,8 +153,22 @@ func (cf *ConfigFetcher) fetchConfigContents(ctx context.Context, client *github
 
 	file, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opts)
 	if err != nil {
-		if rerr, ok := err.(*github.ErrorResponse); ok && rerr.Response.StatusCode == http.StatusNotFound {
+		rerr, ok := err.(*github.ErrorResponse)
+		if ok && rerr.Response.StatusCode == http.StatusNotFound {
 			return nil, nil
+		}
+		if ok && cf.hasTooLargeError(rerr) {
+			// GetContents only supports file sizes up to 1 MB, DownloadContents supports files up to 100 MB (with an additional API call)
+			reader, downloadErr := client.Repositories.DownloadContents(ctx, owner, repo, path, opts)
+			if downloadErr != nil {
+				return nil, errors.Wrapf(downloadErr, "failed to download content of %s/%s@%s/%s", owner, repo, ref, path)
+			}
+			downloadedContent, readErr := ioutil.ReadAll(reader)
+			reader.Close()
+			if readErr != nil {
+				return nil, errors.Wrapf(readErr, "failed to read content of %s/%s/@%s/%s", owner, repo, ref, path)
+			}
+			return downloadedContent, nil
 		}
 		return nil, errors.Wrapf(err, "failed to fetch content of %s/%s@%s/%s", owner, repo, ref, path)
 	}
@@ -178,4 +193,13 @@ func (cf *ConfigFetcher) unmarshalConfig(bytes []byte) (*policy.Config, error) {
 	}
 
 	return &config, nil
+}
+
+func (cf *ConfigFetcher) hasTooLargeError(errorResponse *github.ErrorResponse) bool {
+	for _, error := range errorResponse.Errors {
+		if error.Code == "too_large" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Previous usage of Git Repos API only supports policy files with max size of 1 MB. This adds a fall-back to use the Git Data API if the initial call fails as the file is too large.

The DownloadContents method could be used in place of GetContents, but since this code is called very often and DownloadContents makes an additional API call to list the tree to acquire the file SHA,
and this is an edge case, I have implemented it as a fallback instead (per Billy's suggestion)

Fixes #83