### PR TITLE
Fix author_is_only_contributor for web commits

### DIFF
--- a/policy/predicate/author.go
+++ b/policy/predicate/author.go
@@ -90,7 +90,7 @@ func (pred AuthorIsOnlyContributor) Evaluate(ctx context.Context, prctx pull.Con
 
 	author := prctx.Author()
 	for _, c := range commits {
-		if c.Author != author || c.Committer != author {
+		if c.Author != author || (!c.CommittedViaWeb && c.Committer != author) {
 			if pred {
 				return false, fmt.Sprintf("Commit %.10s was authored or committed by a different user", c.SHA), nil
 			}

--- a/policy/predicate/author_test.go
+++ b/policy/predicate/author_test.go
@@ -192,7 +192,7 @@ func TestAuthorIsOnlyContributor(t *testing.T) {
 
 	runAuthorTests(t, p, []AuthorTestCase{
 		{
-			"authorIsOnlyConrtributor",
+			"authorIsOnlyContributor",
 			true,
 			&pulltest.Context{
 				AuthorValue: "mhaypenny",
@@ -206,6 +206,21 @@ func TestAuthorIsOnlyContributor(t *testing.T) {
 						SHA:       "9df0f1cee4b58363b534dbb5e9070fceee23fa10",
 						Author:    "mhaypenny",
 						Committer: "mhaypenny",
+					},
+				},
+			},
+		},
+		{
+			"authorIsOnlyContributorViaWeb",
+			true,
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:             "0cb194c52ee7c6c82110b59ec51b959ecfcb2fa2",
+						Author:          "mhaypenny",
+						Committer:       "",
+						CommittedViaWeb: true,
 					},
 				},
 			},
@@ -256,7 +271,7 @@ func TestAuthorIsNotOnlyContributor(t *testing.T) {
 
 	runAuthorTests(t, p, []AuthorTestCase{
 		{
-			"authorIsOnlyConrtributor",
+			"authorIsOnlyContributor",
 			false,
 			&pulltest.Context{
 				AuthorValue: "mhaypenny",


### PR DESCRIPTION
When creating a commit via the GitHub UI, the committer is GitHub, which
doesn't map to a user and results in an empty committer string. If the
commit was generated from the UI, only check the author string against
the pull request author.

Fixes #88.