### PR TITLE
Order rules by status on the details page

### DIFF
--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -17,7 +17,7 @@ package common
 type EvaluationStatus int
 
 const (
-	StatusSkipped EvaluationStatus = iota
+	StatusSkipped EvaluationStatus = iota // note: values used for ordering
 	StatusPending
 	StatusApproved
 	StatusDisapproved

--- a/server/handler/frontend.go
+++ b/server/handler/frontend.go
@@ -17,9 +17,12 @@ package handler
 import (
 	"html/template"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/bluekeyes/templatetree"
+
+	"github.com/palantir/policy-bot/policy/common"
 )
 
 const (
@@ -35,6 +38,16 @@ type FilesConfig struct {
 func LoadTemplates(c *FilesConfig) (templatetree.HTMLTree, error) {
 	root := template.New("root").Funcs(template.FuncMap{
 		"titlecase": strings.Title,
+		"sortByStatus": func(results []*common.Result) []*common.Result {
+			r := make([]*common.Result, len(results))
+			copy(r, results)
+
+			sort.SliceStable(r, func(i, j int) bool {
+				return r[i].Status > r[j].Status
+			})
+
+			return r
+		},
 	})
 
 	dir := c.Templates

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -30,7 +30,7 @@
     </div>
     <div class="pl-8 overflow-auto flex-grow">
       <ul class="tree px-4 pb-4">
-          {{range .Result.Children}}{{template "result" .}}{{end}}
+          {{range .Result.Children | sortByStatus}}{{template "result" .}}{{end}}
       </ul>
     </div>
   {{end}}
@@ -44,7 +44,7 @@
   </div>
   {{if .Children}}
   <ul class="tree">
-    {{range .Children}}{{template "result" .}}{{end}}
+    {{range .Children | sortByStatus}}{{template "result" .}}{{end}}
   </ul>
   {{end}}
 </li>


### PR DESCRIPTION
Show approved and pending rules first and skipped rules last. When
multiple rules have the same status, preserve the order in which they
are defined by the policy.

Fixes #93.