### PR TITLE
Document URLs for GitHub App configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,14 @@ that terminates TLS connections.
 
 ### GitHub App Configuration
 
-`policy-bot` requires the following permissions as a GitHub app:
+To configure `policy-bot` as a GitHub App, these general options are required:
+
+- **User authorization callback URL**: `http(s)://<your-policy-bot-domain>/api/github/auth`
+- **Webhook URL**: `http(s)://<your-policy-bot-domain>/api/github/hook`
+- **Webhook secret**: A random string that matches the value of the
+  `github.app.webhook_secret` property in the server configuration
+
+The app requires these permissions:
 
 | Permission | Access | Reason |
 | ---------- | ------ | ------ |
@@ -375,7 +382,7 @@ that terminates TLS connections.
 | Commit status | Read & write | Post commit statuses |
 | Organization members | Read-only | Determine organization and team membership |
 
-It should be subscribed to the following events:
+The app should be subscribed to these events:
 
 * Issue comment
 * Pull request

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -34,7 +34,12 @@ github:
     # A random string used to validate webhooks
     webhook_secret: "app_secret"
     # The private key of the GitHub app
-    private_key: "app_private_key"
+    private_key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      xxxxx
+      xxxxx
+      xxxxx
+      -----END RSA PRIVATE KEY-----
   oauth:
     # The client ID of the OAuth app associated with the GitHub app
     client_id: "client_id"


### PR DESCRIPTION
Also fix the example configuration to show the correct private key formatting.

Closes #103 and closes #100.