### PR TITLE
Read some config values from the environment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,14 +133,14 @@
 
 [[projects]]
   branch = "develop"
-  digest = "1:a25cea36e32fe9f171da95aa4199e0a97f113af70ae2802bcbd2aa1e95647439"
+  digest = "1:40b01e7a361d48730a51d8113417f2787667703d30ff6c0f04ef6b2283430453"
   name = "github.com/palantir/go-githubapp"
   packages = [
     "githubapp",
     "oauth2",
   ]
   pruneopts = "NUT"
-  revision = "9f023162a90f86c702017192b62d39a7e2fe32d7"
+  revision = "e3527091824a277432abfb5754cd9f41b4e3cd1b"
 
 [[projects]]
   digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"

--- a/README.md
+++ b/README.md
@@ -358,9 +358,9 @@ We provide both a Docker container and a binary distribution of the server:
 - Binaries: https://bintray.com/palantir/releases/policy-bot
 - Docker Images: https://hub.docker.com/r/palantirtechnologies/policy-bot/
 
-A sample configuration file is provided at `config/policy-bot.example.yml`. We
-recommend deploying the application behind a reverse proxy or load balancer
-that terminates TLS connections.
+A sample configuration file is provided at `config/policy-bot.example.yml`.
+Certain values may also be set by environment variables; these are noted in the
+comments in the sample configuration file.
 
 ### GitHub App Configuration
 

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -5,6 +5,11 @@ server:
   port: 8080
   # The public URL, used for URL generation when the server is behind a proxy
   public_url: http://localhost:8080
+  # Uncomment the "tls_config" block to enable HTTPS support in the server.
+  # The cert and key files must be usable by net/http.ListenAndServeTLS().
+  # tls_config:
+  #   cert_file: /path/to/server.pem
+  #   key_file: /path/to/server.key
 
 # Options for logging output
 logging:
@@ -22,18 +27,24 @@ cache:
 
 # Options for connecting to GitHub
 github:
-  # The URL of the GitHub homepage
+  # The URL of the GitHub homepage. Can also be set by the GITHUB_WEB_URL
+  # environment variable.
   web_url: "https://github.com"
-  # The base URL for v3 (REST) API requests
+  # The base URL for v3 (REST) API requests. Can also be set by the
+  # GITHUB_V3_API_URL environment variable.
   v3_api_url: "https://api.github.com"
-  # The base URL for v4 (GraphQL) API requests
+  # The base URL for v4 (GraphQL) API requests. Can also be set by the
+  # GITHUB_V4_API_URL environment variable.
   v4_api_url: "https://api.github.com/graphql"
   app:
-    # The integration ID of the GitHub app
+    # The integration ID of the GitHub app. Can also be set by the
+    # GITHUB_APP_INTEGRATION_ID environment variable.
     integration_id: 1
-    # A random string used to validate webhooks
+    # A random string used to validate webhooks. Can also be set by the
+    # GITHUB_APP_WEBHOOK_SECRET environment variable.
     webhook_secret: "app_secret"
-    # The private key of the GitHub app
+    # The private key of the GitHub app. Can also be set by the
+    # GITHUB_APP_PRIVATE_KEY environment variable.
     private_key: |
       -----BEGIN RSA PRIVATE KEY-----
       xxxxx
@@ -41,14 +52,17 @@ github:
       xxxxx
       -----END RSA PRIVATE KEY-----
   oauth:
-    # The client ID of the OAuth app associated with the GitHub app
+    # The client ID of the OAuth app associated with the GitHub app. Can also
+    # be set by the GITHUB_OAUTH_CLIENT_ID environment variable.
     client_id: "client_id"
-    # The client secret of the OAuth app associated with the GitHub app
+    # The client secret of the OAuth app associated with the GitHub app. Can
+    # also be set by the GITHUB_OAUTH_CLIENT_SECRET environment variable.
     client_secret: "client_secret"
 
 # Options for user sessions
 sessions:
-  # A random string used to sign session cookies
+  # A random string used to sign session cookies. Can also be set by the
+  # POLICYBOT_SESSIONS_KEY environment variable.
   key: "secretsessionkey"
 
 # Options for application behavior

--- a/server/config.go
+++ b/server/config.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"os"
+
 	"github.com/c2h5oh/datasize"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
@@ -52,12 +54,16 @@ type SessionsConfig struct {
 
 func ParseConfig(bytes []byte) (*Config, error) {
 	var c Config
-	err := yaml.UnmarshalStrict(bytes, &c)
-	if err != nil {
+	if err := yaml.UnmarshalStrict(bytes, &c); err != nil {
 		return nil, errors.Wrapf(err, "failed unmarshalling yaml")
 	}
 
 	c.Options.FillDefaults()
+	c.Github.SetValuesFromEnv("")
+
+	if v, ok := os.LookupEnv("POLICYBOT_SESSIONS_KEY"); ok {
+		c.Sessions.Key = v
+	}
 
 	return &c, nil
 }

--- a/vendor/github.com/palantir/go-githubapp/githubapp/config.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/config.go
@@ -14,6 +14,11 @@
 
 package githubapp
 
+import (
+	"os"
+	"strconv"
+)
+
 type Config struct {
 	WebURL   string `yaml:"web_url" json:"webUrl"`
 	V3APIURL string `yaml:"v3_api_url" json:"v3ApiUrl"`
@@ -29,4 +34,34 @@ type Config struct {
 		ClientID     string `yaml:"client_id" json:"clientId"`
 		ClientSecret string `yaml:"client_secret" json:"clientSecret"`
 	} `yaml:"oauth" json:"oauth"`
+}
+
+// SetValuesFromEnv sets values in the configuration from coresponding
+// environment variables, if they exist. The optional prefix is added to the
+// start of the environment variable names.
+func (c *Config) SetValuesFromEnv(prefix string) {
+	setStringFromEnv("GITHUB_WEB_URL", prefix, &c.WebURL)
+	setStringFromEnv("GITHUB_V3_API_URL", prefix, &c.V3APIURL)
+	setStringFromEnv("GITHUB_V4_API_URL", prefix, &c.V4APIURL)
+
+	setIntFromEnv("GITHUB_APP_INTEGRATION_ID", prefix, &c.App.IntegrationID)
+	setStringFromEnv("GITHUB_APP_WEBHOOK_SECRET", prefix, &c.App.WebhookSecret)
+	setStringFromEnv("GITHUB_APP_PRIVATE_KEY", prefix, &c.App.PrivateKey)
+
+	setStringFromEnv("GITHUB_OAUTH_CLIENT_ID", prefix, &c.OAuth.ClientID)
+	setStringFromEnv("GITHUB_OAUTH_CLIENT_SECRET", prefix, &c.OAuth.ClientSecret)
+}
+
+func setStringFromEnv(key, prefix string, value *string) {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value = v
+	}
+}
+
+func setIntFromEnv(key, prefix string, value *int) {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			*value = i
+		}
+	}
 }

--- a/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/dispatcher.go
@@ -16,6 +16,7 @@ package githubapp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/github"
@@ -41,28 +42,70 @@ type EventHandler interface {
 	Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error
 }
 
-type ErrorHandler func(http.ResponseWriter, *http.Request, error)
+// ErrorCallback is called when an event handler returns an error. The error
+// from the handler is passed directly as the final argument.
+type ErrorCallback func(w http.ResponseWriter, r *http.Request, err error)
+
+// ResponseCallback is called to send a response to GitHub after an event is
+// handled. It is passed the event type and a flag indicating if an event
+// handler was called for the event.
+type ResponseCallback func(w http.ResponseWriter, r *http.Request, event string, handled bool)
+
+// DispatcherOption configures properties of an event dispatcher.
+type DispatcherOption func(*eventDispatcher)
+
+// WithErrorCallback sets the error callback for an event dispatcher.
+func WithErrorCallback(onError ErrorCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onError != nil {
+			d.onError = onError
+		}
+	}
+}
+
+// WithResponseCallback sets the response callback for an event dispatcher.
+func WithResponseCallback(onResponse ResponseCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onResponse != nil {
+			d.onResponse = onResponse
+		}
+	}
+}
+
+// ValidationError is passed to error callbacks when the webhook payload fails
+// validation.
+type ValidationError struct {
+	EventType  string
+	DeliveryID string
+	Cause      error
+}
+
+func (ve ValidationError) Error() string {
+	return fmt.Sprintf("invalid event: %v", ve.Cause)
+}
 
 type eventDispatcher struct {
 	handlerMap map[string]EventHandler
 	secret     string
-	onError    ErrorHandler
+
+	onError    ErrorCallback
+	onResponse ResponseCallback
 }
 
-// NewDefaultEventDispatcher is a convenience method to create an
-// EventDispatcher from configuration using the default error handler.
+// NewDefaultEventDispatcher is a convenience method to create an event
+// dispatcher from configuration using the default error and response
+// callbacks.
 func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler {
-	return NewEventDispatcher(handlers, c.App.WebhookSecret, nil)
+	return NewEventDispatcher(handlers, c.App.WebhookSecret)
 }
 
 // NewEventDispatcher creates an http.Handler that dispatches GitHub webhook
 // requests to the appropriate event handlers. It validates payload integrity
 // using the given secret value.
 //
-// If an error occurs during handling, the error handler is called with the
-// error and should write an appropriate response. If the error handler is nil,
-// a default handler is used.
-func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHandler) http.Handler {
+// Responses are controlled by optional error and response callbacks. If these
+// options are not provided, default callbacks are used.
+func NewEventDispatcher(handlers []EventHandler, secret string, opts ...DispatcherOption) http.Handler {
 	handlerMap := make(map[string]EventHandler)
 
 	// Iterate in reverse so the first entries in the slice have priority
@@ -72,67 +115,129 @@ func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHan
 		}
 	}
 
-	if onError == nil {
-		onError = DefaultErrorHandler
-	}
-
-	return &eventDispatcher{
+	d := &eventDispatcher{
 		handlerMap: handlerMap,
 		secret:     secret,
-		onError:    onError,
+		onError:    DefaultErrorCallback,
+		onResponse: DefaultResponseCallback,
 	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
 }
 
-// ServeHTTP to implement http.Handler
+// ServeHTTP processes a webhook request from GitHub.
 func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// initialize context for SetResponder/GetResponder
+	// we store a pointer in the context so that functions deeper in the call
+	// tree can modify the value without creating a new context
+	var responder func(http.ResponseWriter, *http.Request)
+	ctx = context.WithValue(ctx, responderKey{}, &responder)
+	r = r.WithContext(ctx)
+
 	eventType := r.Header.Get("X-GitHub-Event")
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+
 	if eventType == "" {
-		// ACK payload that was received but won't be processed
-		w.WriteHeader(http.StatusAccepted)
+		d.onError(w, r, ValidationError{
+			EventType:  eventType,
+			DeliveryID: deliveryID,
+			Cause:      errors.New("missing event type"),
+		})
 		return
 	}
-	deliveryID := r.Header.Get("X-GitHub-Delivery")
 
 	logger := zerolog.Ctx(ctx).With().
 		Str(LogKeyEventType, eventType).
 		Str(LogKeyDeliveryID, deliveryID).
 		Logger()
 
-	// update context and request to contain new log fields
+	// initialize context with event logger
 	ctx = logger.WithContext(ctx)
 	r = r.WithContext(ctx)
 
 	payloadBytes, err := github.ValidatePayload(r, []byte(d.secret))
 	if err != nil {
-		d.onError(w, r, errors.Wrapf(err, "failed to validate webhook payload"))
+		d.onError(w, r, ValidationError{
+			EventType:  eventType,
+			DeliveryID: deliveryID,
+			Cause:      err,
+		})
 		return
 	}
 
 	logger.Info().Msgf("Received webhook event")
-	handler, ok := d.handlerMap[eventType]
 
-	switch {
-	case ok:
+	handler, ok := d.handlerMap[eventType]
+	if ok {
 		if err := handler.Handle(ctx, eventType, deliveryID, payloadBytes); err != nil {
-			// pass error directly so handler can inspect types if needed
 			d.onError(w, r, err)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
-	case eventType == "ping":
-		w.WriteHeader(http.StatusOK)
-	default:
+	}
+	d.onResponse(w, r, eventType, ok)
+}
+
+// DefaultErrorCallback logs errors and responds with a 500 status code.
+func DefaultErrorCallback(w http.ResponseWriter, r *http.Request, err error) {
+	logger := zerolog.Ctx(r.Context())
+
+	if ve, ok := err.(ValidationError); ok {
+		logger.Warn().Err(ve.Cause).Msgf("Received invalid webhook headers or payload")
+		http.Error(w, "Invalid webhook headers or payload", http.StatusBadRequest)
+		return
+	}
+
+	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// DefaultResponseCallback responds with a 200 OK for handled events and a 202
+// Accepted status for all other events. By default, responses are empty.
+// Event handlers may send custom responses by calling the SetResponder
+// function before returning.
+func DefaultResponseCallback(w http.ResponseWriter, r *http.Request, event string, handled bool) {
+	if !handled && event != "ping" {
 		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	if res := GetResponder(r.Context()); res != nil {
+		res(w, r)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
-// DefaultErrorHandler logs errors and responds with a 500 status code.
-func DefaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	logger := zerolog.Ctx(r.Context())
-	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+type responderKey struct{}
 
-	msg := http.StatusText(http.StatusInternalServerError)
-	http.Error(w, msg, http.StatusInternalServerError)
+// SetResponder sets a function that sends a response to GitHub after event
+// processing completes. This function may only be called from event handler
+// functions invoked by the event dispatcher.
+//
+// Customizing individual handler responses should be rare. Applications that
+// want to modify the standard responses should consider registering a response
+// callback before using this function.
+func SetResponder(ctx context.Context, responder func(http.ResponseWriter, *http.Request)) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		panic("SetResponder() must be called from an event handler invoked by the go-githubapp event dispatcher")
+	}
+	*r = responder
+}
+
+// GetResponder returns the response function that was set by an event handler.
+// If no response function exists, it returns nil. There is usually no reason
+// to call this outside of a response callback implementation.
+func GetResponder(ctx context.Context) func(http.ResponseWriter, *http.Request) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		return nil
+	}
+	return *r
 }


### PR DESCRIPTION
All GitHub options and certain sensitive Policy Bot options can be
defined or overridden by environment variables.

Fixes #112.