### PR TITLE
only_has_contributors_in rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,17 @@ if:
     paths:
       - "config/.*"
 
-  # "has_author_in" is satisified if the user who opened the pull request is in
+  # "has_author_in" is satisfied if the user who opened the pull request is in
   # the users list or belongs to any of the listed organizations or teams.
   has_author_in:
+    users: ["user1", "user2", ...]
+    organizations: ["org1", "org2", ...]
+    teams: ["org1/team1", "org2/team2", ...]
+    
+  # "only_has_authors_in" is satisfied if the user who opened the pull request
+  # and all commit authors are in the users list or belong to any of the listed
+  # organizations or teams.
+  only_has_authors_in:
     users: ["user1", "user2", ...]
     organizations: ["org1", "org2", ...]
     teams: ["org1/team1", "org2/team2", ...]

--- a/README.md
+++ b/README.md
@@ -137,19 +137,19 @@ if:
     users: ["user1", "user2", ...]
     organizations: ["org1", "org2", ...]
     teams: ["org1/team1", "org2/team2", ...]
-    
-  # "only_has_authors_in" is satisfied if the user who opened the pull request
-  # and all commit authors are in the users list or belong to any of the listed
-  # organizations or teams.
-  only_has_authors_in:
-    users: ["user1", "user2", ...]
-    organizations: ["org1", "org2", ...]
-    teams: ["org1/team1", "org2/team2", ...]
 
   # "has_contributor_in" is satisfied if any commits on the pull request have
   # an author or committer in the users list or that belong to any of the
   # listed organizations or teams.
   has_contributor_in:
+    users: ["user1", "user2", ...]
+    organizations: ["org1", "org2", ...]
+    teams: ["org1/team1", "org2/team2", ...]
+    
+  # "only_has_contributors_in" is satisfied if all of the commits on the pull
+  # request have an author or committer in the users list or that belong to
+  # any of the listed organizations or teams.
+  only_has_contributors_in:
     users: ["user1", "user2", ...]
     organizations: ["org1", "org2", ...]
     teams: ["org1/team1", "org2/team2", ...]

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -23,8 +23,8 @@ type Predicates struct {
 	OnlyChangedFiles *predicate.OnlyChangedFiles `yaml:"only_changed_files"`
 
 	HasAuthorIn             *predicate.HasAuthorIn             `yaml:"has_author_in"`
-	OnlyHasAuthorsIn        *predicate.OnlyHasAuthorsIn        `yaml:"only_has_authors_in"`
 	HasContributorIn        *predicate.HasContributorIn        `yaml:"has_contributor_in"`
+	OnlyHasContributorsIn   *predicate.OnlyHasContributorsIn   `yaml:"only_has_contributors_in"`
 	AuthorIsOnlyContributor *predicate.AuthorIsOnlyContributor `yaml:"author_is_only_contributor"`
 
 	TargetsBranch *predicate.TargetsBranch `yaml:"targets_branch"`

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -23,6 +23,7 @@ type Predicates struct {
 	OnlyChangedFiles *predicate.OnlyChangedFiles `yaml:"only_changed_files"`
 
 	HasAuthorIn             *predicate.HasAuthorIn             `yaml:"has_author_in"`
+	OnlyHasAuthorsIn        *predicate.OnlyHasAuthorsIn        `yaml:"only_has_authors_in"`
 	HasContributorIn        *predicate.HasContributorIn        `yaml:"has_contributor_in"`
 	AuthorIsOnlyContributor *predicate.AuthorIsOnlyContributor `yaml:"author_is_only_contributor"`
 

--- a/policy/predicate/author.go
+++ b/policy/predicate/author.go
@@ -24,6 +24,41 @@ import (
 	"github.com/palantir/policy-bot/pull"
 )
 
+type OnlyHasAuthorsIn struct {
+	common.Actors `yaml:",inline"`
+}
+
+var _ Predicate = &OnlyHasAuthorsIn{}
+
+func (pred *OnlyHasAuthorsIn) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
+	author := prctx.Author()
+
+	result, err := pred.IsActor(ctx, prctx, author)
+	if err != nil {
+		return false, "", errors.Wrap(err, "failed to validate author")
+	}
+	if !result {
+		return false, fmt.Sprintf("The pull request author %q does not meet the required membership conditions", author), nil
+	}
+
+	commits, err := prctx.Commits()
+	if err != nil {
+		return false, "", errors.Wrap(err, "failed to get commits")
+	}
+
+	for _, c := range commits {
+		result, err := pred.IsActor(ctx, prctx, c.Author)
+		if err != nil {
+			return false, "", errors.Wrap(err, "failed to validate author")
+		}
+		if !result {
+			return false, fmt.Sprintf("The author of commit %.10s does not meet required membership conditions", c.SHA), nil
+		}
+	}
+
+	return true, "", nil
+}
+
 type HasAuthorIn struct {
 	common.Actors `yaml:",inline"`
 }

--- a/policy/predicate/author_test.go
+++ b/policy/predicate/author_test.go
@@ -88,6 +88,89 @@ func TestHasAuthorIn(t *testing.T) {
 	})
 }
 
+func TestOnlyHasAuthorsIn(t *testing.T) {
+	p := &OnlyHasAuthorsIn{
+		common.Actors{
+			Teams:         []string{"testorg/team"},
+			Users:         []string{"mhaypenny"},
+			Organizations: []string{"testorg"},
+		},
+	}
+
+	runAuthorTests(t, p, []AuthorTestCase{
+		{
+			"noMatch",
+			false,
+			&pulltest.Context{
+				AuthorValue: "ttest",
+				TeamMemberships: map[string][]string{
+					"ttest": {
+						"boringorg/testers",
+					},
+				},
+				OrgMemberships: map[string][]string{
+					"ttest": {
+						"boringorg",
+					},
+				},
+			},
+		},
+		{
+			"authorInUsers",
+			true,
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+			},
+		},
+		{
+			"authorInTeams",
+			true,
+			&pulltest.Context{
+				AuthorValue: "mortonh",
+				TeamMemberships: map[string][]string{
+					"mortonh": {
+						"coolorg/approvers",
+						"testorg/team",
+					},
+				},
+			},
+		},
+		{
+			"authorInOrgs",
+			true,
+			&pulltest.Context{
+				AuthorValue: "mortonh",
+				OrgMemberships: map[string][]string{
+					"mortonh": {
+						"coolorg",
+						"testorg",
+					},
+				},
+			},
+		},
+		{
+			"someAuthorsNotInUsers",
+			false,
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{Author: "notmhaypenny"},
+				},
+			},
+		},
+		{
+			"prAuthorNotInUsers",
+			false,
+			&pulltest.Context{
+				AuthorValue: "notmhaypenny",
+				CommitsValue: []*pull.Commit{
+					{Author: "mhaypenny"},
+				},
+			},
+		},
+	})
+}
+
 func TestHasContributorIn(t *testing.T) {
 	p := &HasContributorIn{
 		common.Actors{

--- a/policy/predicate/author_test.go
+++ b/policy/predicate/author_test.go
@@ -88,89 +88,6 @@ func TestHasAuthorIn(t *testing.T) {
 	})
 }
 
-func TestOnlyHasAuthorsIn(t *testing.T) {
-	p := &OnlyHasAuthorsIn{
-		common.Actors{
-			Teams:         []string{"testorg/team"},
-			Users:         []string{"mhaypenny"},
-			Organizations: []string{"testorg"},
-		},
-	}
-
-	runAuthorTests(t, p, []AuthorTestCase{
-		{
-			"noMatch",
-			false,
-			&pulltest.Context{
-				AuthorValue: "ttest",
-				TeamMemberships: map[string][]string{
-					"ttest": {
-						"boringorg/testers",
-					},
-				},
-				OrgMemberships: map[string][]string{
-					"ttest": {
-						"boringorg",
-					},
-				},
-			},
-		},
-		{
-			"authorInUsers",
-			true,
-			&pulltest.Context{
-				AuthorValue: "mhaypenny",
-			},
-		},
-		{
-			"authorInTeams",
-			true,
-			&pulltest.Context{
-				AuthorValue: "mortonh",
-				TeamMemberships: map[string][]string{
-					"mortonh": {
-						"coolorg/approvers",
-						"testorg/team",
-					},
-				},
-			},
-		},
-		{
-			"authorInOrgs",
-			true,
-			&pulltest.Context{
-				AuthorValue: "mortonh",
-				OrgMemberships: map[string][]string{
-					"mortonh": {
-						"coolorg",
-						"testorg",
-					},
-				},
-			},
-		},
-		{
-			"someAuthorsNotInUsers",
-			false,
-			&pulltest.Context{
-				AuthorValue: "mhaypenny",
-				CommitsValue: []*pull.Commit{
-					{Author: "notmhaypenny"},
-				},
-			},
-		},
-		{
-			"prAuthorNotInUsers",
-			false,
-			&pulltest.Context{
-				AuthorValue: "notmhaypenny",
-				CommitsValue: []*pull.Commit{
-					{Author: "mhaypenny"},
-				},
-			},
-		},
-	})
-}
-
 func TestHasContributorIn(t *testing.T) {
 	p := &HasContributorIn{
 		common.Actors{
@@ -250,6 +167,119 @@ func TestHasContributorIn(t *testing.T) {
 				AuthorValue: "ttest",
 				OrgMemberships: map[string][]string{
 					"mhaypenny": {
+						"testorg",
+					},
+				},
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "ttest",
+						Committer: "ttest",
+					},
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestOnlyHasContributorsIn(t *testing.T) {
+	p := &OnlyHasContributorsIn{
+		common.Actors{
+			Teams:         []string{"testorg/team"},
+			Users:         []string{"mhaypenny"},
+			Organizations: []string{"testorg"},
+		},
+	}
+
+	runAuthorTests(t, p, []AuthorTestCase{
+		{
+			"authorNotInList",
+			false,
+			&pulltest.Context{
+				AuthorValue: "ttest",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+					},
+				},
+			},
+		},
+		{
+			"containsCommitAuthorNotInList",
+			false,
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+					},
+					{
+						SHA:       "abcdef123456789",
+						Author:    "ttest",
+						Committer: "ttest",
+					},
+				},
+			},
+		},
+		{
+			"committersInListButAuthorsAreNot",
+			false,
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "ttest1",
+						Committer: "mhaypenny",
+					},
+					{
+						SHA:       "abcdef123456789",
+						Author:    "ttest2",
+						Committer: "mhaypenny",
+					},
+				},
+			},
+		},
+		{
+			"commitAuthorInTeam",
+			true,
+			&pulltest.Context{
+				AuthorValue: "ttest",
+				TeamMemberships: map[string][]string{
+					"ttest": {
+						"testorg/team",
+					},
+				},
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "ttest",
+						Committer: "ttest",
+					},
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+					},
+				},
+			},
+		},
+		{
+			"commitAuthorInOrg",
+			true,
+			&pulltest.Context{
+				AuthorValue: "ttest",
+				OrgMemberships: map[string][]string{
+					"ttest": {
 						"testorg",
 					},
 				},


### PR DESCRIPTION
Use case is when you have more than one set of users (or bots!) that can make pre-approved changes, all of which you want to allow to go through.

In our case, we have one bot that creates PRs, and another bot that ensures the PRs stay up to date with master. In some cases the timing works out where a PR ends up with commits from both bots before it's able to be merged. We want to allow these to push through.