### PR TITLE
Extract base-path from public URLs and use it as prefix for all service endpoint URLs

### DIFF
--- a/server/handler/login.go
+++ b/server/handler/login.go
@@ -68,7 +68,7 @@ func Login(c githubapp.Config, sessions *scs.Manager) oauth2.LoginCallback {
 	}
 }
 
-func RequireLogin(sessions *scs.Manager) func(http.Handler) http.Handler {
+func RequireLogin(sessions *scs.Manager, basePath string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			sess := sessions.Load(r)
@@ -85,7 +85,7 @@ func RequireLogin(sessions *scs.Manager) func(http.Handler) http.Handler {
 					return
 				}
 
-				http.Redirect(w, r, oauth2.DefaultRoute, http.StatusFound)
+				http.Redirect(w, r, basePath+oauth2.DefaultRoute, http.StatusFound)
 				return
 			}
 


### PR DESCRIPTION
We want to run policy-bot docker container in a kubernetes pod.
In our enviroment, we tried to configure a public URL like this:
  https://out-host-name:443/policy-bot
Initially we configured the ingress (nginx) web proxy to map that URL to the
policy-bot kubernetes service (mapped to the policy-bot container's local port,
and to strip off the external-URLs /policy-bot base-path from the URL.

This approach didn't work, since the policy-bot container used it's own URLs (not the public URL)
for oauth redirects.

My solution is to extend policy-bot to extract the path from the public URL as use
is as a base-path for all handled and redirected URLs.

Then we could configure the ingress proxy to just pass the .../policy-bot URL unchanged to the
container, and everything worked smoothly.