### PR TITLE
fix graphql unmarshaling for draft pr status

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -573,7 +573,9 @@ type v4PullRequest struct {
 	Author v4Actor
 
 	IsCrossRepository bool
-	IsDraft           bool
+
+	// This field is in GraphQL Preview, so don't ask for it just yet
+	IsDraft bool `graphql:""`
 
 	HeadRefOID     string
 	HeadRefName    string


### PR DESCRIPTION
Don't unmarshal this in the graphql query, since we pull it from the v3 locator anyway: https://github.com/palantir/policy-bot/blob/develop/pull/github.go#L102

Alternatively, we could store this in the `GitHubContext` struct 