### PR TITLE
Don't request reviewers if there are existing reviews

### DIFF
--- a/pull/context.go
+++ b/pull/context.go
@@ -95,7 +95,10 @@ type Context interface {
 	Teams() (map[string]string, error)
 
 	// HasReviewers returns true if the Pull Request has reviewers
-	HasReveiwers() (bool, error)
+	HasReviewers() (bool, error)
+
+	// HasReviews returns true if the Pull Request has reviews
+	HasReviews() (bool, error)
 }
 
 type FileStatus int

--- a/pull/context.go
+++ b/pull/context.go
@@ -94,11 +94,8 @@ type Context interface {
 	// their respective permission on a repo.
 	Teams() (map[string]string, error)
 
-	// HasReviewers returns true if the Pull Request has reviewers
+	// HasReviewers returns true if the Pull Request has reviewers or any reviews
 	HasReviewers() (bool, error)
-
-	// HasReviews returns true if the Pull Request has reviews
-	HasReviews() (bool, error)
 }
 
 type FileStatus int

--- a/pull/github.go
+++ b/pull/github.go
@@ -277,7 +277,7 @@ func (ghc *GitHubContext) RepositoryCollaborators() (map[string]string, error) {
 	return ghc.collaborators, nil
 }
 
-func (ghc *GitHubContext) HasReveiwers() (bool, error) {
+func (ghc *GitHubContext) HasReviewers() (bool, error) {
 	// Intentionally kept to a small result size, since we just want to determine if there are existing reviewers
 	subsetCurrentReviewers, _, err := ghc.client.PullRequests.ListReviewers(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &github.ListOptions{
 		Page:    0,
@@ -288,6 +288,19 @@ func (ghc *GitHubContext) HasReveiwers() (bool, error) {
 	}
 
 	return len(subsetCurrentReviewers.Users) > 0 || len(subsetCurrentReviewers.Teams) > 0, nil
+}
+
+func (ghc *GitHubContext) HasReviews() (bool, error) {
+	// Intentionally kept to a small result size, since we just want to determine if there are existing reviews
+	subsetCurrentReviews, _, err := ghc.client.PullRequests.ListReviews(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &github.ListOptions{
+		Page:    0,
+		PerPage: 1,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "Unable to list request reviewers")
+	}
+
+	return len(subsetCurrentReviews) > 0, nil
 }
 
 func (ghc *GitHubContext) Teams() (map[string]string, error) {

--- a/pull/github.go
+++ b/pull/github.go
@@ -287,20 +287,12 @@ func (ghc *GitHubContext) HasReviewers() (bool, error) {
 		return false, errors.Wrap(err, "Unable to list request reviewers")
 	}
 
-	return len(subsetCurrentReviewers.Users) > 0 || len(subsetCurrentReviewers.Teams) > 0, nil
-}
-
-func (ghc *GitHubContext) HasReviews() (bool, error) {
-	// Intentionally kept to a small result size, since we just want to determine if there are existing reviews
-	subsetCurrentReviews, _, err := ghc.client.PullRequests.ListReviews(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &github.ListOptions{
-		Page:    0,
-		PerPage: 1,
-	})
+	reviews, err := ghc.Reviews()
 	if err != nil {
-		return false, errors.Wrap(err, "Unable to list request reviewers")
+		return false, errors.Wrap(err, "Unable to list reviews")
 	}
 
-	return len(subsetCurrentReviews) > 0, nil
+	return len(subsetCurrentReviewers.Users) > 0 || len(subsetCurrentReviewers.Teams) > 0 || len(reviews) > 0, nil
 }
 
 func (ghc *GitHubContext) Teams() (map[string]string, error) {

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -56,9 +56,6 @@ type Context struct {
 	HasReviewersValue bool
 	HasReviewersError error
 
-	HasReviewsValue bool
-	HasReviewsError error
-
 	Draft bool
 }
 
@@ -198,10 +195,6 @@ func (c *Context) TeamMembers(team string) ([]string, error) {
 
 func (c *Context) HasReviewers() (bool, error) {
 	return c.HasReviewersValue, c.HasReviewersError
-}
-
-func (c *Context) HasReviews() (bool, error) {
-	return c.HasReviewsValue, c.HasReviewsError
 }
 
 func (c *Context) Comments() ([]*pull.Comment, error) {

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -56,6 +56,9 @@ type Context struct {
 	HasReviewersValue bool
 	HasReviewersError error
 
+	HasReviewsValue bool
+	HasReviewsError error
+
 	Draft bool
 }
 
@@ -193,8 +196,12 @@ func (c *Context) TeamMembers(team string) ([]string, error) {
 	return inverted[team], nil
 }
 
-func (c *Context) HasReveiwers() (bool, error) {
+func (c *Context) HasReviewers() (bool, error) {
 	return c.HasReviewersValue, c.HasReviewersError
+}
+
+func (c *Context) HasReviews() (bool, error) {
+	return c.HasReviewsValue, c.HasReviewsError
 }
 
 func (c *Context) Comments() ([]*pull.Comment, error) {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -214,7 +214,13 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 				logger.Warn().Err(err).Msg("Unable to select random request reviewers")
 			}
 
-			if len(requestedUsers) > 0 {
+			// check again if someone assigned a reviewer while we were calculating users to request
+			hasReviewersAfter, err := prctx.HasReveiwers()
+			if err != nil {
+				logger.Warn().Err(err).Msg("Unable to list request reviewers a second time")
+			}
+
+			if len(requestedUsers) > 0 && !hasReviewersAfter {
 				reviewers := github.ReviewersRequest{
 					Reviewers:     requestedUsers,
 					TeamReviewers: []string{},
@@ -226,7 +232,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 					logger.Warn().Err(err).Msg("Unable to request reviewers")
 				}
 			} else {
-				logger.Debug().Msg("No users found for review, or no users were requested")
+				logger.Debug().Msg("No users found for review, no users were requested, or users were assigned during review calculation")
 			}
 		} else {
 			logger.Debug().Msg("PR has existing reviewers, not adding anyone")

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -204,25 +204,20 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 	if performActions && statusState == "pending" && !prctx.IsDraft() {
 		hasReviewers, err := prctx.HasReviewers()
 		if err != nil {
-			logger.Warn().Err(err).Msg("Unable to list request reviewers")
+			return errors.Wrap(err, "Unable to list request reviewers")
 		}
 
-		hasReviews, err := prctx.HasReviews()
-		if err != nil {
-			logger.Warn().Err(err).Msg("Unable to list reviews")
-		}
-
-		if !hasReviewers && !hasReviews {
+		if !hasReviewers {
 			r := rand.New(rand.NewSource(time.Now().UnixNano()))
 			requestedUsers, err := reviewer.FindRandomRequesters(ctx, prctx, result, r)
 			if err != nil {
-				logger.Warn().Err(err).Msg("Unable to select random request reviewers")
+				return errors.Wrap(err, "Unable to select random request reviewers")
 			}
 
 			// check again if someone assigned a reviewer while we were calculating users to request
 			hasReviewersAfter, err := prctx.HasReviewers()
 			if err != nil {
-				logger.Warn().Err(err).Msg("Unable to double-check existing reviewers, assuming original state is still valid")
+				return errors.Wrap(err, "Unable to double-check existing reviewers, assuming original state is still valid")
 			}
 
 			if len(requestedUsers) > 0 && !hasReviewersAfter {
@@ -234,7 +229,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 				logger.Debug().Msgf("PR is not in draft, there are no current reviewers, and reviews are requested from %q users", requestedUsers)
 				_, _, err = client.PullRequests.RequestReviewers(ctx, prctx.RepositoryOwner(), prctx.RepositoryName(), prctx.Number(), reviewers)
 				if err != nil {
-					logger.Warn().Err(err).Msg("Unable to request reviewers")
+					return errors.Wrap(err, "Unable to request reviewers")
 				}
 			} else {
 				logger.Debug().Msg("No users found for review, no users were requested, or users were assigned during review calculation")

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -202,12 +202,17 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 	}
 
 	if performActions && statusState == "pending" && !prctx.IsDraft() {
-		hasReviewers, err := prctx.HasReveiwers()
+		hasReviewers, err := prctx.HasReviewers()
 		if err != nil {
 			logger.Warn().Err(err).Msg("Unable to list request reviewers")
 		}
 
-		if !hasReviewers {
+		hasReviews, err := prctx.HasReviews()
+		if err != nil {
+			logger.Warn().Err(err).Msg("Unable to list reviews")
+		}
+
+		if !hasReviewers && !hasReviews {
 			r := rand.New(rand.NewSource(time.Now().UnixNano()))
 			requestedUsers, err := reviewer.FindRandomRequesters(ctx, prctx, result, r)
 			if err != nil {
@@ -215,7 +220,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 			}
 
 			// check again if someone assigned a reviewer while we were calculating users to request
-			hasReviewersAfter, err := prctx.HasReveiwers()
+			hasReviewersAfter, err := prctx.HasReviewers()
 			if err != nil {
 				logger.Warn().Err(err).Msg("Unable to double-check existing reviewers, assuming original state is still valid")
 			}

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -217,7 +217,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 			// check again if someone assigned a reviewer while we were calculating users to request
 			hasReviewersAfter, err := prctx.HasReveiwers()
 			if err != nil {
-				logger.Warn().Err(err).Msg("Unable to list request reviewers a second time")
+				logger.Warn().Err(err).Msg("Unable to double-check existing reviewers, assuming original state is still valid")
 			}
 
 			if len(requestedUsers) > 0 && !hasReviewersAfter {

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -42,9 +42,14 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
+	performActions := false
+	if event.GetAction() == "ready_for_review" || event.GetAction() == "opened" {
+		performActions = true
+	}
+
 	switch event.GetAction() {
 	case "opened", "reopened", "synchronize", "edited", "ready_for_review":
-		return h.Evaluate(ctx, installationID, true, pull.Locator{
+		return h.Evaluate(ctx, installationID, performActions, pull.Locator{
 			Owner:  event.GetRepo().GetOwner().GetLogin(),
 			Repo:   event.GetRepo().GetName(),
 			Number: event.GetPullRequest().GetNumber(),


### PR DESCRIPTION
Github removes the set of users requested for review once they finish adding a review, which can cause the `HasReviewers()` flow to feel pretty klunky.

To fix this, we can also check if there are any reviews left on the PR, and reasonably assume that if a user has already left some reviews that the bot can safely move on.