### PR TITLE
Add policy yaml validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,27 @@ disapproval:
     teams: ["org1/team1", "org2/team2"]
 ```
 
+### Testing and Debugging Policies
+
+Sometimes it is useful to test if a given policy file is valid, especially in a CI environment.
+
+An API endpoint exists at `/api/validate` to validate the syntax of the yaml and policy configuration,
+however it cannot validate that the rules are semantically correct for a given use case.
+
+The API can be used as such:
+
+```sh
+$ curl https://policybot.domain/api/validate -XPOST -F @path/to/policy.yml
+{"message":"failed to parse approval policy: failed to parse subpolicies for 'and': policy references undefined rule 'the devtools team has approved', allowed values: [the devtools team has]","version":"1.12.5"}
+```
+
+You can combine the HTTP response code to automatically detect failures
+
+```sh
+$ rcode=$(curl https://policybot.domain/api/validate -XPOST -F @path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)
+$ if [[ "${rcode}" -gt 299 ]]; then cat /tmp/response && exit 1; fi
+```
+
 ### Caveats and Notes
 
 There are several additional behaviors that follow from the rules above that

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ $ curl https://policybot.domain/api/validate -XPUT -T path/to/policy.yml
 {"message":"failed to parse approval policy: failed to parse subpolicies for 'and': policy references undefined rule 'the devtools team has approved', allowed values: [the devtools team has]","version":"1.12.5"}
 ```
 
-You can combine the HTTP response code to automatically detect failures
+You can examine the HTTP response code to automatically detect failures
 
 ```sh
 $ rcode=$(curl https://policybot.domain/api/validate -XPUT -T path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)

--- a/README.md
+++ b/README.md
@@ -328,17 +328,17 @@ Sometimes it is useful to test if a given policy file is valid, especially in a 
 An API endpoint exists at `/api/validate` to validate the syntax of the yaml and policy configuration,
 however it cannot validate that the rules are semantically correct for a given use case.
 
-The API can be used as such, noting the use of `--data-binary` to preserve yaml indentation:
+The API can be used as such:
 
 ```sh
-$ curl https://policybot.domain/api/validate -XPOST --data-binary @path/to/policy.yml
+$ curl https://policybot.domain/api/validate -XPUT -T path/to/policy.yml
 {"message":"failed to parse approval policy: failed to parse subpolicies for 'and': policy references undefined rule 'the devtools team has approved', allowed values: [the devtools team has]","version":"1.12.5"}
 ```
 
 You can combine the HTTP response code to automatically detect failures
 
 ```sh
-$ rcode=$(curl https://policybot.domain/api/validate -XPOST --data-binary @path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)
+$ rcode=$(curl https://policybot.domain/api/validate -XPUT -T path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)
 $ if [[ "${rcode}" -gt 299 ]]; then cat /tmp/response && exit 1; fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -328,17 +328,17 @@ Sometimes it is useful to test if a given policy file is valid, especially in a 
 An API endpoint exists at `/api/validate` to validate the syntax of the yaml and policy configuration,
 however it cannot validate that the rules are semantically correct for a given use case.
 
-The API can be used as such:
+The API can be used as such, noting the use of `--data-binary` to preserve yaml indentation:
 
 ```sh
-$ curl https://policybot.domain/api/validate -XPOST -F @path/to/policy.yml
+$ curl https://policybot.domain/api/validate -XPOST --data-binary @path/to/policy.yml
 {"message":"failed to parse approval policy: failed to parse subpolicies for 'and': policy references undefined rule 'the devtools team has approved', allowed values: [the devtools team has]","version":"1.12.5"}
 ```
 
 You can combine the HTTP response code to automatically detect failures
 
 ```sh
-$ rcode=$(curl https://policybot.domain/api/validate -XPOST -F @path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)
+$ rcode=$(curl https://policybot.domain/api/validate -XPOST --data-binary @path/to/policy.yml -s -w "%{http_code}" -o /tmp/response)
 $ if [[ "${rcode}" -gt 299 ]]; then cat /tmp/response && exit 1; fi
 ```
 

--- a/server/handler/validate.go
+++ b/server/handler/validate.go
@@ -43,7 +43,12 @@ func Validate() http.Handler {
 			baseapp.WriteJSON(w, http.StatusBadRequest, &ValidateCheck{Message: "Unable to read policy file from request", Version: version.GetVersion()})
 			return
 		}
-		defer file.Close()
+		defer func() {
+			ferr := file.Close()
+			if ferr != nil {
+				logger.Error().Err(ferr).Msg("Unable to close file")
+			}
+		}()
 
 		var policyBuf bytes.Buffer
 		_, err = io.Copy(&policyBuf, file)

--- a/server/handler/validate.go
+++ b/server/handler/validate.go
@@ -42,7 +42,7 @@ func Validate() http.Handler {
 		requestPolicy, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			check.Message = "Unable to read policy file buffer"
-			baseapp.WriteJSON(w, http.StatusBadRequest, &check)
+			baseapp.WriteJSON(w, http.StatusInternalServerError, &check)
 			return
 		}
 

--- a/server/handler/validate.go
+++ b/server/handler/validate.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/palantir/go-baseapp/baseapp"
+	"github.com/rs/zerolog"
+	"gopkg.in/yaml.v2"
+
+	"github.com/palantir/policy-bot/policy"
+	"github.com/palantir/policy-bot/version"
+)
+
+type ValidateCheck struct {
+	Message string `json:"message"`
+	Version string `json:"version"`
+}
+
+func Validate() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := zerolog.Ctx(ctx)
+
+		logger.Info().Msg("Attempting to validate policy file")
+		file, _, err := r.FormFile("policy")
+		if err != nil {
+			baseapp.WriteJSON(w, http.StatusBadRequest, &ValidateCheck{Message: "Unable to read policy file from request", Version: version.GetVersion()})
+			return
+		}
+		defer file.Close()
+
+		var policyBuf bytes.Buffer
+		_, err = io.Copy(&policyBuf, file)
+		if err != nil {
+			baseapp.WriteJSON(w, http.StatusBadRequest, &ValidateCheck{Message: "Unable to read policy file buffer", Version: version.GetVersion()})
+			return
+		}
+
+		var policyConfig policy.Config
+		err = yaml.UnmarshalStrict(policyBuf.Bytes(), &policyConfig)
+		if err != nil {
+			baseapp.WriteJSON(w, http.StatusBadRequest, &ValidateCheck{Message: err.Error(), Version: version.GetVersion()})
+			return
+		}
+
+		_, err = policy.ParsePolicy(&policyConfig)
+		if err != nil {
+			baseapp.WriteJSON(w, http.StatusBadRequest, &ValidateCheck{Message: err.Error(), Version: version.GetVersion()})
+			return
+		}
+
+		baseapp.WriteJSON(w, http.StatusOK, &ValidateCheck{Message: "Policy file is valid", Version: version.GetVersion()})
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,7 @@ func New(c *Config) (*Server, error) {
 
 	// additional API routes
 	mux.Handle(pat.Get("/api/health"), handler.Health())
-	mux.Handle(pat.Post("/api/validate"), handler.Validate())
+	mux.Handle(pat.Put("/api/validate"), handler.Validate())
 	mux.Handle(pat.Get(oauth2.DefaultRoute), oauth2.NewHandler(
 		oauth2.GetConfig(c.Github, nil),
 		oauth2.ForceTLS(forceTLS),

--- a/server/server.go
+++ b/server/server.go
@@ -143,6 +143,7 @@ func New(c *Config) (*Server, error) {
 
 	// additional API routes
 	mux.Handle(pat.Get("/api/health"), handler.Health())
+	mux.Handle(pat.Post("/api/validate"), handler.Validate())
 	mux.Handle(pat.Get(oauth2.DefaultRoute), oauth2.NewHandler(
 		oauth2.GetConfig(c.Github, nil),
 		oauth2.ForceTLS(forceTLS),


### PR DESCRIPTION
One way to resolve #10. 

Another approach could also take in the org/repo and current PR to run a more complete validation of all settings, similar to the details endpoint. 