### PR TITLE
Add ignore list to changed_files predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ if:
       - "config/special\\.file"
 
   # "only_changed_files" is satisfied if all files changed by the pull request
-  # match at least one regular expression in the list. The "ignore" list is
-  # optional and will ignore any files that match the regular expressions listed.
+  # match at least one regular expression in the list.
   only_changed_files:
     paths:
       - "config/.*"

--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ name: "example rule"
 # exist, the rule applies to every pull request.
 if:
   # "changed_files" is satisfied if any file in the pull request matches any
-  # regular expression in the list. The "ignore" list is optional and will
-  # ignore any files that match the regular expressions listed.
+  # regular expression in the "paths" list. If the "ignore" list is present,
+  # files in the pull request matching these regular expressions are ignored
+  # by this rule.
   changed_files:
     paths:
       - "config/.*"

--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ if:
   only_changed_files:
     paths:
       - "config/.*"
-    ignore:
-      - "config/special\\.file"
 
   # "has_author_in" is satisfied if the user who opened the pull request is in
   # the users list or belongs to any of the listed organizations or teams.

--- a/README.md
+++ b/README.md
@@ -120,17 +120,23 @@ name: "example rule"
 # exist, the rule applies to every pull request.
 if:
   # "changed_files" is satisfied if any file in the pull request matches any
-  # regular expression in the list.
+  # regular expression in the list. The "ignore" list is optional and will
+  # ignore any files that match the regular expressions listed.
   changed_files:
     paths:
       - "config/.*"
       - "server/views/.*\\.tmpl"
+    ignore:
+      - "config/special\\.file"
 
   # "only_changed_files" is satisfied if all files changed by the pull request
-  # match at least one regular expression in the list.
+  # match at least one regular expression in the list. The "ignore" list is
+  # optional and will ignore any files that match the regular expressions listed.
   only_changed_files:
     paths:
       - "config/.*"
+    ignore:
+      - "config/special\\.file"
 
   # "has_author_in" is satisfied if the user who opened the pull request is in
   # the users list or belongs to any of the listed organizations or teams.

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -66,8 +66,7 @@ func (pred *ChangedFiles) Evaluate(ctx context.Context, prctx pull.Context) (boo
 }
 
 type OnlyChangedFiles struct {
-	Paths       []string `yaml:"paths"`
-	IgnorePaths []string `yaml:"ignore"`
+	Paths []string `yaml:"paths"`
 }
 
 var _ Predicate = &OnlyChangedFiles{}
@@ -78,32 +77,20 @@ func (pred *OnlyChangedFiles) Evaluate(ctx context.Context, prctx pull.Context) 
 		return false, "", errors.Wrap(err, "failed to parse paths")
 	}
 
-	ignorePaths, err := pathsToRegexps(pred.IgnorePaths)
-	if err != nil {
-		return false, "", errors.Wrap(err, "failed to parse ignore paths")
-	}
-
 	files, err := prctx.ChangedFiles()
 	if err != nil {
 		return false, "", errors.Wrap(err, "failed to list changed files")
 	}
 
-	var relevantFiles []string
 	for _, f := range files {
-		if !anyMatches(ignorePaths, f.Filename) {
-			relevantFiles = append(relevantFiles, f.Filename)
-		}
-	}
-
-	for _, filename := range relevantFiles {
-		if anyMatches(paths, filename) {
+		if anyMatches(paths, f.Filename) {
 			continue
 		}
 		desc := "A changed file does not match the required pattern"
 		return false, desc, nil
 	}
 
-	filesChanged := len(relevantFiles) > 0
+	filesChanged := len(files) > 0
 
 	desc := ""
 	if !filesChanged {

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -48,14 +48,14 @@ func (pred *ChangedFiles) Evaluate(ctx context.Context, prctx pull.Context) (boo
 		return false, "", errors.Wrap(err, "failed to list changed files")
 	}
 
-	var cleanedFilenames []string
+	var relevantFiles []string
 	for _, f := range files {
 		if !anyMatches(ignorePaths, f.Filename) {
-			cleanedFilenames = append(cleanedFilenames, f.Filename)
+			relevantFiles = append(relevantFiles, f.Filename)
 		}
 	}
 
-	for _, filename := range cleanedFilenames {
+	for _, filename := range relevantFiles {
 		if anyMatches(paths, filename) {
 			return true, "", nil
 		}

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -48,15 +48,12 @@ func (pred *ChangedFiles) Evaluate(ctx context.Context, prctx pull.Context) (boo
 		return false, "", errors.Wrap(err, "failed to list changed files")
 	}
 
-	var relevantFiles []string
 	for _, f := range files {
-		if !anyMatches(ignorePaths, f.Filename) {
-			relevantFiles = append(relevantFiles, f.Filename)
+		if anyMatches(ignorePaths, f.Filename) {
+			continue
 		}
-	}
 
-	for _, filename := range relevantFiles {
-		if anyMatches(paths, filename) {
+		if anyMatches(paths, f.Filename) {
 			return true, "", nil
 		}
 	}

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -120,6 +120,9 @@ func TestOnlyChangedFiles(t *testing.T) {
 			"app/.*\\.go",
 			"server/.*\\.go",
 		},
+		IgnorePaths: []string{
+			".*/special\\.go",
+		},
 	}
 
 	runFileTests(t, p, []FileTestCase{
@@ -166,6 +169,20 @@ func TestOnlyChangedFiles(t *testing.T) {
 				},
 				{
 					Filename: "model/user.go",
+					Status:   pull.FileModified,
+				},
+			},
+		},
+		{
+			"ignoreSome",
+			true,
+			[]*pull.File{
+				{
+					Filename: "app/normal.go",
+					Status:   pull.FileDeleted,
+				},
+				{
+					Filename: "other/special.go",
 					Status:   pull.FileModified,
 				},
 			},

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -120,9 +120,6 @@ func TestOnlyChangedFiles(t *testing.T) {
 			"app/.*\\.go",
 			"server/.*\\.go",
 		},
-		IgnorePaths: []string{
-			".*/special\\.go",
-		},
 	}
 
 	runFileTests(t, p, []FileTestCase{
@@ -169,20 +166,6 @@ func TestOnlyChangedFiles(t *testing.T) {
 				},
 				{
 					Filename: "model/user.go",
-					Status:   pull.FileModified,
-				},
-			},
-		},
-		{
-			"ignoreSome",
-			true,
-			[]*pull.File{
-				{
-					Filename: "app/normal.go",
-					Status:   pull.FileDeleted,
-				},
-				{
-					Filename: "other/special.go",
 					Status:   pull.FileModified,
 				},
 			},

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -30,6 +30,9 @@ func TestChangedFiles(t *testing.T) {
 			"app/.*\\.go",
 			"server/.*\\.go",
 		},
+		IgnorePaths: []string{
+			".*/special\\.go",
+		},
 	}
 
 	runFileTests(t, p, []FileTestCase{
@@ -76,6 +79,34 @@ func TestChangedFiles(t *testing.T) {
 				},
 				{
 					Filename: "model/user.go",
+					Status:   pull.FileModified,
+				},
+			},
+		},
+		{
+			"ignoreAll",
+			false,
+			[]*pull.File{
+				{
+					Filename: "app/special.go",
+					Status:   pull.FileDeleted,
+				},
+				{
+					Filename: "server/special.go",
+					Status:   pull.FileModified,
+				},
+			},
+		},
+		{
+			"ignoreSome",
+			true,
+			[]*pull.File{
+				{
+					Filename: "app/normal.go",
+					Status:   pull.FileDeleted,
+				},
+				{
+					Filename: "server/special.go",
 					Status:   pull.FileModified,
 				},
 			},


### PR DESCRIPTION
this would allow us to ignore specific files. a common scenario is:

* Team Infra owns the infrastructure code for a project (`build.gradle` files, etc.)
* another team, Team Coder owns the code in a project folder

i'd want the policy to reflect that Team Coder owns everything except the `build.gradle` file. this allows me to use a regex for the folder for Team Coder, and add an ignore pattern to remove files that aren't owned by Team Coder.