### PR TITLE
add has_labels predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ if:
     - "status-name-1"
     - "status-name-2"
     - "status-name-3"
+  
+  # "has_label_applied" is satisfied if the pull request has the specified labels
+  # applied
+  has_label_applied:
+    - "label-1"
+    - "label-2"
 
 # "options" specifies a set of restrictions on approvals. If the block does not
 # exist, the default values are used.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ if:
     - "status-name-2"
     - "status-name-3"
   
-  # "has_label_applied" is satisfied if the pull request has the specified labels
+  # "has_labels" is satisfied if the pull request has the specified labels
   # applied
   has_labels:
     - "label-1"

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ if:
   
   # "has_label_applied" is satisfied if the pull request has the specified labels
   # applied
-  has_label_applied:
+  has_labels:
     - "label-1"
     - "label-2"
 

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -33,7 +33,7 @@ type Predicates struct {
 
 	HasSuccessfulStatus *predicate.HasSuccessfulStatus `yaml:"has_successful_status"`
 
-	HasLabelApplied *predicate.HasLabelApplied `yaml:"has_label_applied"`
+	HasLabels *predicate.HasLabels `yaml:"has_labels"`
 }
 
 func (p *Predicates) Predicates() []predicate.Predicate {
@@ -70,8 +70,8 @@ func (p *Predicates) Predicates() []predicate.Predicate {
 		ps = append(ps, predicate.Predicate(p.HasSuccessfulStatus))
 	}
 
-	if p.HasLabelApplied != nil {
-		ps = append(ps, predicate.Predicate(p.HasLabelApplied))
+	if p.HasLabels != nil {
+		ps = append(ps, predicate.Predicate(p.HasLabels))
 	}
 
 	return ps

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -32,6 +32,8 @@ type Predicates struct {
 	ModifiedLines *predicate.ModifiedLines `yaml:"modified_lines"`
 
 	HasSuccessfulStatus *predicate.HasSuccessfulStatus `yaml:"has_successful_status"`
+
+	HasLabelApplied *predicate.HasLabelApplied `yaml:"has_label_applied"`
 }
 
 func (p *Predicates) Predicates() []predicate.Predicate {
@@ -66,6 +68,10 @@ func (p *Predicates) Predicates() []predicate.Predicate {
 
 	if p.HasSuccessfulStatus != nil {
 		ps = append(ps, predicate.Predicate(p.HasSuccessfulStatus))
+	}
+
+	if p.HasLabelApplied != nil {
+		ps = append(ps, predicate.Predicate(p.HasLabelApplied))
 	}
 
 	return ps

--- a/policy/predicate/label.go
+++ b/policy/predicate/label.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/palantir/policy-bot/pull"
+)
+
+type HasLabelApplied []string
+
+var _ Predicate = HasLabelApplied([]string{})
+
+func (pred HasLabelApplied) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
+	if len(pred) > 0 {
+
+		labels, err := prctx.Labels()
+		if err != nil {
+			return false, "", errors.Wrap(err, "failed to list pull request labels")
+		}
+
+		for _, requiredLabel := range pred {
+			if !contains(labels, strings.ToLower(requiredLabel)) {
+				return false, "Missing label:" + requiredLabel, nil
+			}
+		}
+	}
+
+	return true, "", nil
+}
+
+func contains(elements []string, value string) bool {
+	for _, element := range elements {
+		if element == value {
+			return true
+		}
+	}
+	return false
+}

--- a/policy/predicate/label.go
+++ b/policy/predicate/label.go
@@ -23,13 +23,12 @@ import (
 	"github.com/palantir/policy-bot/pull"
 )
 
-type HasLabelApplied []string
+type HasLabels []string
 
-var _ Predicate = HasLabelApplied([]string{})
+var _ Predicate = HasLabels([]string{})
 
-func (pred HasLabelApplied) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
+func (pred HasLabels) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
 	if len(pred) > 0 {
-
 		labels, err := prctx.Labels()
 		if err != nil {
 			return false, "", errors.Wrap(err, "failed to list pull request labels")
@@ -37,7 +36,7 @@ func (pred HasLabelApplied) Evaluate(ctx context.Context, prctx pull.Context) (b
 
 		for _, requiredLabel := range pred {
 			if !contains(labels, strings.ToLower(requiredLabel)) {
-				return false, "Missing label:" + requiredLabel, nil
+				return false, "Missing label: " + requiredLabel, nil
 			}
 		}
 	}

--- a/policy/predicate/label_test.go
+++ b/policy/predicate/label_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+)
+
+func TestHasLabels(t *testing.T) {
+	p := HasLabels([]string{"foo", "bar"})
+
+	runLabelsTestCase(t, p, []HasLabelsTestCase{
+		{
+			"all labels",
+			true,
+			&pulltest.Context{
+				LabelsValue: []string{"foo", "bar"},
+			},
+		},
+		{
+			"missing a label",
+			false,
+			&pulltest.Context{
+				LabelsValue: []string{"foo"},
+			},
+		},
+		{
+			"no labels",
+			false,
+			&pulltest.Context{
+				LabelsValue: []string{},
+			},
+		},
+		{
+			"labels does not exist",
+			false,
+			&pulltest.Context{},
+		},
+	})
+}
+
+type HasLabelsTestCase struct {
+	name     string
+	expected bool
+	context  pull.Context
+}
+
+func runLabelsTestCase(t *testing.T, p Predicate, cases []HasLabelsTestCase) {
+	ctx := context.Background()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, _, err := p.Evaluate(ctx, tc.context)
+			if assert.NoError(t, err, "evaluation failed") {
+				assert.Equal(t, tc.expected, ok, "predicate was not correct")
+			}
+		})
+	}
+}

--- a/pull/context.go
+++ b/pull/context.go
@@ -99,6 +99,9 @@ type Context interface {
 
 	// LatestStatuses returns a map of status check names to the latest result
 	LatestStatuses() (map[string]string, error)
+
+	// Labels returns a list of labels applied on the Pull Request
+	Labels() ([]string, error)
 }
 
 type FileStatus int

--- a/pull/github.go
+++ b/pull/github.go
@@ -126,6 +126,7 @@ type GitHubContext struct {
 	teamIDs       map[string]int64
 	membership    map[string]bool
 	statuses      map[string]string
+	labels        []string
 }
 
 // NewGitHubContext creates a new pull.Context that makes GitHub requests to
@@ -344,6 +345,25 @@ func (ghc *GitHubContext) LatestStatuses() (map[string]string, error) {
 	}
 
 	return ghc.statuses, nil
+}
+
+func (ghc *GitHubContext) Labels() ([]string, error) {
+	if ghc.labels == nil {
+		var labels []string
+		issueLabels, _, err := ghc.client.Issues.ListLabelsByIssue(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &github.ListOptions{
+			Page:    0,
+			PerPage: 1,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list labels")
+		}
+
+		for _, label := range issueLabels {
+			labels = append(labels, strings.ToLower(label.GetName()))
+		}
+		ghc.labels = labels
+	}
+	return ghc.labels, nil
 }
 
 func (ghc *GitHubContext) loadPagedData() error {

--- a/pull/github.go
+++ b/pull/github.go
@@ -352,7 +352,7 @@ func (ghc *GitHubContext) Labels() ([]string, error) {
 		var labels []string
 		issueLabels, _, err := ghc.client.Issues.ListLabelsByIssue(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &github.ListOptions{
 			Page:    0,
-			PerPage: 1,
+			PerPage: 100,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to list labels")

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -59,6 +59,9 @@ type Context struct {
 	LatestStatusesValue map[string]string
 	LatestStatusesError error
 
+	LabelsValue []string
+	LabelsError error
+
 	Draft bool
 }
 
@@ -214,6 +217,10 @@ func (c *Context) Teams() (map[string]string, error) {
 
 func (c *Context) LatestStatuses() (map[string]string, error) {
 	return c.LatestStatusesValue, c.LatestStatusesError
+}
+
+func (c *Context) Labels() ([]string, error) {
+	return c.LabelsValue, c.LabelsError
 }
 
 // assert that the test object implements the full interface

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -48,7 +48,7 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	}
 
 	switch event.GetAction() {
-	case "opened", "reopened", "synchronize", "edited", "ready_for_review":
+	case "opened", "reopened", "synchronize", "edited", "ready_for_review", "labeled", "unlabeled":
 		return h.Evaluate(ctx, installationID, performActions, pull.Locator{
 			Owner:  event.GetRepo().GetOwner().GetLogin(),
 			Repo:   event.GetRepo().GetName(),


### PR DESCRIPTION
## Before this PR
There was no way to create policies that took into account the labels that were applied onto a PR

## After this PR
==COMMIT_MSG==
Add `has_label_applied` field to a clause allowing users to define predicates which are only applied if all of the specified labels are applied
==COMMIT_MSG==

Fixes #29.

## Possible downsides?
There is some additional computation since we now respond to pull request `labeled` and `unlabeled` events, but I don't think this should be a big deal