### PR TITLE
Add ignore_commits_by option

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,16 @@ options:
   # commonly created by using the "Update branch" button in the UI.
   ignore_update_merges: false
 
+  # If present, commits authored and committed by users meeting the conditions
+  # are ignored for the purposes of approval. This means the users will not
+  # count as contributors and their commits will not invalidate approval if
+  # invalidate_on_push is enabled. Both the author and the committer must match
+  # the conditions to ignore the commit.
+  ignore_commits_by:
+    users: ["bulldozer[bot]"]
+    organizatons: ["org1']
+    teams: ["org1/team1"]
+
   # Automatically request reviewers when a Pull Request is opened
   # if this rule is pending, there are no assigned reviewers, and if the
   # Pull Request is not in Draft.

--- a/policy/common/actor.go
+++ b/policy/common/actor.go
@@ -42,7 +42,7 @@ const (
 
 // IsEmpty returns true if no conditions for actors are defined.
 func (a *Actors) IsEmpty() bool {
-	return a == nil || (len(a.Users) == 0 && len(a.Teams) == 0 && len(a.Organizations) == 0)
+	return a == nil || (len(a.Users) == 0 && len(a.Teams) == 0 && len(a.Organizations) == 0 && !a.Admins && !a.WriteCollaborators)
 }
 
 // IsActor returns true if the given user satisfies at least one of the


### PR DESCRIPTION
This option ignores all commits that have both an author and
contributor matching the conditions in the block. These commits
effectively do not exist to policy-bot, meaning they don't influence
invalidation on push or contributor detection.

This can be useful to ignore certain automated commits or commits from
trusted user groups. Note that commit authorship is easy to forge, so
this is not a secure option unless paired with a pre-receive hook that
enforces accurate commit attribution.

Closes #120.