### PR TITLE
Unmarshal regexps directly from configuration

### DIFF
--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,10 +69,14 @@ func TestRules(t *testing.T) {
 			Name: "rule1",
 			Predicates: Predicates{
 				ChangedFiles: &predicate.ChangedFiles{
-					Paths: []string{"path1"},
+					Paths: []common.Regexp{
+						common.NewCompiledRegexp(regexp.MustCompile("path1")),
+					},
 				},
 				OnlyChangedFiles: &predicate.OnlyChangedFiles{
-					Paths: []string{"path2"},
+					Paths: []common.Regexp{
+						common.NewCompiledRegexp(regexp.MustCompile("path2")),
+					},
 				},
 				HasAuthorIn: &predicate.HasAuthorIn{
 					Actors: common.Actors{

--- a/policy/common/regexp.go
+++ b/policy/common/regexp.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"regexp"
+)
+
+// Regexp is a regexp.Regexp that only supports matching and can be
+// deserialized from a string.
+type Regexp struct {
+	r *regexp.Regexp
+}
+
+func NewRegexp(pattern string) (Regexp, error) {
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		return Regexp{}, err
+	}
+	return Regexp{r: r}, nil
+}
+
+func NewCompiledRegexp(r *regexp.Regexp) Regexp {
+	return Regexp{r: r}
+}
+
+func (r Regexp) Matches(s string) bool {
+	if r.r == nil {
+		return false
+	}
+	return r.r.MatchString(s)
+}
+
+func (r Regexp) String() string {
+	if r.r == nil {
+		return ""
+	}
+	return r.r.String()
+}
+
+func (r *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
+	var pattern string
+	if err := unmarshal(&pattern); err != nil {
+		return err
+	}
+	*r, err = NewRegexp(pattern)
+	return err
+}
+
+func (r *Regexp) UnmarshalJSON(data []byte) (err error) {
+	var pattern string
+	if err := json.Unmarshal(data, &pattern); err != nil {
+		return err
+	}
+	*r, err = NewRegexp(pattern)
+	return err
+}

--- a/policy/common/regexp_test.go
+++ b/policy/common/regexp_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRegexpUnmarshal(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		var r Regexp
+		require.NoError(t, json.Unmarshal([]byte(`"test/.*"`), &r), "failed to unmarshal json")
+
+		assert.True(t, r.Matches("test/path/to/file.txt"))
+		assert.False(t, r.Matches("something/else/path/to/file.txt"))
+	})
+
+	t.Run("jsonEmpty", func(t *testing.T) {
+		var r Regexp
+		require.NoError(t, json.Unmarshal([]byte(`""`), &r), "failed to unmarshal json")
+
+		assert.True(t, r.Matches("any string"))
+		assert.True(t, r.Matches(""))
+	})
+
+	t.Run("jsonError", func(t *testing.T) {
+		var r Regexp
+		require.Error(t, json.Unmarshal([]byte(`"this(is an unclosed [group"`), &r), "invalid regexp unmarshalled without error")
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var r Regexp
+		require.NoError(t, yaml.Unmarshal([]byte(`"test/.*"`), &r), "failed to unmarshal yaml")
+
+		assert.True(t, r.Matches("test/path/to/file.txt"))
+		assert.False(t, r.Matches("something/else/path/to/file.txt"))
+	})
+
+	t.Run("yamlEmpty", func(t *testing.T) {
+		var r Regexp
+		require.NoError(t, yaml.Unmarshal([]byte(`""`), &r), "failed to unmarshal yaml")
+
+		assert.True(t, r.Matches("any string"))
+		assert.True(t, r.Matches(""))
+	})
+
+	t.Run("yamlError", func(t *testing.T) {
+		var r Regexp
+		require.Error(t, yaml.Unmarshal([]byte(`"this(is an unclosed [group"`), &r), "invalid regexp unmarshalled without error")
+	})
+}

--- a/policy/predicate/branch.go
+++ b/policy/predicate/branch.go
@@ -17,27 +17,20 @@ package predicate
 import (
 	"context"
 	"fmt"
-	"regexp"
 
-	"github.com/pkg/errors"
-
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
 )
 
 type TargetsBranch struct {
-	Pattern string `yaml:"pattern"`
+	Pattern common.Regexp `yaml:"pattern"`
 }
 
 var _ Predicate = &TargetsBranch{}
 
 func (pred *TargetsBranch) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
-	pattern, err := regexp.Compile(pred.Pattern)
-	if err != nil {
-		return false, "", errors.Wrap(err, "failed to compile the target regex")
-	}
-
 	targetName, _ := prctx.Branches()
-	matches := pattern.MatchString(targetName)
+	matches := pred.Pattern.Matches(targetName)
 
 	desc := ""
 	if !matches {

--- a/policy/predicate/branch_test.go
+++ b/policy/predicate/branch_test.go
@@ -16,17 +16,19 @@ package predicate
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/palantir/policy-bot/pull/pulltest"
 )
 
 func TestTargetsBranch(t *testing.T) {
 	p := &TargetsBranch{
-		Pattern: "^master$",
+		Pattern: common.NewCompiledRegexp(regexp.MustCompile("^master$")),
 	}
 
 	runTargetsTestCase(t, p, []targetsTestCase{
@@ -54,7 +56,7 @@ func TestTargetsBranch(t *testing.T) {
 	})
 
 	pMatchAll := &TargetsBranch{
-		Pattern: ".*",
+		Pattern: common.NewCompiledRegexp(regexp.MustCompile(".*")),
 	}
 
 	runTargetsTestCase(t, pMatchAll, []targetsTestCase{
@@ -75,7 +77,7 @@ func TestTargetsBranch(t *testing.T) {
 	})
 
 	pRegex := &TargetsBranch{
-		Pattern: "(prod|staging)",
+		Pattern: common.NewCompiledRegexp(regexp.MustCompile("(prod|staging)")),
 	}
 
 	runTargetsTestCase(t, pRegex, []targetsTestCase{

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -16,22 +16,24 @@ package predicate
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/palantir/policy-bot/pull/pulltest"
 )
 
 func TestChangedFiles(t *testing.T) {
 	p := &ChangedFiles{
-		Paths: []string{
-			"app/.*\\.go",
-			"server/.*\\.go",
+		Paths: []common.Regexp{
+			common.NewCompiledRegexp(regexp.MustCompile("app/.*\\.go")),
+			common.NewCompiledRegexp(regexp.MustCompile("server/.*\\.go")),
 		},
-		IgnorePaths: []string{
-			".*/special\\.go",
+		IgnorePaths: []common.Regexp{
+			common.NewCompiledRegexp(regexp.MustCompile(".*/special\\.go")),
 		},
 	}
 
@@ -116,9 +118,9 @@ func TestChangedFiles(t *testing.T) {
 
 func TestOnlyChangedFiles(t *testing.T) {
 	p := &OnlyChangedFiles{
-		Paths: []string{
-			"app/.*\\.go",
-			"server/.*\\.go",
+		Paths: []common.Regexp{
+			common.NewCompiledRegexp(regexp.MustCompile("app/.*\\.go")),
+			common.NewCompiledRegexp(regexp.MustCompile("server/.*\\.go")),
 		},
 	}
 


### PR DESCRIPTION
Introduce the common.Regexp type as a simple wrapper for regexp.Regexp
that adds unmarshalling methods for JSON and YAML. This simplifies code
using these expressions and ensures that invalid regular expressions are
caught early and are detectable with the validation API.

The downside is that invalid expressions now break the loading
processes, so we can't report multiple errors at once. We don't do this
now, but if we want to in the future, another refactoring will be
required.

This is a precursor for implementing #155. 