### PR TITLE
Add comment_patterns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ if:
     users: ["user1", "user2", ...]
     organizations: ["org1", "org2", ...]
     teams: ["org1/team1", "org2/team2", ...]
-    
+
   # "only_has_contributors_in" is satisfied if all of the commits on the pull
   # request have an author or committer in the users list or that belong to
   # any of the listed organizations or teams.
@@ -177,14 +177,14 @@ if:
     additions: "> 100"
     deletions: "> 100"
     total: "> 200"
-  
+
   # "has_successful_status" is satisfied if the status checks that are specified
   # are marked successful on the head commit of the pull request.
   has_successful_status:
     - "status-name-1"
     - "status-name-2"
     - "status-name-3"
-  
+
   # "has_labels" is satisfied if the pull request has the specified labels
   # applied
   has_labels:
@@ -229,11 +229,19 @@ options:
     # defaults to 'random-users'
     mode: all-users|random-users
 
-  # "methods" defines how users may express approval. The defaults are below.
+  # "methods" defines how users may express approval.
   methods:
+    # If a comment contains a string in this list, it counts as approval. Use
+    # the "comment_patterns" option if you want to match full comments. The
+    # default values are shown.
     comments:
       - ":+1:"
       - "👍"
+    # If a comment matches a regular expression in this list, it counts as
+    # approval. Defaults to an empty list.
+    comment_patterns:
+      - "^Signed-off by \\s+$"
+    # If true, GitHub reviews can be used for approval. Default is true.
     github_review: true
 
 # "requires" specifies the approval requirements for the rule. If the block

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -23,8 +23,9 @@ import (
 )
 
 type Methods struct {
-	Comments     []string `yaml:"comments,omitempty"`
-	GithubReview bool     `yaml:"github_review,omitempty"`
+	Comments        []string `yaml:"comments,omitempty"`
+	CommentPatterns []Regexp `yaml:"comment_patterns,omitempty"`
+	GithubReview    bool     `yaml:"github_review,omitempty"`
 
 	// If GithubReview is true, GithubReviewState is the state a review must
 	// have to be considered a candidated. It is currently excluded from
@@ -52,7 +53,7 @@ func (cs CandidatesByCreationTime) Less(i, j int) bool {
 func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candidate, error) {
 	var candidates []*Candidate
 
-	if len(m.Comments) > 0 {
+	if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 		comments, err := prctx.Comments()
 		if err != nil {
 			return nil, err
@@ -110,6 +111,10 @@ func (m *Methods) CommentMatches(commentBody string) bool {
 			return true
 		}
 	}
-
+	for _, pattern := range m.CommentPatterns {
+		if pattern.Matches(commentBody) {
+			return true
+		}
+	}
 	return false
 }


### PR DESCRIPTION
This allows users to specify regular expressions for identifying
approval comments and can also be used to force full/exact string
matches instead of substring matches.

Closes #155.