### PR TITLE
Add handler for check_run events

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ The app requires these permissions:
 | Permission | Access | Reason |
 | ---------- | ------ | ------ |
 | Repository contents | Read-only | Read configuration and commit metadata |
+| Checks | Read-only | Read check run results |
 | Repository administration | Read-only | Read admin team(s) membership |
 | Issues | Read-only | Read pull request comments |
 | Repository metadata | Read-only | Basic repository data |
@@ -571,10 +572,11 @@ The app requires these permissions:
 
 The app should be subscribed to these events:
 
+* Check run
 * Issue comment
 * Pull request
-* Status
 * Pull request review
+* Status
 
 There is a [`logo.png`](https://github.com/palantir/policy-bot/blob/develop/logo.png)
 provided if you'd like to use it as the GitHub application logo. The background

--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -1,0 +1,72 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/go-github/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+
+	"github.com/palantir/policy-bot/pull"
+)
+
+type CheckRun struct {
+	Base
+}
+
+func (h *CheckRun) Handles() []string { return []string{"check_run"} }
+
+func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	var event github.CheckRunEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse check_run event payload")
+	}
+
+	if event.GetAction() != "completed" || event.GetCheckRun().GetConclusion() != "success" {
+		return nil
+	}
+
+	repo := event.GetRepo()
+	ownerName := repo.GetOwner().GetLogin()
+	repoName := repo.GetName()
+	commitSHA := event.GetCheckRun().GetHeadSHA()
+	installationID := githubapp.GetInstallationIDFromEvent(&event)
+
+	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
+
+	evaluationFailures := 0
+	for _, pr := range event.GetCheckRun().PullRequests {
+		// TODO(bkeyes): I'm assuming PRs in a check run are open at the time
+		// of the event, but I can't find confirmation of that in the GitHub
+		// docs. The PR object is a minimal version that is missing the "state"
+		// field, so we can't check without loading the full object.
+		if err := h.Evaluate(ctx, installationID, false, pull.Locator{
+			Owner:  ownerName,
+			Repo:   repoName,
+			Number: pr.GetNumber(),
+			Value:  pr,
+		}); err != nil {
+			evaluationFailures++
+			logger.Error().Err(err).Msgf("Failed to evaluate pull request '%d' for SHA '%s'", pr.GetNumber(), commitSHA)
+		}
+	}
+	if evaluationFailures == 0 {
+		return nil
+	}
+	return errors.Errorf("failed to evaluate %d pull requests", evaluationFailures)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -123,6 +123,7 @@ func New(c *Config) (*Server, error) {
 		&handler.PullRequestReview{Base: basePolicyHandler},
 		&handler.IssueComment{Base: basePolicyHandler},
 		&handler.Status{Base: basePolicyHandler},
+		&handler.CheckRun{Base: basePolicyHandler},
 	)
 
 	templates, err := handler.LoadTemplates(&c.Files)


### PR DESCRIPTION
This is functionally equivalent to the status handler, but shares little code because the events have different structures.

Follow-up to #176.