### PR TITLE
Enable asynchronous webhook processing

### DIFF
--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -20,10 +20,19 @@ logging:
   # Choose from: debug, info, warn, error
   level: debug
 
-# Options for the HTTP Cache
-cache:
-  # The maximum size of the cache (specified in human readable units)
-  max_size: 50 MB
+# Options for the GitHub response cache. When the cache reaches max_size, the
+# oldest entries are evicted. Size properties can use any format supported by
+# https://github.com/c2h5oh/datasize
+#
+# cache:
+#   max_size: "50MB"
+
+# Options for webhook processing workers. Events are dropped if the queue is
+# full. The defaults are shown below.
+#
+# workers:
+#   workers: 10
+#   queue_size: 100
 
 # Options for connecting to GitHub
 github:

--- a/server/config.go
+++ b/server/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Options  handler.PullEvaluationOptions `yaml:"options"`
 	Files    handler.FilesConfig           `yaml:"files"`
 	Datadog  datadog.Config                `yaml:"datadog"`
+	Workers  WorkerConfig                  `yaml:"workers"`
 }
 
 type LoggingConfig struct {
@@ -45,6 +46,11 @@ type LoggingConfig struct {
 
 type CachingConfig struct {
 	MaxSize datasize.ByteSize `yaml:"max_size"`
+}
+
+type WorkerConfig struct {
+	Workers   int `yaml:"workers"`
+	QueueSize int `yaml:"queue_size"`
 }
 
 type SessionsConfig struct {


### PR DESCRIPTION
While policy-bot is generally pretty fast at responding to webhooks,
this avoids any possibility for timeouts for repositories that have
large policies that require many requests to evaluate.