### PR TITLE
Use unqualified names in team assignment

### DIFF
--- a/policy/reviewer/reviewer.go
+++ b/policy/reviewer/reviewer.go
@@ -142,7 +142,7 @@ func getPossibleReviewers(prctx pull.Context, users map[string]struct{}, collabo
 func stripOrg(teamWithOrg string) (string, error) {
 	split := strings.Split(teamWithOrg, "/")
 	if len(split) < 0 {
-		return "", fmt.Errorf("Expected org with team: '%s'", teamWithOrg)
+		return "", fmt.Errorf("expected org with team: '%s'", teamWithOrg)
 	}
 	return split[1], nil
 }
@@ -224,12 +224,12 @@ func SelectReviewers(ctx context.Context, prctx pull.Context, result common.Resu
 				return nil, nil, err
 			}
 			for team := range allTeamsWithUsers {
-				formattedTeam, err := stripOrg(team)
+				slug, err := stripOrg(team)
 				if err != nil {
 					return nil, nil, err
 				}
-				if _, ok := permissionedTeams[formattedTeam]; ok {
-					possibleTeams = append(possibleTeams, team)
+				if _, ok := permissionedTeams[slug]; ok {
+					possibleTeams = append(possibleTeams, slug)
 				}
 			}
 			logger.Debug().Msgf("Found %d total teams; requesting teams", len(possibleTeams))

--- a/policy/reviewer/reviewer_test.go
+++ b/policy/reviewer/reviewer_test.go
@@ -114,7 +114,7 @@ func TestSelectAdminTeam(t *testing.T) {
 	reviewers, teams, err := SelectReviewers(context.Background(), prctx, results, r)
 	require.NoError(t, err)
 	require.Len(t, teams, 1, "admin team should be selected")
-	require.Contains(t, teams, "everyone/team-admin", "admin team seleted")
+	require.Contains(t, teams, "team-admin", "admin team seleted")
 
 	require.Len(t, reviewers, 0, "policy should request no people")
 }
@@ -166,7 +166,7 @@ func TestSelectReviewers_Team_teams(t *testing.T) {
 	reviewers, teams, err := SelectReviewers(context.Background(), prctx, results, r)
 	require.NoError(t, err)
 	require.Len(t, teams, 1, "one team should be returned")
-	require.Contains(t, teams, "everyone/team-write", "team-write should be selected")
+	require.Contains(t, teams, "team-write", "team-write should be selected")
 	require.Len(t, reviewers, 2, "policy should request 2 people")
 	require.Contains(t, reviewers, "review-approver", "at least review-approver must be selected")
 	require.NotContains(t, reviewers, "user-team-write", "user-team-write should not be selected")


### PR DESCRIPTION
Because you can only assign teams from the organization, the API expects
to get unqualified team slugs as input.

cc @AdamDeHovitz