### PR TITLE
fix broken docs URL, missing v prefix

### DIFF
--- a/server/templates/index.html.tmpl
+++ b/server/templates/index.html.tmpl
@@ -6,7 +6,7 @@
   {{ $appsPath = "apps" }}
 {{ end }}
 {{ $appURL := printf "%s/%s/%s" .GitHubURL $appsPath .AppName }}
-{{ $docsURL := printf "https://github.com/palantir/policy-bot/blob/%s/README.md" .Version }}
+{{ $docsURL := printf "https://github.com/palantir/policy-bot/blob/v%s/README.md" .Version }}
 <header class="p-4 mb-8 text-white flex flex-col items-center">
   <div class="logo mb-4 drop-shadow-sm"></div>
   <h1 class="mb-4 text-5xl">PolicyBot</h1>


### PR DESCRIPTION
Given that:

* the latest tag has a `v` prefix
* godel's `version.GetVersion` strips the leading `v` prefix

We end up in a situation where the docs URL being constructed doesn't exist (since the URL is missing the `v` prefix).

This PR adds the prefix explicitly.