### PR TITLE
Request reviewers if a pull-request is reopened

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -125,7 +125,7 @@ func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *g
 	return ctx, logger
 }
 
-func (b *Base) Evaluate(ctx context.Context, installationID int64, performActions bool, loc pull.Locator) error {
+func (b *Base) Evaluate(ctx context.Context, installationID int64, requestReviews bool, loc pull.Locator) error {
 	client, err := b.NewInstallationClient(installationID)
 	if err != nil {
 		return err
@@ -147,10 +147,10 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, performAction
 		return errors.WithMessage(err, fmt.Sprintf("failed to fetch policy: %s", fetchedConfig))
 	}
 
-	return b.EvaluateFetchedConfig(ctx, prctx, performActions, client, fetchedConfig)
+	return b.EvaluateFetchedConfig(ctx, prctx, requestReviews, client, fetchedConfig)
 }
 
-func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, performActions bool, client *github.Client, fetchedConfig FetchedConfig) error {
+func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, requestReviews bool, client *github.Client, fetchedConfig FetchedConfig) error {
 	logger := zerolog.Ctx(ctx)
 
 	if fetchedConfig.Missing() {
@@ -201,7 +201,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, pe
 		return err
 	}
 
-	if performActions && statusState == "pending" && !prctx.IsDraft() {
+	if requestReviews && statusState == "pending" && !prctx.IsDraft() {
 		hasReviewers, err := prctx.HasReviewers()
 		if err != nil {
 			return errors.Wrap(err, "Unable to list request reviewers")

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -42,14 +42,16 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
-	performActions := false
-	if event.GetAction() == "ready_for_review" || event.GetAction() == "opened" {
-		performActions = true
-	}
-
 	switch event.GetAction() {
-	case "opened", "reopened", "synchronize", "edited", "ready_for_review", "labeled", "unlabeled":
-		return h.Evaluate(ctx, installationID, performActions, pull.Locator{
+	case "opened", "reopened", "ready_for_review", "labeled":
+		return h.Evaluate(ctx, installationID, true, pull.Locator{
+			Owner:  event.GetRepo().GetOwner().GetLogin(),
+			Repo:   event.GetRepo().GetName(),
+			Number: event.GetPullRequest().GetNumber(),
+			Value:  event.GetPullRequest(),
+		})
+	case "synchronize", "edited", "unlabeled":
+		return h.Evaluate(ctx, installationID, false, pull.Locator{
 			Owner:  event.GetRepo().GetOwner().GetLogin(),
 			Repo:   event.GetRepo().GetName(),
 			Number: event.GetPullRequest().GetNumber(),

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -43,14 +43,14 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
 	switch event.GetAction() {
-	case "opened", "reopened", "ready_for_review", "labeled":
+	case "opened", "reopened", "ready_for_review":
 		return h.Evaluate(ctx, installationID, true, pull.Locator{
 			Owner:  event.GetRepo().GetOwner().GetLogin(),
 			Repo:   event.GetRepo().GetName(),
 			Number: event.GetPullRequest().GetNumber(),
 			Value:  event.GetPullRequest(),
 		})
-	case "synchronize", "edited", "unlabeled":
+	case "synchronize", "edited", "labeled", "unlabeled":
 		return h.Evaluate(ctx, installationID, false, pull.Locator{
 			Owner:  event.GetRepo().GetOwner().GetLogin(),
 			Repo:   event.GetRepo().GetName(),


### PR DESCRIPTION
We've seen a couple instances where policy-bot fails to request any reviewers. The ability to close/reopen a pull-request to retrigger the request feature would make it easier to resolve those situations.

I'm also open to further requesting reviewers in more situations, but want to avoid the race condition concern raised [here](https://github.com/palantir/policy-bot/pull/127#pullrequestreview-301481864).