### PR TITLE
Reduce requests for evaluation and revew assignment

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -117,6 +117,7 @@ type GitHubContext struct {
 	comments      []*Comment
 	reviews       []*Review
 	collaborators map[string]string
+	teams         map[string]string
 	teamIDs       map[string]int64
 	membership    map[string]bool
 	statuses      map[string]string
@@ -272,7 +273,6 @@ func (ghc *GitHubContext) RepositoryCollaborators() (map[string]string, error) {
 			return nil, err
 		}
 	}
-
 	return ghc.collaborators, nil
 }
 
@@ -295,27 +295,28 @@ func (ghc *GitHubContext) HasReviewers() (bool, error) {
 }
 
 func (ghc *GitHubContext) Teams() (map[string]string, error) {
-	opt := &github.ListOptions{
-		PerPage: 100,
-	}
+	if ghc.teams == nil {
+		opt := &github.ListOptions{
+			PerPage: 100,
+		}
 
-	// get all pages of results
-	allTeams := make(map[string]string)
-	for {
-		teams, resp, err := ghc.client.Repositories.ListTeams(ghc.ctx, ghc.RepositoryOwner(), ghc.RepositoryName(), opt)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list teams page %d", opt.Page)
+		allTeams := make(map[string]string)
+		for {
+			teams, resp, err := ghc.client.Repositories.ListTeams(ghc.ctx, ghc.RepositoryOwner(), ghc.RepositoryName(), opt)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to list teams page %d", opt.Page)
+			}
+			for _, t := range teams {
+				allTeams[t.GetSlug()] = t.GetPermission()
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
 		}
-		for _, t := range teams {
-			allTeams[t.GetSlug()] = t.GetPermission()
-		}
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
+		ghc.teams = allTeams
 	}
-
-	return allTeams, nil
+	return ghc.teams, nil
 }
 
 func (ghc *GitHubContext) LatestStatuses() (map[string]string, error) {

--- a/pull/github.go
+++ b/pull/github.go
@@ -189,7 +189,10 @@ func (ghc *GitHubContext) Branches() (base string, head string) {
 
 func (ghc *GitHubContext) ChangedFiles() ([]*File, error) {
 	if ghc.files == nil {
-		var opt github.ListOptions
+		opt := github.ListOptions{
+			PerPage: 100,
+		}
+
 		var allFiles []*github.CommitFile
 		for {
 			files, res, err := ghc.client.PullRequests.ListFiles(ghc.ctx, ghc.owner, ghc.repo, ghc.number, &opt)


### PR DESCRIPTION
Fix several instances where data was not cached or we were making more requests than necessary:

- Cache team permissions for repositories
- Cache organization and team member lists
- Request files in a pull request with a higher page size

Note that all of this caching is within a single request, so it helps when multiple rules in a policy need the same data, but doesn't help between requests. We currently rely on a global cache of response data from GitHub to optimize that case.

An alternate solution might be to increase the size of the global cache to reduce evictions. The benefit of the change here is that it skips the request entirely, while hitting the global cache will still make a conditional request to re-validate the data.