### PR TITLE
help make validation errors easier to read

### DIFF
--- a/policy/approval/parse.go
+++ b/policy/approval/parse.go
@@ -85,10 +85,15 @@ func parsePolicyR(policy interface{}, rules map[string]*Rule, depth int) (common
 		}
 
 		var subrequirements []common.Evaluator
-		for _, subpolicy := range values {
+		for index, subpolicy := range values {
 			subreq, err := parsePolicyR(subpolicy, rules, depth+1)
 			if err != nil {
-				return nil, errors.WithMessage(err, fmt.Sprintf("failed to parse subpolicies for '%s'", op))
+				errMsg := fmt.Sprintf("failed to parse subpolicy (index=%d) for '%s'", index, op)
+				if depth == 0 {
+					errMsg = fmt.Sprintf("failed to parse policy (index=%d)", index)
+				}
+
+				return nil, errors.WithMessage(err, errMsg)
 			}
 			subrequirements = append(subrequirements, subreq)
 		}

--- a/policy/approval/parse_test.go
+++ b/policy/approval/parse_test.go
@@ -182,10 +182,10 @@ func TestParsePolicyError_indexedError(t *testing.T) {
 	expectedErrMsg := strings.Join([]string{
 		"failed to parse policy (index=1)",
 		"failed to parse subpolicy (index=2) for 'or'",
-		"policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]",
+		"policy references undefined rule 'ruleUnknown', allowed values: [",
 	}, ": ")
 
-	require.Equal(t, expectedErrMsg, err.Error())
+	require.Contains(t, err.Error(), expectedErrMsg)
 }
 
 func TestParsePolicyError_illegalType(t *testing.T) {

--- a/policy/approval/parse_test.go
+++ b/policy/approval/parse_test.go
@@ -165,8 +165,8 @@ func TestParsePolicyError_indexedError(t *testing.T) {
 - rule1
 - or:
    - rule2
-   - ruleUnknown
    - rule3
+   - ruleUnknown
 `
 
 	rules := `
@@ -181,7 +181,7 @@ func TestParsePolicyError_indexedError(t *testing.T) {
 	// failed to parse policy (index=1): failed to parse subpolicy (index=1) for 'or': policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]
 	expectedErrMsg := strings.Join([]string{
 		"failed to parse policy (index=1)",
-		"failed to parse subpolicy (index=1) for 'or'",
+		"failed to parse subpolicy (index=2) for 'or'",
 		"policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]",
 	}, ": ")
 


### PR DESCRIPTION
This is an attempt to help clarify the error messages returned by the validation code. The text is returned by the validation endpoint, and can be difficult to read. The specific changes to error message are:

* reworded error for the root level `and` using `policy` instead of `subpolicy`
* added `(index=#)` to help identify which of the children rules are broken

With the following policy file:

```yaml
policy:
  approval:
    - rule1
    - or:
       - rule2
       - rule3
       - ruleUnknown

approval_rules:
  - name: rule1
  - name: rule2
  - name: rule3
```

The error would be:

```
failed to parse subpolicy for 'and': failed to parse subpolicy for 'or': policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]

// when formatted
failed to parse subpolicy for 'and': // due to the implied root-level AND
failed to parse subpolicy for 'or':
policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]
```

and now the new err is:

```
failed to parse policy (index=1): failed to parse subpolicy (index=2) for 'or': policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]

// when formatted
failed to parse policy (index=1):
failed to parse subpolicy (index=2) for 'or':
policy references undefined rule 'ruleUnknown', allowed values: [rule1 rule2 rule3]
```