### PR TITLE
Only process review requests when enabled

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -113,15 +113,18 @@ func (r *Rule) Evaluate(ctx context.Context, prctx pull.Context) (res common.Res
 		res.Status = common.StatusPending
 
 		if r.Options.RequestReview.Enabled {
-			res.ReviewRequestRule = common.ReviewRequestRule{
+			mode := r.Options.RequestReview.Mode
+			if mode == "" {
+				mode = common.RequestModeRandomUsers
+			}
+			res.ReviewRequestRule = &common.ReviewRequestRule{
 				Users:              r.Requires.Users,
 				Teams:              r.Requires.Teams,
 				Organizations:      r.Requires.Organizations,
 				Admins:             r.Requires.Admins,
 				WriteCollaborators: r.Requires.WriteCollaborators,
 				RequiredCount:      r.Requires.Count,
-
-				Mode: r.Options.RequestReview.Mode,
+				Mode:               mode,
 			}
 		}
 	}

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -57,20 +57,12 @@ type ReviewRequestRule struct {
 }
 
 type Result struct {
-	Name              string
-	Description       string
-	Status            EvaluationStatus
-	ReviewRequestRule ReviewRequestRule
+	Name        string
+	Description string
+	Status      EvaluationStatus
+	Error       error
 
-	Error error
+	ReviewRequestRule *ReviewRequestRule
 
 	Children []*Result
-}
-
-func (r Result) GetMode() RequestMode {
-	mode := RequestModeRandomUsers
-	if r.ReviewRequestRule.Mode != "" {
-		mode = r.ReviewRequestRule.Mode
-	}
-	return mode
 }


### PR DESCRIPTION
While reviewers were never assigned incorrectly, we previously made
unnecessary requests to GitHub to get collaborator and reviewer details
that were discarded when no enabled rules existed. Now, check for rules
that enable review requests first and only start reviewer assignment if
at least one exists.

This also cleans up some logging and other minor style things in code I
touched to fix the problem.