### PR TITLE
Fix rename handling for changed files

### DIFF
--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -39,7 +39,7 @@ func TestChangedFiles(t *testing.T) {
 	files, err := ctx.ChangedFiles()
 	require.NoError(t, err)
 
-	require.Len(t, files, 3, "incorrect number of files")
+	require.Len(t, files, 5, "incorrect number of files")
 	assert.Equal(t, 2, filesRule.Count, "no http request was made")
 
 	assert.Equal(t, "path/foo.txt", files[0].Filename)
@@ -51,11 +51,21 @@ func TestChangedFiles(t *testing.T) {
 	assert.Equal(t, "README.md", files[2].Filename)
 	assert.Equal(t, FileModified, files[2].Status)
 
+	assert.Equal(t, "path/old.txt", files[3].Filename)
+	assert.Equal(t, FileDeleted, files[3].Status)
+	assert.Equal(t, 0, files[3].Additions)
+	assert.Equal(t, 0, files[3].Deletions)
+
+	assert.Equal(t, "path/new.txt", files[4].Filename)
+	assert.Equal(t, FileAdded, files[4].Status)
+	assert.Equal(t, 2, files[4].Additions)
+	assert.Equal(t, 4, files[4].Deletions)
+
 	// verify that the file list is cached
 	files, err = ctx.ChangedFiles()
 	require.NoError(t, err)
 
-	require.Len(t, files, 3, "incorrect number of files")
+	require.Len(t, files, 5, "incorrect number of files")
 	assert.Equal(t, 2, filesRule.Count, "cached files were not used")
 }
 

--- a/pull/testdata/responses/pull_files.yml
+++ b/pull/testdata/responses/pull_files.yml
@@ -33,5 +33,13 @@
         "additions": 103,
         "deletions": 21,
         "changes": 124
+      },
+      {
+        "filename": "path/new.txt",
+        "status": "renamed",
+        "additions": 2,
+        "deletions": 4,
+        "changes": 6,
+        "previous_filename": "path/old.txt"
       }
     ]


### PR DESCRIPTION
Properly expand a rename into a deletion of the old file and an addition
of the new one so predicates trigger if they apply to either side of the
rename operation. Previously, only the new file (the destination) was
included as a changed file.

cc @AdamDeHovitz 