### PR TITLE
Add toggle to remove skipped rules on details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "copy": "npm-run-all -p copy:*",
     "copy:img": "mkdir -p ./build/static && cp -R ./server/assets/img ./build/static",
+    "copy:js": "mkdir -p ./build/static && cp -R ./server/assets/js ./build/static",
     "postcss": "postcss ./server/assets/css/main.css -o ./build/static/css/main.css",
     "build": "npm-run-all -p postcss copy",
     "build:production": "npm-run-all -p \"postcss --env production\" copy"

--- a/server/assets/css/main.css
+++ b/server/assets/css/main.css
@@ -62,6 +62,52 @@ a:hover {
   justify-self: end;
 }
 
+.toggle {
+  position: relative;
+}
+
+.toggle > [type="checkbox"] {
+  @apply opacity-0 absolute left-0 top-0;
+}
+
+.toggle > label {
+  @apply pl-10 cursor-pointer;
+}
+
+.toggle > label::before {
+  content: "";
+
+  @apply w-8 h-4 rounded-full bg-gray4 bg-opacity-50 left-0 absolute;
+  @apply transition-colors duration-100;
+  @apply top-1/2 transform -translate-y-1/2;
+}
+
+.toggle > label:hover::before {
+  @apply bg-gray3 bg-opacity-50;
+}
+
+.toggle > label::after {
+  content: "";
+
+  @apply rounded-full bg-white absolute;
+  width: calc(theme('width.4') - 4px);
+  height: calc(theme('width.4') - 4px);
+  left: 2px;
+
+  @apply transition-transform duration-100;
+  @apply top-1/2 transform -translate-y-1/2;
+
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 1px 1px rgba(16, 22, 26, 0.2);
+}
+
+.toggle > [type="checkbox"]:checked ~ label::before {
+  @apply bg-blue3;
+}
+
+.toggle > [type="checkbox"]:checked ~ label::after {
+  @apply translate-x-4;
+}
+
 .status-badge {
   @apply px-2 ml-2 text-xs text-white rounded-sm;
   padding-top: 0.125rem;
@@ -136,6 +182,10 @@ a:hover {
 
 .text-shadow-sm {
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.text-shadow-none {
+  text-shadow: none;
 }
 
 .drop-shadow-sm {

--- a/server/assets/js/filter.js
+++ b/server/assets/js/filter.js
@@ -1,0 +1,29 @@
+(function() {
+  const hidden = [];
+
+  function toggleFilter(evt) {
+    const enabled = evt.target.checked;
+    if (enabled) {
+      document
+        .querySelectorAll('[data-status="skipped"]')
+        .forEach(elem => {
+          hidden.push({
+            element: elem,
+            parent: elem.parentElement,
+            before: elem.nextSibling,
+          });
+          elem.remove();
+        });
+    } else {
+      while (hidden.length) {
+        const { element, parent, before } = hidden.pop();
+        parent.insertBefore(element, before);
+      }
+    }
+  }
+
+  const toggle = document.getElementById('filter-toggle');
+  if (toggle) {
+    toggle.addEventListener('change', toggleFilter);
+  }
+})();

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -1,6 +1,10 @@
 {{/* templatetree:extends page.html.tmpl */}}
 {{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
 
+{{define "scripts"}}
+<script defer src="/static/js/filter.js"></script>
+{{end}}
+
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
 {{define "body"}}
   <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">
@@ -24,9 +28,17 @@
     </div>
   {{else}}
     {{ $s := (or (and .Result.Error "error") (.Result.Status | print)) }}
-    <div class="status-banner {{$s}}">
-      <h2 class="mb-1 text-lg font-bold">Status: {{$s | titlecase}}</h2>
-      <p>{{or .Result.Error .Result.Description}}</p>
+    <div class="status-banner {{$s}} flex flex-wrap items-center justify-between">
+      <div>
+        <h2 class="mb-1 text-lg font-bold">Status: {{$s | titlecase}}</h2>
+        <p>{{or .Result.Error .Result.Description}}</p>
+      </div>
+      <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
+        <div class="toggle">
+            <input id="filter-toggle" type="checkbox" />
+            <label for="filter-toggle">Hide skipped rules</label>
+        </div>
+      </div>
     </div>
     <div class="pl-8 overflow-auto flex-grow">
       <ul class="tree px-4 pb-4">
@@ -38,7 +50,7 @@
 
 {{define "result"}}
 {{ $s := (or (and .Error "error") (.Status | print)) }}
-<li>
+<li data-status="{{$s}}">
   <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
     {{template "result-details" .}}
   </div>

--- a/server/templates/page.html.tmpl
+++ b/server/templates/page.html.tmpl
@@ -8,6 +8,7 @@
 
     <link rel="icon" href="/static/img/favicon.ico" />
     <link rel="stylesheet" href="/static/css/main.css">
+    {{block "scripts" .}}{{end}}
   </head>
   <body class="{{block "body-class" .}}bg-light-gray5 text-dark-gray1{{end}}">
     {{block "body" .}}{{end}}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -100,7 +100,7 @@ module.exports = {
     },
     boxShadow: {
       // blueprintjs elevation levels
-      // 0 -> xs, 1 -> sm, 2 -> default, 3 - lg, 4 -> xl
+      // 0 -> xs, 1 -> sm, 2 -> default, 3 -> lg, 4 -> xl
       'xs': '0 0 0 1px rgba(16,22,26, 0.15), 0 0 0 rgba(16,22,26, 0), 0 0 0 rgba(16,22,26, 0)',
       'sm': '0 0 0 1px rgba(16,22,26, 0.1), 0 0 0 rgba(16,22,26, 0), 0 1px 1px rgba(16,22,26, 0.2)',
       'default': '0 0 0 1px rgba(16,22,26, 0.1), 0 1px 1px rgba(16,22,26, 0.2), 0 2px 6px rgba(16,22,26, 0.2)',
@@ -111,6 +111,11 @@ module.exports = {
       'inner': 'inset 0 2px 4px 0 rgba(0,0,0,0.06)',
       'outline': '0 0 0 3px rgba(52,144,220,0.5)',
       'none': 'none',
+    },
+    extend: {
+      inset: {
+        '1/2': '50%',
+      },
     },
   },
   corePlugins: {


### PR DESCRIPTION
This makes it easier to see what is actually required in policies with a lot of rules. This also introduces JS to the UI, but since it's a small file for now, I chose not to add any linting, build, or minification tools.

<img width="852" alt="policy-bot-skipped-filter" src="https://user-images.githubusercontent.com/1745813/91606999-07f9da80-e928-11ea-86e2-e3652d7ba5da.png">

Closes #224.