### PR TITLE
Fix jitter when toggling skipped filter

### DIFF
--- a/server/assets/css/main.css
+++ b/server/assets/css/main.css
@@ -32,14 +32,15 @@ a:hover {
   @apply block;
   @apply absolute left-0 top-0;
 
-  @apply w-8;
-  height: 2.2rem; /* pt-4 (li) + 1.20 (positioning) */
+  width: calc(theme('width.8') + 1px);
+  height: calc(theme('padding.4') + 1.2rem); /* 1.2 rem is arbitrary, for alignment */
+  margin-left: -1px; /* make border align with parent's border */
 
   @apply border-b border-gray5;
 }
 
 .tree > li:last-child {
-  border-left: none;
+  border-left-color: transparent;
 }
 
 .tree > li:last-child:before {

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -35,7 +35,7 @@
       </div>
       <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
         <div class="toggle">
-            <input id="filter-toggle" type="checkbox" />
+            <input id="filter-toggle" type="checkbox" autocomplete="off" />
             <label for="filter-toggle">Hide skipped rules</label>
         </div>
       </div>


### PR DESCRIPTION
All elements were shifting by a pixel due to changes in the left border.
Also add the autocomplete property to prevent Firefox from saving the
value across page loads, since the filtering happens on interaction.