### PR TITLE
Fix author value for bot-authored pull requests

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -165,7 +165,7 @@ func (ghc *GitHubContext) Number() int {
 }
 
 func (ghc *GitHubContext) Author() string {
-	return ghc.pr.Author.Login
+	return ghc.pr.Author.GetV3Login()
 }
 
 func (ghc *GitHubContext) HeadSHA() string {


### PR DESCRIPTION
The v3 API includes the '[bot]' suffix, while the v4 API does not. Depending on how the context was created, the object may have come from either API, so we need the helper function to standardize the value.

This might fix the bug in #230, but we'd have to backport to a 1.17.x release branch to test it out.