### PR TITLE
Load app name from GitHub dynamically

### DIFF
--- a/godel/config/check-plugin.yml
+++ b/godel/config/check-plugin.yml
@@ -3,3 +3,4 @@ checks:
     filters:
     - value: should have comment or be unexported
     - value: or a comment on this block
+    - value: don't use underscores in Go names; struct field Deprecated_

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -36,7 +36,6 @@ import (
 const (
 	DefaultPolicyPath         = ".policy.yml"
 	DefaultStatusCheckContext = "policy-bot"
-	DefaultAppName            = "policy-bot"
 
 	LogKeyGitHubSHA = "github_sha"
 )
@@ -45,13 +44,14 @@ type Base struct {
 	githubapp.ClientCreator
 
 	Installations githubapp.InstallationsService
-	PullOpts      *PullEvaluationOptions
 	ConfigFetcher *ConfigFetcher
 	BaseConfig    *baseapp.HTTPConfig
+	PullOpts      *PullEvaluationOptions
+
+	AppName string
 }
 
 type PullEvaluationOptions struct {
-	AppName    string `yaml:"app_name"`
 	PolicyPath string `yaml:"policy_path"`
 
 	// StatusCheckContext will be used to create the status context. It will be used in the following
@@ -62,6 +62,12 @@ type PullEvaluationOptions struct {
 	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
 	// context behaviour, and will be removed in 2.0
 	PostInsecureStatusChecks bool `yaml:"post_insecure_status_checks"`
+
+	// This field is unused but is left to avoid breaking configuration files:
+	// yaml.UnmarshalStrict returns an error for unmapped fields
+	//
+	// TODO(bkeyes): remove in version 2.0
+	Deprecated_AppName string `yaml:"app_name"`
 }
 
 func (p *PullEvaluationOptions) FillDefaults() {
@@ -71,10 +77,6 @@ func (p *PullEvaluationOptions) FillDefaults() {
 
 	if p.StatusCheckContext == "" {
 		p.StatusCheckContext = DefaultStatusCheckContext
-	}
-
-	if p.AppName == "" {
-		p.AppName = DefaultAppName
 	}
 }
 

--- a/server/handler/index.go
+++ b/server/handler/index.go
@@ -38,7 +38,7 @@ func (h *Index) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 		PolicyPath string
 	}
 
-	data.AppName = h.PullOpts.AppName
+	data.AppName = h.AppName
 	data.Version = version.GetVersion()
 	data.GitHubURL = h.GithubConfig.WebURL
 	data.PolicyPath = h.PullOpts.PolicyPath

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -67,7 +67,7 @@ func (h *Status) processOwn(ctx context.Context, event github.StatusEvent) error
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
 	sender := event.GetSender()
 
-	if sender.GetLogin() == h.PullOpts.AppName+"[bot]" {
+	if sender.GetLogin() == h.AppName+"[bot]" {
 		return nil
 	}
 


### PR DESCRIPTION
The 'options.app_name' server configuration value is now deprecated and ignored. The struct field is still defined to avoid breaking configuration when using UnmarshalStrict.

Fixes #207.