### PR TITLE
Fix post-login redirect without a saved path

### DIFF
--- a/server/handler/login.go
+++ b/server/handler/login.go
@@ -32,7 +32,7 @@ const (
 	SessionKeyRedirect = "redirect"
 )
 
-func Login(c githubapp.Config, sessions *scs.Manager) oauth2.LoginCallback {
+func Login(c githubapp.Config, basePath string, sessions *scs.Manager) oauth2.LoginCallback {
 	return func(w http.ResponseWriter, r *http.Request, login *oauth2.Login) {
 		client := github.NewClient(login.Client)
 
@@ -62,6 +62,9 @@ func Login(c githubapp.Config, sessions *scs.Manager) oauth2.LoginCallback {
 		if err != nil {
 			hatpear.Store(r, errors.Wrap(err, "failed to read session"))
 			return
+		}
+		if target == "" {
+			target = basePath + "/"
 		}
 
 		http.Redirect(w, r, target, http.StatusFound)

--- a/server/server.go
+++ b/server/server.go
@@ -186,7 +186,7 @@ func New(c *Config) (*Server, error) {
 		oauth2.WithStore(&oauth2.SessionStateStore{
 			Sessions: sessions,
 		}),
-		oauth2.OnLogin(handler.Login(c.Github, sessions)),
+		oauth2.OnLogin(handler.Login(c.Github, basePath, sessions)),
 	))
 
 	// additional client routes


### PR DESCRIPTION
Normally, the session contains a redirect target containing the path you
visited before being redirected to authenticate. In some cases, it's
possible to end up at the login page without a target in the session,
which should redirect you to the base path. Unfortunately, we used the
empty string, which redirected to an unmapped route.

Fixes #237.