### PR TITLE
Add from_branch predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ if:
   targets_branch:
     pattern: "^(master|regexPattern)$"
 
+  # "from_branch" is satisfied if the source branch of the pull request
+  # matches the regular expression. Note that source branches from forks will
+  # have the pattern "repo_owner:branch_name"
+  from_branch:
+    pattern: "^(master|regexPattern)$"
+
   # "modified_lines" is satisfied if the number of lines added or deleted by
   # the pull request matches any of the listed conditions. Each expression is
   # an operator (one of '<' or '>'), an optional space, and a number.

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -28,7 +28,7 @@ type Predicates struct {
 	AuthorIsOnlyContributor *predicate.AuthorIsOnlyContributor `yaml:"author_is_only_contributor"`
 
 	TargetsBranch *predicate.TargetsBranch `yaml:"targets_branch"`
-	SourceBranch  *predicate.SourceBranch  `yaml:"source_branch"`
+	FromBranch    *predicate.FromBranch    `yaml:"from_branch"`
 
 	ModifiedLines *predicate.ModifiedLines `yaml:"modified_lines"`
 

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -63,6 +63,10 @@ func (p *Predicates) Predicates() []predicate.Predicate {
 	if p.TargetsBranch != nil {
 		ps = append(ps, predicate.Predicate(p.TargetsBranch))
 	}
+	if p.FromBranch != nil {
+		ps = append(ps, predicate.Predicate(p.FromBranch))
+	}
+
 	if p.ModifiedLines != nil {
 		ps = append(ps, predicate.Predicate(p.ModifiedLines))
 	}

--- a/policy/approval/predicate.go
+++ b/policy/approval/predicate.go
@@ -28,6 +28,7 @@ type Predicates struct {
 	AuthorIsOnlyContributor *predicate.AuthorIsOnlyContributor `yaml:"author_is_only_contributor"`
 
 	TargetsBranch *predicate.TargetsBranch `yaml:"targets_branch"`
+	SourceBranch  *predicate.SourceBranch  `yaml:"source_branch"`
 
 	ModifiedLines *predicate.ModifiedLines `yaml:"modified_lines"`
 

--- a/policy/predicate/branch.go
+++ b/policy/predicate/branch.go
@@ -39,3 +39,21 @@ func (pred *TargetsBranch) Evaluate(ctx context.Context, prctx pull.Context) (bo
 
 	return matches, desc, nil
 }
+
+type SourceBranch struct {
+	Pattern common.Regexp `yaml:"pattern"`
+}
+
+var _ Predicate = &SourceBranch{}
+
+func (pred *SourceBranch) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
+	_, sourceBranchName := prctx.Branches()
+	matches := pred.Pattern.Matches(sourceBranchName)
+
+	desc := ""
+	if !matches {
+		desc = fmt.Sprintf("Source branch %q does not match required pattern %q", sourceBranchName, pred.Pattern)
+	}
+
+	return matches, desc, nil
+}

--- a/policy/predicate/branch.go
+++ b/policy/predicate/branch.go
@@ -40,19 +40,19 @@ func (pred *TargetsBranch) Evaluate(ctx context.Context, prctx pull.Context) (bo
 	return matches, desc, nil
 }
 
-type SourceBranch struct {
+type FromBranch struct {
 	Pattern common.Regexp `yaml:"pattern"`
 }
 
-var _ Predicate = &SourceBranch{}
+var _ Predicate = &FromBranch{}
 
-func (pred *SourceBranch) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
+func (pred *FromBranch) Evaluate(ctx context.Context, prctx pull.Context) (bool, string, error) {
 	_, sourceBranchName := prctx.Branches()
 	matches := pred.Pattern.Matches(sourceBranchName)
 
 	desc := ""
 	if !matches {
-		desc = fmt.Sprintf("Source branch %q does not match required pattern %q", sourceBranchName, pred.Pattern)
+		desc = fmt.Sprintf("Source branch %q does not match specified from_branch pattern %q", sourceBranchName, pred.Pattern)
 	}
 
 	return matches, desc, nil

--- a/policy/predicate/branch_test.go
+++ b/policy/predicate/branch_test.go
@@ -103,6 +103,34 @@ func TestTargetsBranch(t *testing.T) {
 			},
 		},
 	})
+
+	pSourceMaster := &SourceBranch{
+		Pattern: common.NewCompiledRegexp(regexp.MustCompile("^master$")),
+	}
+
+	runTargetsTestCase(t, pSourceMaster, []targetsTestCase{
+		{
+			"simple match - master",
+			true,
+			&pulltest.Context{
+				BranchHeadName: "master",
+			},
+		},
+		{
+			"simple non match",
+			false,
+			&pulltest.Context{
+				BranchHeadName: "another-branch",
+			},
+		},
+		{
+			"tests anchoring",
+			false,
+			&pulltest.Context{
+				BranchHeadName: "not-master",
+			},
+		},
+	})
 }
 
 // TODO: generalize this and use it all our test cases

--- a/policy/predicate/branch_test.go
+++ b/policy/predicate/branch_test.go
@@ -92,28 +92,28 @@ func runBranchesTestCase(t *testing.T, regex string, cases []branchesTestCase) {
 		targetsPredicate := &TargetsBranch{
 			Pattern: compiledRegexp,
 		}
-		sourcePredicate := &SourceBranch{
+		fromPredicate := &FromBranch{
 			Pattern: compiledRegexp,
 		}
 
 		targetsContext := &pulltest.Context{
 			BranchBaseName: tc.branchName,
 		}
-		sourceContext := &pulltest.Context{
+		fromContext := &pulltest.Context{
 			BranchHeadName: tc.branchName,
 		}
 
-		t.Run(tc.name+" targets", func(t *testing.T) {
+		t.Run(tc.name+" targets_branch", func(t *testing.T) {
 			ok, _, err := targetsPredicate.Evaluate(ctx, targetsContext)
-			if assert.NoError(t, err, "targets predicate evaluation failed") {
-				assert.Equal(t, tc.expected, ok, "targets predicate was not correct")
+			if assert.NoError(t, err, "targets_branch predicate evaluation failed") {
+				assert.Equal(t, tc.expected, ok, "targets_branch predicate was not correct")
 			}
 		})
 
-		t.Run(tc.name+" source", func(t *testing.T) {
-			ok, _, err := sourcePredicate.Evaluate(ctx, sourceContext)
-			if assert.NoError(t, err, "source predicate evaluation failed") {
-				assert.Equal(t, tc.expected, ok, "source predicate was not correct")
+		t.Run(tc.name+" from_branch", func(t *testing.T) {
+			ok, _, err := fromPredicate.Evaluate(ctx, fromContext)
+			if assert.NoError(t, err, "from_branch predicate evaluation failed") {
+				assert.Equal(t, tc.expected, ok, "from_branch predicate was not correct")
 			}
 		})
 	}

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -396,6 +396,35 @@ func TestIsOrgMember(t *testing.T) {
 	assert.Equal(t, 1, yesRule.Count, "cached membership was not used")
 }
 
+func TestBranches(t *testing.T) {
+	rp := &ResponsePlayer{}
+	ctx := makeContext(t, rp, nil)
+
+	base, head := ctx.Branches()
+	assert.Equal(t, "develop", base, "base branch was not correctly set")
+	assert.Equal(t, "test-branch", head, "head branch was not correctly set")
+}
+
+func TestCrossRepoBranches(t *testing.T) {
+	rp := &ResponsePlayer{}
+
+	// change the source repo to a forked repo
+	crossRepoPr := defaultTestPR()
+	crossRepoPr.Head.Repo = &github.Repository{
+		ID: github.Int64(12345),
+		Owner: &github.User{
+			Login: github.String("testorg2"),
+		},
+		Name: github.String("testrepofork"),
+	}
+
+	ctx := makeContext(t, rp, crossRepoPr)
+
+	base, head := ctx.Branches()
+	assert.Equal(t, "develop", base, "cross-repo base branch was not correctly set")
+	assert.Equal(t, "testorg2:test-branch", head, "cross-repo head branch was not correctly set")
+}
+
 func makeContext(t *testing.T, rp *ResponsePlayer, pr *github.PullRequest) Context {
 	ctx := context.Background()
 	client := github.NewClient(&http.Client{Transport: rp})


### PR DESCRIPTION
Fixes #241.

This adds a new predicate called `source_branch` that's analogous to `targets_branch`, but for the PR's source branch. I'm very open to different names for this option, but I haven't come up with something I love.

I changed the existing `targets_branch` tests to also run the patterns against the source branch. I also added tests for making sure both branches are correctly set when creating the `GitHubContext` objects.