### PR TITLE
Add support for handling review comments

### DIFF
--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -241,7 +241,7 @@ func TestComments(t *testing.T) {
 	comments, err := ctx.Comments()
 	require.NoError(t, err)
 
-	require.Len(t, comments, 2, "incorrect number of comments")
+	require.Len(t, comments, 3, "incorrect number of comments")
 	assert.Equal(t, 2, dataRule.Count, "no http request was made")
 
 	expectedTime, err := time.Parse(time.RFC3339, "2018-06-27T20:28:22Z")
@@ -255,11 +255,15 @@ func TestComments(t *testing.T) {
 	assert.Equal(t, expectedTime.Add(time.Minute), comments[1].CreatedAt)
 	assert.Equal(t, "I merge!", comments[1].Body)
 
+	assert.Equal(t, "jgiannuzzi", comments[2].Author)
+	assert.Equal(t, expectedTime.Add(10*time.Minute), comments[2].CreatedAt)
+	assert.Equal(t, "A review comment", comments[2].Body)
+
 	// verify that the commit list is cached
 	comments, err = ctx.Comments()
 	require.NoError(t, err)
 
-	require.Len(t, comments, 2, "incorrect number of comments")
+	require.Len(t, comments, 3, "incorrect number of comments")
 	assert.Equal(t, 2, dataRule.Count, "cached comments were not used")
 }
 
@@ -359,7 +363,7 @@ func TestMixedReviewCommentPaging(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, dataRule.Count, "cached values were not used")
-	assert.Len(t, comments, 2, "incorrect number of comments")
+	assert.Len(t, comments, 3, "incorrect number of comments")
 	assert.Len(t, reviews, 2, "incorrect number of reviews")
 }
 

--- a/pull/testdata/responses/pull_comments.yml
+++ b/pull/testdata/responses/pull_comments.yml
@@ -20,6 +20,22 @@
                   "createdAt": "2018-06-27T20:28:22Z"
                 }
               ]
+            },
+            "reviews": {
+              "pageInfo": {
+                "endCursor": "2",
+                "hasNextPage": true
+              },
+              "nodes": [
+                {
+                  "author": {
+                    "login": "mhaypenny"
+                  },
+                  "state": "CHANGES_REQUESTED",
+                  "body": "",
+                  "submittedAt": "2018-06-27T20:33:26Z"
+                }
+              ]
             }
           }
         }
@@ -45,6 +61,30 @@
                   },
                   "body": "I merge!",
                   "createdAt": "2018-06-27T20:29:22Z"
+                }
+              ]
+            },
+            "reviews": {
+              "pageInfo": {
+                "endCursor": "3",
+                "hasNextPage": false
+              },
+              "nodes": [
+                {
+                  "author": {
+                    "login": "bkeyes"
+                  },
+                  "state": "APPROVED",
+                  "body": "the body",
+                  "submittedAt": "2018-06-27T20:33:27Z"
+                },
+                {
+                  "author": {
+                    "login": "jgiannuzzi"
+                  },
+                  "state": "COMMENTED",
+                  "body": "A review comment",
+                  "submittedAt": "2018-06-27T20:38:22Z"
                 }
               ]
             }

--- a/pull/testdata/responses/pull_reviews.yml
+++ b/pull/testdata/responses/pull_reviews.yml
@@ -45,6 +45,14 @@
                   "state": "APPROVED",
                   "body": "the body",
                   "submittedAt": "2018-06-27T20:33:27Z"
+                },
+                {
+                  "author": {
+                    "login": "jgiannuzzi"
+                  },
+                  "state": "COMMENTED",
+                  "body": "A review comment",
+                  "submittedAt": "2018-06-27T20:38:22Z"
                 }
               ]
             }

--- a/pull/testdata/responses/pull_reviews_comments.yml
+++ b/pull/testdata/responses/pull_reviews_comments.yml
@@ -76,6 +76,14 @@
                   "state": "APPROVED",
                   "body": "the body",
                   "submittedAt": "2018-06-27T20:33:27Z"
+                },
+                {
+                  "author": {
+                    "login": "jgiannuzzi"
+                  },
+                  "state": "COMMENTED",
+                  "body": "A review comment",
+                  "submittedAt": "2018-06-27T20:38:22Z"
                 }
               ]
             }


### PR DESCRIPTION
This PR adds support for handling review comments like regular comments, thus allowing users to approve or disapprove without switching back to the "Conversation" tab of the pull request whilst reviewing the changes.

Fixes #51.