### PR TITLE
Update status check on details page evaluation

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -706,7 +706,11 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 	}
 
 	if len(commitsBySHA) > 0 {
-		return errors.Errorf("%d commits were not found while loading pushed dates", len(commitsBySHA))
+		missingSHAs := make([]string, 0, len(commitsBySHA))
+		for sha := range commitsBySHA {
+			missingSHAs = append(missingSHAs, sha)
+		}
+		return errors.Errorf("%d commits were not found while loading pushed dates. Missing: %s", len(commitsBySHA), strings.Join(missingSHAs, ", "))
 	}
 	return nil
 }

--- a/pull/github.go
+++ b/pull/github.go
@@ -16,6 +16,7 @@ package pull
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -44,6 +45,14 @@ type Locator struct {
 	Number int
 
 	Value *github.PullRequest
+}
+
+type TemporaryError struct{
+	error string
+}
+
+func (te *TemporaryError) Error() string {
+	return te.error
 }
 
 // IsComplete returns true if the locator contains a pull request object with
@@ -710,8 +719,10 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		for sha := range commitsBySHA {
 			missingSHAs = append(missingSHAs, sha)
 		}
-		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s. This may be temporary. Wait 30 seconds, and refresh this page to re-evaluate.",
-			len(commitsBySHA), strings.Join(missingSHAs, ", "))
+
+		err := &TemporaryError{fmt.Sprintf("%d commits were not found while loading pushed dates. Missing %s.",
+			len(commitsBySHA), strings.Join(missingSHAs, ", "))}
+		return err
 	}
 	return nil
 }

--- a/pull/github.go
+++ b/pull/github.go
@@ -710,7 +710,8 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		for sha := range commitsBySHA {
 			missingSHAs = append(missingSHAs, sha)
 		}
-		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s", len(commitsBySHA), strings.Join(missingSHAs, ", "))
+		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s. This may be temporary. Wait, and refresh this page to re-evaluate.",
+			len(commitsBySHA), strings.Join(missingSHAs, ", "))
 	}
 	return nil
 }

--- a/pull/github.go
+++ b/pull/github.go
@@ -710,7 +710,7 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		for sha := range commitsBySHA {
 			missingSHAs = append(missingSHAs, sha)
 		}
-		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s. This may be temporary. Wait, and refresh this page to re-evaluate.",
+		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s. This may be temporary. Wait 30 seconds, and refresh this page to re-evaluate.",
 			len(commitsBySHA), strings.Join(missingSHAs, ", "))
 	}
 	return nil

--- a/pull/github.go
+++ b/pull/github.go
@@ -710,7 +710,7 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		for sha := range commitsBySHA {
 			missingSHAs = append(missingSHAs, sha)
 		}
-		return errors.Errorf("%d commits were not found while loading pushed dates. Missing: %s", len(commitsBySHA), strings.Join(missingSHAs, ", "))
+		return errors.Errorf("%d commits were not found while loading pushed dates. Missing %s", len(commitsBySHA), strings.Join(missingSHAs, ", "))
 	}
 	return nil
 }

--- a/pull/github.go
+++ b/pull/github.go
@@ -617,7 +617,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 	// In the second case, retrying after a delay can fix things, but the delay
 	// can be 15+ seconds in practice, so using the alternate API should
 	// improve latency at the cost of more API requests.
-	if head.PushedAt == nil {
+	//if head.PushedAt == nil {
 		log.Debug().
 			Bool("fork", ghc.pr.IsCrossRepository).
 			Msgf("failed to load pushed date via pull request, falling back to commit APIs")
@@ -625,7 +625,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 		if err := ghc.loadPushedAt(commits); err != nil {
 			return nil, err
 		}
-	}
+	//}
 
 	if head.PushedAt == nil {
 		return nil, errors.Errorf("head commit %.10s is missing pushed date; this is probably a bug", ghc.pr.HeadRefOID)
@@ -670,49 +670,49 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		commitsBySHA[c.SHA] = c
 	}
 
-	var q struct {
-		Repository struct {
-			Object struct {
-				Commit struct {
-					History struct {
-						PageInfo v4PageInfo
-						Nodes    []struct {
-							OID        string
-							PushedDate *time.Time
-						}
-					} `graphql:"history(first: 100, after: $cursor)"`
-				} `graphql:"... on Commit"`
-			} `graphql:"object(oid: $oid)"`
-		} `graphql:"repository(owner: $owner, name: $name)"`
-	}
-	qvars := map[string]interface{}{
-		"owner":  githubv4.String(ghc.pr.HeadRepository.Owner.Login),
-		"name":   githubv4.String(ghc.pr.HeadRepository.Name),
-		"oid":    githubv4.GitObjectID(ghc.pr.HeadRefOID),
-		"cursor": (*githubv4.String)(nil),
-	}
-
-	loaded := 0
-	for {
-		if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {
-			return errors.Wrap(err, "failed to load commit pushed dates")
-		}
-		for _, n := range q.Repository.Object.Commit.History.Nodes {
-			if c, ok := commitsBySHA[n.OID]; ok {
-				c.PushedAt = n.PushedDate
-				delete(commitsBySHA, n.OID)
-			}
-		}
-
-		loaded += len(q.Repository.Object.Commit.History.Nodes)
-		if loaded > len(commits) {
-			break
-		}
-
-		if !q.Repository.Object.Commit.History.PageInfo.UpdateCursor(qvars, "cursor") {
-			break
-		}
-	}
+	//var q struct {
+	//	Repository struct {
+	//		Object struct {
+	//			Commit struct {
+	//				History struct {
+	//					PageInfo v4PageInfo
+	//					Nodes    []struct {
+	//						OID        string
+	//						PushedDate *time.Time
+	//					}
+	//				} `graphql:"history(first: 100, after: $cursor)"`
+	//			} `graphql:"... on Commit"`
+	//		} `graphql:"object(oid: $oid)"`
+	//	} `graphql:"repository(owner: $owner, name: $name)"`
+	//}
+	//qvars := map[string]interface{}{
+	//	"owner":  githubv4.String(ghc.pr.HeadRepository.Owner.Login),
+	//	"name":   githubv4.String(ghc.pr.HeadRepository.Name),
+	//	"oid":    githubv4.GitObjectID(ghc.pr.HeadRefOID),
+	//	"cursor": (*githubv4.String)(nil),
+	//}
+	//
+	//loaded := 0
+	//for {
+	//	if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {
+	//		return errors.Wrap(err, "failed to load commit pushed dates")
+	//	}
+	//	for _, n := range q.Repository.Object.Commit.History.Nodes {
+	//		if c, ok := commitsBySHA[n.OID]; ok {
+	//			c.PushedAt = n.PushedDate
+	//			delete(commitsBySHA, n.OID)
+	//		}
+	//	}
+	//
+	//	loaded += len(q.Repository.Object.Commit.History.Nodes)
+	//	if loaded > len(commits) {
+	//		break
+	//	}
+	//
+	//	if !q.Repository.Object.Commit.History.PageInfo.UpdateCursor(qvars, "cursor") {
+	//		break
+	//	}
+	//}
 
 	if len(commitsBySHA) > 0 {
 		missingSHAs := make([]string, 0, len(commitsBySHA))

--- a/pull/github.go
+++ b/pull/github.go
@@ -47,7 +47,7 @@ type Locator struct {
 	Value *github.PullRequest
 }
 
-type TemporaryError struct{
+type TemporaryError struct {
 	error string
 }
 

--- a/pull/github.go
+++ b/pull/github.go
@@ -617,7 +617,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 	// In the second case, retrying after a delay can fix things, but the delay
 	// can be 15+ seconds in practice, so using the alternate API should
 	// improve latency at the cost of more API requests.
-	//if head.PushedAt == nil {
+	if head.PushedAt == nil {
 		log.Debug().
 			Bool("fork", ghc.pr.IsCrossRepository).
 			Msgf("failed to load pushed date via pull request, falling back to commit APIs")
@@ -625,7 +625,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 		if err := ghc.loadPushedAt(commits); err != nil {
 			return nil, err
 		}
-	//}
+	}
 
 	if head.PushedAt == nil {
 		return nil, errors.Errorf("head commit %.10s is missing pushed date; this is probably a bug", ghc.pr.HeadRefOID)
@@ -670,49 +670,49 @@ func (ghc *GitHubContext) loadPushedAt(commits []*Commit) error {
 		commitsBySHA[c.SHA] = c
 	}
 
-	//var q struct {
-	//	Repository struct {
-	//		Object struct {
-	//			Commit struct {
-	//				History struct {
-	//					PageInfo v4PageInfo
-	//					Nodes    []struct {
-	//						OID        string
-	//						PushedDate *time.Time
-	//					}
-	//				} `graphql:"history(first: 100, after: $cursor)"`
-	//			} `graphql:"... on Commit"`
-	//		} `graphql:"object(oid: $oid)"`
-	//	} `graphql:"repository(owner: $owner, name: $name)"`
-	//}
-	//qvars := map[string]interface{}{
-	//	"owner":  githubv4.String(ghc.pr.HeadRepository.Owner.Login),
-	//	"name":   githubv4.String(ghc.pr.HeadRepository.Name),
-	//	"oid":    githubv4.GitObjectID(ghc.pr.HeadRefOID),
-	//	"cursor": (*githubv4.String)(nil),
-	//}
-	//
-	//loaded := 0
-	//for {
-	//	if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {
-	//		return errors.Wrap(err, "failed to load commit pushed dates")
-	//	}
-	//	for _, n := range q.Repository.Object.Commit.History.Nodes {
-	//		if c, ok := commitsBySHA[n.OID]; ok {
-	//			c.PushedAt = n.PushedDate
-	//			delete(commitsBySHA, n.OID)
-	//		}
-	//	}
-	//
-	//	loaded += len(q.Repository.Object.Commit.History.Nodes)
-	//	if loaded > len(commits) {
-	//		break
-	//	}
-	//
-	//	if !q.Repository.Object.Commit.History.PageInfo.UpdateCursor(qvars, "cursor") {
-	//		break
-	//	}
-	//}
+	var q struct {
+		Repository struct {
+			Object struct {
+				Commit struct {
+					History struct {
+						PageInfo v4PageInfo
+						Nodes    []struct {
+							OID        string
+							PushedDate *time.Time
+						}
+					} `graphql:"history(first: 100, after: $cursor)"`
+				} `graphql:"... on Commit"`
+			} `graphql:"object(oid: $oid)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+	qvars := map[string]interface{}{
+		"owner":  githubv4.String(ghc.pr.HeadRepository.Owner.Login),
+		"name":   githubv4.String(ghc.pr.HeadRepository.Name),
+		"oid":    githubv4.GitObjectID(ghc.pr.HeadRefOID),
+		"cursor": (*githubv4.String)(nil),
+	}
+
+	loaded := 0
+	for {
+		if err := ghc.v4client.Query(ghc.ctx, &q, qvars); err != nil {
+			return errors.Wrap(err, "failed to load commit pushed dates")
+		}
+		for _, n := range q.Repository.Object.Commit.History.Nodes {
+			if c, ok := commitsBySHA[n.OID]; ok {
+				c.PushedAt = n.PushedDate
+				delete(commitsBySHA, n.OID)
+			}
+		}
+
+		loaded += len(q.Repository.Object.Commit.History.Nodes)
+		if loaded > len(commits) {
+			break
+		}
+
+		if !q.Repository.Object.Commit.History.PageInfo.UpdateCursor(qvars, "cursor") {
+			break
+		}
+	}
 
 	if len(commitsBySHA) > 0 {
 		missingSHAs := make([]string, 0, len(commitsBySHA))

--- a/server/assets/css/main.css
+++ b/server/assets/css/main.css
@@ -129,6 +129,8 @@ a:hover {
 .status-banner.skipped { @apply bg-gray3 border-gray2; }
 .status-banner.error { @apply bg-red3 border-red2; }
 
+.status-temporary { @apply rounded bg-red1 p-3 mt-4 inline-block }
+
 .status-stripe {
   @apply border-l-8;
 }

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -146,7 +146,7 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 
 	fetchedConfig, err := b.ConfigFetcher.ConfigForPR(ctx, prctx, client)
 	if err != nil {
-		return errors.WithMessage(err, fmt.Sprintf("failed to fetch policy: %s", fetchedConfig))
+		return errors.WithMessage(err, fmt.Sprintf("Failed to fetch configuration: %s", fetchedConfig))
 	}
 
 	return b.EvaluateFetchedConfig(ctx, prctx, client, fetchedConfig, trigger)
@@ -204,7 +204,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 		statusState = "error"
 		statusDescription = "All rules were skipped. At least one rule must match."
 	default:
-		return errors.Errorf("evaluation resulted in unexpected state: %s", result.Status)
+		return errors.Errorf("Evaluation resulted in unexpected status: %s", result.Status)
 	}
 
 	if err := b.PostStatus(ctx, prctx, client, statusState, statusDescription); err != nil {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -100,6 +100,7 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
+		errors.Wrap(err, "unable to post repo status")
 		logger.Err(err)
 		return
 	}
@@ -107,6 +108,7 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	if b.PullOpts.PostInsecureStatusChecks {
 		status.Context = &b.PullOpts.StatusCheckContext
 		if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
+			errors.Wrap(err, "unable to post repo status with StatusCheckContext")
 			logger.Err(err)
 		}
 	}
@@ -183,7 +185,7 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 		logger.Warn().Err(fetchedConfig.Error).Msg(fetchedConfig.Description())
 		b.PostStatus(ctx, prctx, client, "error", fetchedConfig.Description())
 
-		return nil, errors.WithMessage(fetchedConfig.Error, fetchedConfig.Description())
+		return nil, errors.Wrap(fetchedConfig.Error, fetchedConfig.Description())
 	}
 
 	evaluator, err := policy.ParsePolicy(fetchedConfig.Config)
@@ -193,7 +195,7 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 		logger.Warn().Err(err).Msg(statusMessage)
 		b.PostStatus(ctx, prctx, client, "error", statusMessage)
 
-		return nil, errors.WithMessage(err, statusMessage)
+		return nil, errors.Wrap(err, statusMessage)
 	}
 
 	policyTrigger := evaluator.Trigger()

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -249,18 +249,16 @@ func (b *Base) PostStatusForResult(ctx context.Context, prctx pull.Context, clie
 func (b *Base) RequestReviewsForResult(ctx context.Context, prctx pull.Context, client *github.Client, result common.Result) error {
 	logger := zerolog.Ctx(ctx)
 
-	if prctx.IsDraft() {
+	if prctx.IsDraft() || result.Status != common.StatusPending{
 		return nil
 	}
 
-	if result.Status == common.StatusPending {
-		if reqs := reviewer.FindRequests(&result); len(reqs) > 0 {
-			logger.Debug().Msgf("Found %d pending rules with review requests enabled", len(reqs))
-			return b.requestReviews(ctx, prctx, client, reqs)
-		}
-		logger.Debug().Msgf("No pending rules have review requests enabled, skipping reviewer assignment")
+	if reqs := reviewer.FindRequests(&result); len(reqs) > 0 {
+		logger.Debug().Msgf("Found %d pending rules with review requests enabled", len(reqs))
+		return b.requestReviews(ctx, prctx, client, reqs)
 	}
 
+	logger.Debug().Msgf("No pending rules have review requests enabled, skipping reviewer assignment")
 	return nil
 }
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -166,7 +166,7 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 	if err != nil {
 		return err
 	}
-	
+
 	return b.RequestReviewsForResult(ctx, prctx, client, result)
 }
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -194,7 +194,7 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	if err != nil {
 		statusMessage := fmt.Sprintf("Unable to parse policy defined by %s", fetchedConfig)
 		logger.Warn().Err(err).Msg(statusMessage)
-		
+
 		b.PostStatus(ctx, prctx, client, "error", statusMessage)
 
 		return nil, errors.Wrap(err, statusMessage)
@@ -251,7 +251,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 func (b *Base) RequestReviewsForResult(ctx context.Context, prctx pull.Context, client *github.Client, result common.Result) error {
 	logger := zerolog.Ctx(ctx)
 
-	if prctx.IsDraft() || result.Status != common.StatusPending{
+	if prctx.IsDraft() || result.Status != common.StatusPending {
 		return nil
 	}
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -218,14 +218,6 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 		return result, result.Error
 	}
 
-	if err := b.PostStatusForResult(ctx, prctx, client, result); err != nil {
-		return result, err
-	}
-
-	return result, nil
-}
-
-func (b *Base) PostStatusForResult(ctx context.Context, prctx pull.Context, client *github.Client, result common.Result) error {
 	statusDescription := result.StatusDescription
 
 	var statusState string
@@ -240,10 +232,13 @@ func (b *Base) PostStatusForResult(ctx context.Context, prctx pull.Context, clie
 		statusState = "error"
 		statusDescription = "All rules were skipped. At least one rule must match."
 	default:
-		return errors.Errorf("Evaluation resulted in unexpected status: %s", result.Status)
+		err := errors.Errorf("Evaluation resulted in unexpected status: %s", result.Status)
+		return result, err
 	}
 
-	return b.PostStatus(ctx, prctx, client, statusState, statusDescription)
+	b.PostStatus(ctx, prctx, client, statusState, statusDescription)
+
+	return result, nil
 }
 
 func (b *Base) RequestReviewsForResult(ctx context.Context, prctx pull.Context, client *github.Client, result common.Result) error {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -183,6 +183,8 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 
 	if fetchedConfig.Invalid() {
 		statusMessage := fetchedConfig.Description()
+		logger.Warn().Err(fetchedConfig.Error).Msg(statusMessage)
+
 		b.PostStatus(ctx, prctx, client, "error", statusMessage)
 
 		return nil, errors.Wrap(fetchedConfig.Error, statusMessage)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -169,7 +169,7 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	if fetchedConfig.Missing() {
 		logger.Debug().Msg(fetchedConfig.Description())
 
-		return nil, errors.New(fetchedConfig.Description())
+		return nil, nil
 	}
 
 	if fetchedConfig.Invalid() {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -193,8 +193,8 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	evaluator, err := policy.ParsePolicy(fetchedConfig.Config)
 	if err != nil {
 		statusMessage := fmt.Sprintf("Unable to parse policy defined by %s", fetchedConfig)
-
 		logger.Warn().Err(err).Msg(statusMessage)
+		
 		b.PostStatus(ctx, prctx, client, "error", statusMessage)
 
 		return nil, errors.Wrap(err, statusMessage)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -185,7 +185,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 
 	result := evaluator.Evaluate(ctx, prctx)
 	if result.Error != nil {
-		statusMessage := fmt.Sprintf("Error evaluating policy defined by %s", fetchedConfig)
+		statusMessage := fmt.Sprintf("Error evaluating policy defined by %s. This may be temporary. Create a PR comment to try again. ", fetchedConfig)
 		logger.Warn().Err(result.Error).Msg(statusMessage)
 		err := b.PostStatus(ctx, prctx, client, "error", statusMessage)
 		return err

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -100,16 +100,14 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-		errors.Wrap(err, "unable to post repo status")
-		logger.Err(err)
+		logger.Err(errors.Wrap(err, "unable to post repo status"))
 		return
 	}
 
 	if b.PullOpts.PostInsecureStatusChecks {
 		status.Context = &b.PullOpts.StatusCheckContext
 		if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-			errors.Wrap(err, "unable to post repo status with StatusCheckContext")
-			logger.Err(err)
+			logger.Err(errors.Wrap(err, "unable to post repo status with StatusCheckContext"))
 		}
 	}
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -100,14 +100,24 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-		logger.Err(errors.Wrap(err, "unable to post repo status"))
+		logger.Err(errors.WithStack(err)).
+			Str("owner", owner).
+			Str("repo", repo).
+			Str("sha", sha).
+			Str("status", *status.State).
+			Msg("Failed to post repo status")
 		return
 	}
 
 	if b.PullOpts.PostInsecureStatusChecks {
 		status.Context = &b.PullOpts.StatusCheckContext
 		if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-			logger.Err(errors.Wrap(err, "unable to post repo status with StatusCheckContext"))
+			logger.Err(errors.WithStack(err)).
+				Str("owner", owner).
+				Str("repo", repo).
+				Str("sha", sha).
+				Str("status", *status.State).
+				Msg("Failed to post repo status with StatusCheckContext")
 		}
 	}
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -151,8 +151,12 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 
 	evaluator, err := b.ValidateFetchedConfig(ctx, prctx, client, fetchedConfig, trigger)
 
-	if evaluator == nil {
+	if err != nil {
 		return err
+	}
+
+	if evaluator == nil {
+		return nil
 	}
 
 	_, err = b.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -80,7 +80,9 @@ func (p *PullEvaluationOptions) FillDefaults() {
 	}
 }
 
-func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *github.Client, state, message string) error {
+func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *github.Client, state, message string) {
+	logger := zerolog.Ctx(ctx)
+
 	owner := prctx.RepositoryOwner()
 	repo := prctx.RepositoryName()
 	sha := prctx.HeadSHA()
@@ -98,17 +100,18 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-		return err
+		logger.Err(err)
+		return
 	}
 
 	if b.PullOpts.PostInsecureStatusChecks {
 		status.Context = &b.PullOpts.StatusCheckContext
 		if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-			return err
+			logger.Err(err)
 		}
 	}
 
-	return nil
+	return
 }
 
 func (b *Base) postGitHubRepoStatus(ctx context.Context, client *github.Client, owner, repo, ref string, status *github.RepoStatus) error {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -182,10 +182,10 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	}
 
 	if fetchedConfig.Invalid() {
-		logger.Warn().Err(fetchedConfig.Error).Msg(fetchedConfig.Description())
-		b.PostStatus(ctx, prctx, client, "error", fetchedConfig.Description())
+		statusMessage := fetchedConfig.Description()
+		b.PostStatus(ctx, prctx, client, "error", statusMessage)
 
-		return nil, errors.Wrap(fetchedConfig.Error, fetchedConfig.Description())
+		return nil, errors.Wrap(fetchedConfig.Error, statusMessage)
 	}
 
 	evaluator, err := policy.ParsePolicy(fetchedConfig.Config)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -159,8 +159,12 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 		return nil
 	}
 
-	_, err = b.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
-	return err
+	result, err := b.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
+	if err != nil {
+		return err
+	}
+	
+	return b.RequestReviewsForResult(ctx, prctx, client, result)
 }
 
 func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, fetchedConfig FetchedConfig, trigger common.Trigger) (common.Evaluator, error) {
@@ -215,10 +219,6 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	}
 
 	if err := b.PostStatusForResult(ctx, prctx, client, result); err != nil {
-		return result, err
-	}
-
-	if err := b.RequestReviewsForResult(ctx, prctx, client, result); err != nil {
 		return result, err
 	}
 

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -185,7 +185,7 @@ func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 
 	result := evaluator.Evaluate(ctx, prctx)
 	if result.Error != nil {
-		statusMessage := fmt.Sprintf("Error evaluating policy defined by %s. This may be temporary. Create a PR comment to try again. ", fetchedConfig)
+		statusMessage := fmt.Sprintf("Error evaluating policy defined by %s. This may be temporary. Create a PR comment to try again.", fetchedConfig)
 		logger.Warn().Err(result.Error).Msg(statusMessage)
 		err := b.PostStatus(ctx, prctx, client, "error", statusMessage)
 		return err

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -100,24 +100,14 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-		logger.Err(errors.WithStack(err)).
-			Str("owner", owner).
-			Str("repo", repo).
-			Str("sha", sha).
-			Str("status", *status.State).
-			Msg("Failed to post repo status")
+		logger.Err(errors.WithStack(err)).Msg("Failed to post repo status")
 		return
 	}
 
 	if b.PullOpts.PostInsecureStatusChecks {
 		status.Context = &b.PullOpts.StatusCheckContext
 		if err := b.postGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-			logger.Err(errors.WithStack(err)).
-				Str("owner", owner).
-				Str("repo", repo).
-				Str("sha", sha).
-				Str("status", *status.State).
-				Msg("Failed to post repo status with StatusCheckContext")
+			logger.Err(errors.WithStack(err)).Msg("Failed to post repo status with StatusCheckContext")
 		}
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -134,7 +134,7 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if evaluator == nil {
-		data.Error = errors.Errorf("Unable to evaluate nil evaluator: %s", config.Description())
+		data.Error = errors.Errorf("Unable to evaluate: %s", config.Description())
 		return h.render(w, data)
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -127,7 +127,14 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 
 	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, config, common.TriggerAll)
 	if evaluator == nil {
+
+	if err != nil {
 		data.Error = err
+		return h.render(w, data)
+	}
+
+	if evaluator == nil {
+		data.Error = errors.New(config.Description())
 		return h.render(w, data)
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -126,7 +126,6 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, config, common.TriggerAll)
-	if evaluator == nil {
 
 	if err != nil {
 		data.Error = err

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -133,7 +133,7 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if evaluator == nil {
-		data.Error = errors.New(config.Description())
+		data.Error = errors.Errorf("Unable to evaluate: %s", config.Description())
 		return h.render(w, data)
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -133,7 +133,7 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if evaluator == nil {
-		data.Error = errors.Errorf("Unable to evaluate: %s", config.Description())
+		data.Error = errors.Errorf("Unable to evaluate nil evaluator: %s", config.Description())
 		return h.render(w, data)
 	}
 

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -142,7 +142,7 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 
 	if err != nil {
 		if _, ok := err.(*pull.TemporaryError); ok {
-			errors.WithMessage(err, "This error may be temporary. Wait 30 seconds and refresh this page to retry")
+			err = errors.WithMessage(err, "This error may be temporary. Wait 30 seconds and refresh this page to retry")
 		}
 		data.Error = err
 	}

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -108,11 +108,12 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var data struct {
-		Error       error
-		Result      *common.Result
-		PullRequest *github.PullRequest
-		User        string
-		PolicyURL   string
+		Error            error
+		IsTemporaryError bool
+		Result           *common.Result
+		PullRequest      *github.PullRequest
+		User             string
+		PolicyURL        string
 	}
 
 	data.PullRequest = pr
@@ -141,8 +142,8 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	data.Result = &result
 
 	if err != nil {
-		if _, ok := err.(*pull.TemporaryError); ok {
-			err = errors.WithMessage(err, "This error may be temporary. Wait 30 seconds and refresh this page to retry")
+		if _, ok := errors.Cause(err).(*pull.TemporaryError); ok {
+			data.IsTemporaryError = true
 		}
 		data.Error = err
 	}

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -139,7 +139,14 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 
 	result, err := h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, config)
 	data.Result = &result
-	data.Error = err
+
+	if err != nil {
+		if _, ok := err.(*pull.TemporaryError); ok {
+			errors.WithMessage(err, "This error may be temporary. Wait 30 seconds and refresh this page to retry")
+		}
+		data.Error = err
+	}
+
 	return h.render(w, data)
 }
 

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -58,11 +58,11 @@ func (fc FetchedConfig) String() string {
 func (fc FetchedConfig) Description() string {
 	switch {
 	case fc.Missing():
-		return fmt.Sprintf("No policy found at ref=%s", fc.Ref)
+		return fmt.Sprintf("No policy found at %s", fc)
 	case fc.Invalid():
-		return fmt.Sprintf("Invalid configuration defined by ref=%s", fc.Ref)
+		return fmt.Sprintf("Invalid configuration defined by %s", fc)
 	}
-	return fmt.Sprintf("Valid policy found for ref=%s", fc.Ref)
+	return fmt.Sprintf("Valid policy found for %s", fc)
 }
 
 type ConfigFetcher struct {

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -100,7 +100,13 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 
 	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, fetchedConfig, common.TriggerComment)
 
+	if err != nil {
+		return err
+	}
+
 	if evaluator == nil {
+		return nil
+	}
 		return err
 	}
 

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -107,11 +107,13 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 	if evaluator == nil {
 		return nil
 	}
+
+	result, err := h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
+	if err != nil {
 		return err
 	}
 
-	_, err = h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
-	return err
+	return h.Base.RequestReviewsForResult(ctx, prctx, client, result)
 }
 
 func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Context, client *github.Client, event github.IssueCommentEvent, config *policy.Config) (bool, error) {

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -98,7 +98,14 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		logger.Warn().Str(LogKeyAudit, "issue_comment").Msg("Skipped tampering check because the policy is not valid")
 	}
 
-	return h.EvaluateFetchedConfig(ctx, prctx, client, fetchedConfig, common.TriggerComment)
+	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, fetchedConfig, common.TriggerComment)
+
+	if evaluator == nil {
+		return err
+	}
+
+	_, err = h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
+	return err
 }
 
 func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Context, client *github.Client, event github.IssueCommentEvent, config *policy.Config) (bool, error) {

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -24,7 +24,10 @@
   {{if .Error}}
     <div class="status-banner error">
       <h2 class="mb-1 text-lg font-bold">Error</h2>
-      <p>{{.Error}}<p>
+      <p>{{.Error}}</p>
+      {{if .IsTemporaryError}}
+          <p class="status-temporary">This error may be temporary. Wait 30 seconds and refresh this page to retry.</p>
+      {{end}}
     </div>
   {{else}}
     {{ $s := (or (and .Result.Error "error") (.Result.Status | print)) }}


### PR DESCRIPTION
This PR includes changes which enhance the user experience when commits are missing in the `GitHubContext.loadPushedAt` method. This seeks to improve situations where commits cannot be found, leading to the status check resolving to an error:
```
Error evaluating policy defined by org/project ref=branch
```
### Changes
1. Loading the details page now posts updated status checks to GitHub.
    - This allows users to troubleshoot errors related to incomplete Github API responses, a likely cause for the previously mentioned errors.
    - The details page will no longer be more "up to date" than the GitHub status.
2. The error message/log for missing commits is updated with a troubleshooting tip and a list of missing commit SHAs. 
    - The error itself is expanded: 
`Error evaluating policy defined by org/project ref=branch. Missing: <list of commits>`

    - A new temporary error troubleshooting element is added to the UI: ![Screen Shot 2021-02-08 at 12 09 50 PM](https://user-images.githubusercontent.com/930621/107275422-8e056b80-6a06-11eb-8932-5c346ebbe31c.png)

Issue reports have indicated this troubleshooting method can be successful.
