### PR TITLE
Add note to README about double quoted/plain YAML string escape characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,6 @@ Consider the following example, which allows changes to certain paths without
 review, but all other changes require review from the `palantir/devtools`.
 Any member of the `palantir` organization can also disapprove changes.
 
-#### Notes on YAML Syntax
-The YAML language specification supports flow scalars (basic values like strings
-and numbers) in three formats: 
-[single-quoted](https://yaml.org/spec/1.2/spec.html#id2788097), 
-[double-quoted](https://yaml.org/spec/1.2/spec.html#id2787109), and 
-[plain](https://yaml.org/spec/1.2/spec.html#id2788859). Each support different 
-escape characters, which can cause confusion when used for regex strings 
-(which often contain the `\\` character).
-
-- Single Quoted: `'` is used as an escape character. Backslash characters do not need to be escaped.
-  e.g. `'^BREAKING CHANGE: (\w| )+$'`
-- Double Quoted: `\` is used as an escape character. Backslash characters must 
-  be escaped with a preceding `\`.
-  e.g. `"^BREAKING CHANGE: (\\w| )+$"`
-- Plain: There are no escape characters. Backslash characters do not need to be escaped.
-  e.g. `^BREAKING CHANGE: (\w| )+$`
-
 ```yaml
 # the high level policy
 policy:
@@ -105,6 +88,23 @@ approval_rules:
     requires:
       count: 0
 ```
+
+#### Notes on YAML Syntax
+The YAML language specification supports flow scalars (basic values like strings
+and numbers) in three formats:
+[single-quoted](https://yaml.org/spec/1.2/spec.html#id2788097),
+[double-quoted](https://yaml.org/spec/1.2/spec.html#id2787109), and
+[plain](https://yaml.org/spec/1.2/spec.html#id2788859). Each support different
+escape characters, which can cause confusion when used for regex strings
+(which often contain the `\\` character).
+
+- Single Quoted: `'` is used as an escape character. Backslash characters do not need to be escaped.
+  e.g. `'^BREAKING CHANGE: (\w| )+$'`
+- Double Quoted: `\` is used as an escape character. Backslash characters must
+  be escaped with a preceding `\`.
+  e.g. `"^BREAKING CHANGE: (\\w| )+$"`
+- Plain: There are no escape characters. Backslash characters do not need to be escaped.
+  e.g. `^BREAKING CHANGE: (\w| )+$`
 
 #### Remote Policy Configuration
 You can also define a remote policy by specifying a repository, path, and ref

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ and numbers) in three formats:
 [double-quoted](https://yaml.org/spec/1.2/spec.html#id2787109), and 
 [plain](https://yaml.org/spec/1.2/spec.html#id2788859). Each support different 
 escape characters, which can cause confusion when used for regex strings 
-(which often contain the \\ character).
+(which often contain the `\\` character).
 
 - Single Quoted: `'` is used as an escape character. Backslash characters do not need to be escaped.
   e.g. `'^BREAKING CHANGE: (\w| )+$'`

--- a/README.md
+++ b/README.md
@@ -205,10 +205,13 @@ if:
   # within the "not_matches" list.
   # e.g. this predicate triggers for titles including "BREAKING CHANGE" or titles
   # that are not marked as docs/style/chore changes (using conventional commits 
-  # formatting)    
+  # formatting)
+  # Note: The '\' character must be escaped in double quoted strings, and should not be
+  # escaped in plain (unquoted) strings.
   title:
     matches:
       - "^BREAKING CHANGE: (\\w| )+$"
+      - ^Update (\w| )+$
     not_matches:
       - "^(docs|style|chore): (\\w| )+$"
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ if:
   # by this rule.
   #
   # Note: Double-quote strings must escape backslashes while single/plain do not.
-  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+  # See the Notes on YAML Syntax section of this README for more information.
   changed_files:
     paths:
       - "config/.*"
@@ -155,7 +155,7 @@ if:
   # match at least one regular expression in the list.
   #
   # Note: Double-quote strings must escape backslashes while single/plain do not.
-  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+  # See the Notes on YAML Syntax section of this README for more information.
   only_changed_files:
     paths:
       - "config/.*"
@@ -195,7 +195,7 @@ if:
   # matches the regular expression
   #
   # Note: Double-quote strings must escape backslashes while single/plain do not.
-  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+  # See the Notes on YAML Syntax section of this README for more information.
   targets_branch:
     pattern: "^(master|regexPattern)$"
 
@@ -204,7 +204,7 @@ if:
   # have the pattern "repo_owner:branch_name"
   #
   # Note: Double-quote strings must escape backslashes while single/plain do not.
-  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+  # See the Notes on YAML Syntax section of this README for more information.
   from_branch:
     pattern: "^(master|regexPattern)$"
 
@@ -237,7 +237,7 @@ if:
   # formatting)
   #
   # Note: Double-quote strings must escape backslashes while single/plain do not.
-  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+  # See the Notes on YAML Syntax section of this README for more information.
   title:
     matches:
       - "^BREAKING CHANGE: (\\w| )+$"
@@ -305,7 +305,7 @@ options:
     # approval. Defaults to an empty list.
     #
     # Note: Double-quote strings must escape backslashes while single/plain do not.
-    # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
+    # See the Notes on YAML Syntax section of this README for more information.
     comment_patterns:
       - "^Signed-off by \\s+$"
     # If true, GitHub reviews can be used for approval. Default is true.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ escape characters, which can cause confusion when used for regex strings
 
 - Single Quoted: `'` is used as an escape character. Backslash characters do not need to be escaped.
   e.g. `'^BREAKING CHANGE: (\w| )+$'`
-- Double Quoted: `\\` is used as an escape character. Backslash characters must 
-  be escaped with a preceding `\\`.
+- Double Quoted: `\` is used as an escape character. Backslash characters must 
+  be escaped with a preceding `\`.
   e.g. `"^BREAKING CHANGE: (\\w| )+$"`
 - Plain: There are no escape characters. Backslash characters do not need to be escaped.
   e.g. `^BREAKING CHANGE: (\w| )+$`

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ if:
   # regular expression in the "paths" list. If the "ignore" list is present,
   # files in the pull request matching these regular expressions are ignored
   # by this rule.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
   changed_files:
     paths:
       - "config/.*"
@@ -150,6 +153,9 @@ if:
 
   # "only_changed_files" is satisfied if all files changed by the pull request
   # match at least one regular expression in the list.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
   only_changed_files:
     paths:
       - "config/.*"
@@ -187,12 +193,18 @@ if:
 
   # "targets_branch" is satisfied if the target branch of the pull request
   # matches the regular expression
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
   targets_branch:
     pattern: "^(master|regexPattern)$"
 
   # "from_branch" is satisfied if the source branch of the pull request
   # matches the regular expression. Note that source branches from forks will
   # have the pattern "repo_owner:branch_name"
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
   from_branch:
     pattern: "^(master|regexPattern)$"
 
@@ -223,12 +235,12 @@ if:
   # e.g. this predicate triggers for titles including "BREAKING CHANGE" or titles
   # that are not marked as docs/style/chore changes (using conventional commits 
   # formatting)
-  # Note: The '\' character must be escaped in double quoted strings, and should not be
-  # escaped in plain (unquoted) strings.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
   title:
     matches:
       - "^BREAKING CHANGE: (\\w| )+$"
-      - ^Update (\w| )+$
     not_matches:
       - "^(docs|style|chore): (\\w| )+$"
 
@@ -291,6 +303,9 @@ options:
       - "👍"
     # If a comment matches a regular expression in this list, it counts as
     # approval. Defaults to an empty list.
+    #
+    # Note: Double-quote strings must escape backslashes while single/plain do not.
+    # See [Notes on YAML Syntax](#notes-on-yaml-syntax) for more information.
     comment_patterns:
       - "^Signed-off by \\s+$"
     # If true, GitHub reviews can be used for approval. Default is true.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ Consider the following example, which allows changes to certain paths without
 review, but all other changes require review from the `palantir/devtools`.
 Any member of the `palantir` organization can also disapprove changes.
 
+#### Notes on YAML Syntax
+The YAML language specification supports flow scalars (basic values like strings
+and numbers) in three formats: 
+[single-quoted](https://yaml.org/spec/1.2/spec.html#id2788097), 
+[double-quoted](https://yaml.org/spec/1.2/spec.html#id2787109), and 
+[plain](https://yaml.org/spec/1.2/spec.html#id2788859). Each support different 
+escape characters, which can cause confusion when used for regex strings 
+(which often contain the \\ character).
+
+- Single Quoted: `'` is used as an escape character. Backslash characters do not need to be escaped.
+  e.g. `'^BREAKING CHANGE: (\w| )+$'`
+- Double Quoted: `\\` is used as an escape character. Backslash characters must 
+  be escaped with a preceding `\\`.
+  e.g. `"^BREAKING CHANGE: (\\w| )+$"`
+- Plain: There are no escape characters. Backslash characters do not need to be escaped.
+  e.g. `^BREAKING CHANGE: (\w| )+$`
+
 ```yaml
 # the high level policy
 policy:


### PR DESCRIPTION
Due to the way yaml is decoded, `\` characters must be escaped when used in strings with [double quotes](https://yaml.org/spec/1.2/spec.html#id2787109), but should not be escaped in [plain style](https://yaml.org/spec/1.2/spec.html#id2788859) strings without quotes.