### PR TITLE
Fix conflict between direct and inherited perms

### DIFF
--- a/policy/common/actor_test.go
+++ b/policy/common/actor_test.go
@@ -34,8 +34,18 @@ func TestIsActor(t *testing.T) {
 			"mhaypenny": {"cool-org", "regular-org"},
 		},
 		CollaboratorsValue: []*pull.Collaborator{
-			{Name: "mhaypenny", Permission: pull.PermissionAdmin},
-			{Name: "jstrawnickel", Permission: pull.PermissionWrite},
+			{
+				Name: "mhaypenny",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin},
+				},
+			},
+			{
+				Name: "jstrawnickel",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionWrite},
+				},
+			},
 		},
 	}
 

--- a/policy/reviewer/reviewer.go
+++ b/policy/reviewer/reviewer.go
@@ -249,8 +249,10 @@ func selectUserReviewers(ctx context.Context, prctx pull.Context, selection *Sel
 	if len(result.ReviewRequestRule.Permissions) > 0 {
 		logger.Debug().Msg("Selecting from collaborators by permission for review")
 		for _, c := range collaborators {
-			if c.PermissionViaRepo && requestsPermission(result, c.Permission) {
-				allUsers[c.Name] = struct{}{}
+			for _, cp := range c.Permissions {
+				if cp.ViaRepo && requestsPermission(result, cp.Permission) {
+					allUsers[c.Name] = struct{}{}
+				}
 			}
 		}
 	}

--- a/policy/reviewer/reviewer_test.go
+++ b/policy/reviewer/reviewer_test.go
@@ -373,18 +373,80 @@ func makeContext() pull.Context {
 			"review-approver":       {"everyone", "even-cooler-org"},
 		},
 		CollaboratorsValue: []*pull.Collaborator{
-			{Name: "mhaypenny", Permission: pull.PermissionAdmin},
-			{Name: "org-owner", Permission: pull.PermissionAdmin},
-			{Name: "user-team-admin", Permission: pull.PermissionAdmin, PermissionViaRepo: true},
-			{Name: "user-direct-admin", Permission: pull.PermissionAdmin, PermissionViaRepo: true},
-			{Name: "user-team-write", Permission: pull.PermissionWrite, PermissionViaRepo: true},
-			{Name: "contributor-committer", Permission: pull.PermissionWrite},
-			{Name: "contributor-author", Permission: pull.PermissionWrite},
-			{Name: "review-approver", Permission: pull.PermissionWrite},
-			{Name: "maintainer", Permission: pull.PermissionMaintain, PermissionViaRepo: true},
-			{Name: "indirect-maintainer", Permission: pull.PermissionMaintain}, // note: currently not possible in GitHub
-			{Name: "triager", Permission: pull.PermissionTriage, PermissionViaRepo: true},
-			{Name: "indirect-triager", Permission: pull.PermissionTriage}, // note: currently not possible in GitHub
+			{
+				Name: "mhaypenny",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin},
+				},
+			},
+			{
+				Name: "org-owner",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin},
+				},
+			},
+			{
+				Name: "user-team-admin",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin, ViaRepo: true},
+				},
+			},
+			{
+				Name: "user-direct-admin",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin, ViaRepo: true},
+				},
+			},
+			{
+				Name: "user-team-write",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionWrite, ViaRepo: true},
+				},
+			},
+			{
+				Name: "contributor-committer",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionWrite},
+				},
+			},
+			{
+				Name: "contributor-author",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionWrite},
+				},
+			},
+			{
+				Name: "review-approver",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionWrite},
+				},
+			},
+			{
+				Name: "maintainer",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionMaintain, ViaRepo: true},
+				},
+			},
+			{
+				// note: currently not possible in GitHub
+				Name: "indirect-maintainer",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionMaintain},
+				},
+			},
+			{
+				Name: "triager",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionTriage, ViaRepo: true},
+				},
+			},
+			{
+				// note: currently not possible in GitHub
+				Name: "indirect-triager",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionTriage},
+				},
+			},
 		},
 		TeamsValue: map[string]pull.Permission{
 			"team-write":    pull.PermissionWrite,

--- a/policy/reviewer/reviewer_test.go
+++ b/policy/reviewer/reviewer_test.go
@@ -239,9 +239,11 @@ func TestSelectReviewers_UserPermission(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, selection.Teams, 0, "policy should request no teams")
 
-	require.Len(t, selection.Users, 2, "policy should request two users")
+	require.Len(t, selection.Users, 4, "policy should request two users")
 	require.Contains(t, selection.Users, "maintainer", "maintainer selected")
 	require.Contains(t, selection.Users, "triager", "triager selected")
+	require.Contains(t, selection.Users, "org-owner-team-maintainer", "triager selected")
+	require.Contains(t, selection.Users, "direct-write-team-maintainer", "triager selected")
 }
 
 func TestSelectReviewers_TeamPermission(t *testing.T) {
@@ -445,6 +447,20 @@ func makeContext() pull.Context {
 				Name: "indirect-triager",
 				Permissions: []pull.CollaboratorPermission{
 					{Permission: pull.PermissionTriage},
+				},
+			},
+			{
+				Name: "org-owner-team-maintainer",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionAdmin, ViaRepo: false},
+					{Permission: pull.PermissionMaintain, ViaRepo: true},
+				},
+			},
+			{
+				Name: "direct-write-team-maintainer",
+				Permissions: []pull.CollaboratorPermission{
+					{Permission: pull.PermissionMaintain, ViaRepo: true},
+					{Permission: pull.PermissionWrite, ViaRepo: true},
 				},
 			},
 		},

--- a/pull/context.go
+++ b/pull/context.go
@@ -220,10 +220,23 @@ type Reviewer struct {
 }
 
 type Collaborator struct {
-	Name       string
+	Name        string
+	Permissions []CollaboratorPermission
+}
+
+func (c *Collaborator) HasExactPermission(p Permission, viaRepo bool) bool {
+	for _, cp := range c.Permissions {
+		if cp.ViaRepo == viaRepo && cp.Permission == p {
+			return true
+		}
+	}
+	return false
+}
+
+type CollaboratorPermission struct {
 	Permission Permission
 
 	// True if Permission is granted by a direct or team association with the
 	// repository. If false, the permisssion is granted by the organization.
-	PermissionViaRepo bool
+	ViaRepo bool
 }

--- a/pull/context.go
+++ b/pull/context.go
@@ -224,15 +224,6 @@ type Collaborator struct {
 	Permissions []CollaboratorPermission
 }
 
-func (c *Collaborator) HasExactPermission(p Permission, viaRepo bool) bool {
-	for _, cp := range c.Permissions {
-		if cp.ViaRepo == viaRepo && cp.Permission == p {
-			return true
-		}
-	}
-	return false
-}
-
 type CollaboratorPermission struct {
 	Permission Permission
 

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -493,7 +493,7 @@ func TestRepositoryCollaborators(t *testing.T) {
 	collaborators, err := ctx.RepositoryCollaborators()
 	require.NoError(t, err)
 
-	require.Len(t, collaborators, 6, "incorrect number of collaborators")
+	require.Len(t, collaborators, 8, "incorrect number of collaborators")
 	sort.Slice(collaborators, func(i, j int) bool { return collaborators[i].Name < collaborators[j].Name })
 
 	c0 := collaborators[0]
@@ -509,28 +509,42 @@ func TestRepositoryCollaborators(t *testing.T) {
 	}, c1.Permissions)
 
 	c2 := collaborators[2]
-	assert.Equal(t, "org-owner", c2.Name)
+	assert.Equal(t, "direct-write-team-maintain", c2.Name)
 	assert.Equal(t, []CollaboratorPermission{
-		{Permission: PermissionAdmin, ViaRepo: false},
+		{Permission: PermissionMaintain, ViaRepo: true},
+		{Permission: PermissionWrite, ViaRepo: true},
 	}, c2.Permissions)
 
 	c3 := collaborators[3]
-	assert.Equal(t, "org-read", c3.Name)
+	assert.Equal(t, "org-owner", c3.Name)
 	assert.Equal(t, []CollaboratorPermission{
-		{Permission: PermissionRead, ViaRepo: false},
+		{Permission: PermissionAdmin, ViaRepo: false},
 	}, c3.Permissions)
 
 	c4 := collaborators[4]
-	assert.Equal(t, "team-admin", c4.Name)
+	assert.Equal(t, "org-owner-team-maintain", c4.Name)
 	assert.Equal(t, []CollaboratorPermission{
-		{Permission: PermissionAdmin, ViaRepo: true},
+		{Permission: PermissionAdmin, ViaRepo: false},
+		{Permission: PermissionMaintain, ViaRepo: true},
 	}, c4.Permissions)
 
 	c5 := collaborators[5]
-	assert.Equal(t, "team-maintain", c5.Name)
+	assert.Equal(t, "org-read", c5.Name)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionRead, ViaRepo: false},
+	}, c5.Permissions)
+
+	c6 := collaborators[6]
+	assert.Equal(t, "team-admin", c6.Name)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionAdmin, ViaRepo: true},
+	}, c6.Permissions)
+
+	c7 := collaborators[7]
+	assert.Equal(t, "team-maintain", c7.Name)
 	assert.Equal(t, []CollaboratorPermission{
 		{Permission: PermissionMaintain, ViaRepo: true},
-	}, c5.Permissions)
+	}, c7.Permissions)
 }
 
 func makeContext(t *testing.T, rp *ResponsePlayer, pr *github.PullRequest) Context {

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -498,33 +498,39 @@ func TestRepositoryCollaborators(t *testing.T) {
 
 	c0 := collaborators[0]
 	assert.Equal(t, "direct-admin", c0.Name)
-	assert.Equal(t, PermissionAdmin, c0.Permission)
-	assert.Equal(t, true, c0.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionAdmin, ViaRepo: true},
+	}, c0.Permissions)
 
 	c1 := collaborators[1]
 	assert.Equal(t, "direct-triage", c1.Name)
-	assert.Equal(t, PermissionTriage, c1.Permission)
-	assert.Equal(t, true, c1.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionTriage, ViaRepo: true},
+	}, c1.Permissions)
 
 	c2 := collaborators[2]
 	assert.Equal(t, "org-owner", c2.Name)
-	assert.Equal(t, PermissionAdmin, c2.Permission)
-	assert.Equal(t, false, c2.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionAdmin, ViaRepo: false},
+	}, c2.Permissions)
 
 	c3 := collaborators[3]
 	assert.Equal(t, "org-read", c3.Name)
-	assert.Equal(t, PermissionRead, c3.Permission)
-	assert.Equal(t, false, c3.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionRead, ViaRepo: false},
+	}, c3.Permissions)
 
 	c4 := collaborators[4]
 	assert.Equal(t, "team-admin", c4.Name)
-	assert.Equal(t, PermissionAdmin, c4.Permission)
-	assert.Equal(t, true, c4.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionAdmin, ViaRepo: true},
+	}, c4.Permissions)
 
 	c5 := collaborators[5]
 	assert.Equal(t, "team-maintain", c5.Name)
-	assert.Equal(t, PermissionMaintain, c5.Permission)
-	assert.Equal(t, true, c5.PermissionViaRepo)
+	assert.Equal(t, []CollaboratorPermission{
+		{Permission: PermissionMaintain, ViaRepo: true},
+	}, c5.Permissions)
 }
 
 func makeContext(t *testing.T, rp *ResponsePlayer, pr *github.PullRequest) Context {

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -163,7 +163,7 @@ func (c *Context) CollaboratorPermission(user string) (pull.Permission, error) {
 	}
 	for _, collab := range c.CollaboratorsValue {
 		if collab.Name == user {
-			return collab.Permission, nil
+			return collab.Permissions[0].Permission, nil
 		}
 	}
 	return pull.PermissionNone, nil

--- a/pull/testdata/responses/repo_collaborators.yml
+++ b/pull/testdata/responses/repo_collaborators.yml
@@ -6,7 +6,7 @@
         "repository": {
           "direct": {
             "pageInfo": {
-              "endCursor": "2",
+              "endCursor": "3",
               "hasNextPage": false
             },
             "edges": [
@@ -15,6 +15,9 @@
               },
               {
                 "permission": "TRIAGE"
+              },
+              {
+                "permission": "WRITE"
               }
             ],
             "nodes": [
@@ -25,12 +28,16 @@
               {
                 "__typename": "User",
                 "login": "direct-triage"
+              },
+              {
+                "__typename": "User",
+                "login": "direct-write-team-maintain"
               }
             ]
           },
           "all": {
             "pageInfo": {
-              "endCursor": "3",
+              "endCursor": "4",
               "hasNextPage": true
             },
             "edges": [
@@ -39,6 +46,9 @@
               },
               {
                 "permission": "READ"
+              },
+              {
+                "permission": "ADMIN"
               },
               {
                 "permission": "ADMIN"
@@ -52,6 +62,10 @@
               {
                 "__typename": "User",
                 "login": "org-read"
+              },
+              {
+                "__typename": "User",
+                "login": "org-owner-team-maintain"
               },
               {
                 "__typename": "User",
@@ -70,7 +84,7 @@
         "repository": {
           "direct": {
             "pageInfo": {
-              "endCursor": "2",
+              "endCursor": "3",
               "hasNextPage": false
             },
             "edges": [],
@@ -78,12 +92,15 @@
           },
           "all": {
             "pageInfo": {
-              "endCursor": "6",
+              "endCursor": "8",
               "hasNextPage": false
             },
             "edges": [
               {
                 "permission": "TRIAGE"
+              },
+              {
+                "permission": "MAINTAIN"
               },
               {
                 "permission": "MAINTAIN"
@@ -96,6 +113,10 @@
               {
                 "__typename": "User",
                 "login": "direct-triage"
+              },
+              {
+                "__typename": "User",
+                "login": "direct-write-team-maintain"
               },
               {
                 "__typename": "User",

--- a/pull/testdata/responses/repo_team_members_maintainers.yml
+++ b/pull/testdata/responses/repo_team_members_maintainers.yml
@@ -4,6 +4,14 @@
       {
         "login": "team-maintain",
         "type": "User"
+      },
+      {
+        "login": "org-owner-team-maintain",
+        "type": "User"
+      },
+      {
+        "login": "direct-write-team-maintain",
+        "type": "User"
       }
     ]
 


### PR DESCRIPTION
Previously, if the aggregate permission for a collaborator was higher than a permission granted directly, the direct permission was discarded and the user would not be selected for reviews. This was particularly bad for org admins who are also members of a team with lower permissions.

In the revised model, return both the aggregate permission and additional lower permissions that are granted directly so that they may still be used for reviewer assignment. ~~However, for the approval to actually count, the rule must specify the minimum permission and all higher permissions that selected users may have.~~

~~For example, if a team has `maintain` permission and a member of the team is an org admin, that member's approval will only count if the rule requires both `admin` and `maintain` permission.~~

~~This is making me think that the `permissions` key should be interpreted as a minimum permission for approval, but as an exact list of permissions for requests. That way, you can list `maintain` and both maintainers and admins can approve but if a review is requested, it will only request people who explicitly and directly have `maintain` permission. While it sounds more complicated, I think the actual result will be less confusing - exact permissions don't make a lot of sense for approval.~~

Implemented the minimum permission approval in #298.

I still need to add some tests for the new behavior.