### PR TITLE
Use minimum permission for approval checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,11 @@ requires:
 
   # A user must have at least the minimum permission in this list for their
   # approval to count for this rule. Valid permissions are "admin", "maintain",
-  # "write", "triage", and "read". Specifying more than one permission is
-  # useful to control reviewer assignment.
+  # "write", "triage", and "read".
+  #
+  # Specifying more than one permission is only useful to control which users
+  # or teams are selected for review requests. See the documentation on review
+  # requests for details.
   permissions: ["write"]
 
   # Deprecated: use 'permissions: ["admin"]'

--- a/README.md
+++ b/README.md
@@ -343,10 +343,11 @@ requires:
   organizations: ["org1", "org2"]
   teams: ["org1/team1", "org2/team2"]
 
-  # A user must have a permission in this list for their approval to count for
-  # this rule. Valid permissions are "admin", "maintain", "write", "triage",
-  # and "read".
-  permissions: ["admin", "maintain", "write"]
+  # A user must have at least the minimum permission in this list for their
+  # approval to count for this rule. Valid permissions are "admin", "maintain",
+  # "write", "triage", and "read". Specifying more than one permission is
+  # useful to control reviewer assignment.
+  permissions: ["write"]
 
   # Deprecated: use 'permissions: ["admin"]'
   #
@@ -551,11 +552,14 @@ The set of requested reviewers will not include the author of the pull request o
 users who are not collaborators on the repository.
 
 When requesting reviews for rules that use repository permissions to select
-approvers, only users who are either direct collaborators or members of
-repository teams are eligible for review selection. For example, if a rule can
-be approved by any user with `admin` permission, only direct or team admins
-will be selected for review. Users who inherit repository `admin` permissions
-as organization owners are not selected.
+approvers, only users who are direct collaborators or members of
+repository teams are eligible for review selection. The users or their teams
+must be granted an exact permission specified in the `permissions` list of the
+rule.
+
+For example, if a rule can be approved by any user with `admin` permission,
+only direct or team admins are selected for review. Users who inherit
+repository `admin` permissions as organization owners are not selected.
 
 #### Automatically Requesting Reviewers Example
 

--- a/policy/common/actor.go
+++ b/policy/common/actor.go
@@ -94,7 +94,7 @@ func (a *Actors) IsActor(ctx context.Context, prctx pull.Context, user string) (
 	}
 
 	for _, p := range perms {
-		if userPerm == p {
+		if userPerm >= p {
 			return true, nil
 		}
 	}

--- a/policy/common/actor_test.go
+++ b/policy/common/actor_test.go
@@ -90,13 +90,13 @@ func TestIsActor(t *testing.T) {
 		a := &Actors{WriteCollaborators: true}
 
 		assertActor(t, a, "jstrawnickel")
-		assertNotActor(t, a, "mhaypenny")
+		assertActor(t, a, "mhaypenny")
 		assertNotActor(t, a, "ttest")
 	})
 
 	t.Run("permissions", func(t *testing.T) {
 		a := &Actors{
-			Permissions: []pull.Permission{pull.PermissionAdmin, pull.PermissionWrite},
+			Permissions: []pull.Permission{pull.PermissionTriage},
 		}
 
 		assertActor(t, a, "mhaypenny")


### PR DESCRIPTION
Change the 'permissions' field to accept any approval from a user with
at least the minimum permission specified in the list. This means that
for approval purposes, there is never a reason to specify more than one
permissions.

For reviewer assignment, it may be useful to specify more than one
permission to expand the set of users who are eligible for selection.
For example, this would allow selecting reviews from both admin and
maintainer teams.