### PR TITLE
Fix re-request loop for team reviewers

### DIFF
--- a/pull/context.go
+++ b/pull/context.go
@@ -202,6 +202,8 @@ type Review struct {
 	State     ReviewState
 	Body      string
 	SHA       string
+
+	Teams []string
 }
 
 type ReviewerType string

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -322,6 +322,13 @@ func (b *Base) requestReviews(ctx context.Context, prctx pull.Context, client *g
 				Type: pull.ReviewerUser,
 				Name: r.Author,
 			})
+
+			for _, team := range r.Teams {
+				reviewers = append(reviewers, &pull.Reviewer{
+					Type: pull.ReviewerTeam,
+					Name: team,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
Similar to the previous issue for users, if a user left a review on behalf
of a team, but the review did not change the rule state, policy-bot
would immediately re-requst a review from the team, leading to extra
notification noise.

Fixes #305.