### PR TITLE
Skip reviewer assignment on comment/review events

### DIFF
--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -110,7 +110,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		return err
 	}
 
-	return h.Base.RequestReviewsForResult(ctx, prctx, client, result)
+	return h.Base.RequestReviewsForResult(ctx, prctx, client, common.TriggerComment, result)
 }
 
 func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Context, client *github.Client, event github.IssueCommentEvent, config *policy.Config) bool {


### PR DESCRIPTION
With the current set of predicates, these events can never change the
set of requested reviewers or trigger a re-request so there's no reason
to do the work of computing and assigning reviewers.

This is an alternate solution to the re-request loops that I fixed by
including head commit reviews in the set of reviewers. I think the other
approach is more correct, but this doesn't hurt.

The main downside is that if we add predicates that use comments or
reviews in the future, it will be easy to forget to change this trigger
condition and it might be a while before someone reports unexpected
behavior with the new predicate and reviewer assignment.

See also #306 and #302.