### PR TITLE
Document: Teams must have explicit access

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ options:
   # see the README for more details.
   ignore_commits_by:
     users: ["bulldozer[bot]"]
-    organizatons: ["org1']
+    organizatons: ["org1"]
     teams: ["org1/team1"]
 
   # Automatically request reviewers when a Pull Request is opened
@@ -258,7 +258,9 @@ options:
     # mode modifies how reviewers are selected. `all-users` will request all users
     # who are able to approve the pending rule. `random-users` selects a small
     # set of random users based on the required count of approvals. `teams` will 
-    # request teams to review if possible. Defaults to 'random-users'.
+    # request teams to review. Teams must have explicit access defined under
+    # https://github.com/<org>/<repo>/settings/access in order to be tagged.
+    # Defaults to 'random-users'.
     mode: all-users|random-users|teams
 
   # "methods" defines how users may express approval.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ options:
     # who are able to approve the pending rule. `random-users` selects a small
     # set of random users based on the required count of approvals. `teams` will 
     # request teams to review. Teams must have explicit access defined under
-    # https://github.com/<org>/<repo>/settings/access in order to be tagged.
+    # https://github.com/<org>/<repo>/settings/access in order to be tagged,
+    # at least until https://github.com/palantir/policy-bot/issues/165 is fixed.
     # Defaults to 'random-users'.
     mode: all-users|random-users|teams
 


### PR DESCRIPTION
Took me a while to realize that policy-bot with `mode: teams` wasn't tagging my teams because they were not explicitly listed under the github Manage access tab.


https://github.com/palantir/policy-bot/issues/165#issuecomment-591961813 threw me off the scent because my `request_review` team is a subteam of a superteam that has `Write` access, however I couldn't get policy-bot to tag it until I explicitly added github permissions for that team specifically. Since this same behavior has happened to two users, it might be helpful to others to doc it, even if it's actually more permissive in some unknown situations.