### PR TITLE
Add support for shared organization policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,25 @@ UI to view the detailed approval status of any pull request.
 
 ## Configuration
 
-By default, the behavior of the bot is configured by a `.policy.yml` file at
-the root of the repository. When running your own instance of the server, a
-different file name and location can be configured. The configured name and
-location will be used instead of the default location.
+Policies are defined by a `.policy.yml` file at the root of the repository.
+You can change this path and file name when running your own instance of the
+server.
 
-- If the file does not exist, the `policy-bot` status check is not posted. This
-  means it is safe to enable `policy-bot` on all repositories in an organization.
-- The `.policy.yml` file is read from the most recent commit on the target branch
-  of each pull request.
+- The file is read from the most recent commit on the _target_ branch of each
+  pull request.
+
+- The file may contain a reference to a policy in a different repository (see
+  [Remote Policy Configuration](#remote-policy-configuration).)
+
+- If the file does not exist in the repository, `policy-bot` tries to load a
+  shared `policy.yml` file at the root of the `.github` repository in the same
+  organization. You can change this path and repository name when running your
+  own instance of the server.
+
+- If a policy does not exist in the repository or in the shared organization
+  repository, `policy-bot` does not post a status check on the pull request.
+  This means it is safe to enable `policy-bot` on all repositories in an
+  organization.
 
 ### policy.yml Specification
 
@@ -91,6 +101,7 @@ approval_rules:
 ```
 
 #### Notes on YAML Syntax
+
 The YAML language specification supports flow scalars (basic values like strings
 and numbers) in three formats:
 [single-quoted](https://yaml.org/spec/1.2/spec.html#id2788097),
@@ -108,6 +119,7 @@ escape characters, which can cause confusion when used for regex strings
   e.g. `^BREAKING CHANGE: (\w| )+$`
 
 #### Remote Policy Configuration
+
 You can also define a remote policy by specifying a repository, path, and ref
 (only repository is required). Instead of defining a `policy` key, you would
 define a `remote` key. Only 1 level of remote configuration is supported by design.

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -75,17 +75,26 @@ sessions:
   # POLICYBOT_SESSIONS_KEY environment variable.
   key: "secretsessionkey"
 
-# Options for application behavior
-options:
-  # The path within repositories to find the policy.yml file
-  policy_path: .policy.yml
-  # The context prefix for status checks created by the bot
-  status_check_context: policy-bot
+# Options for application behavior. The defaults are shown below.
+#
+# options:
+#   # The path to the policy file in a repository.
+#   policy_path: .policy.yml
+#
+#   # The name of an organization repository to look in for a shared policy if
+#   # a repository does not define a policy file.
+#   shared_repository: .github
+#
+#   # The path to the policy file in the shared organization repository.
+#   shared_policy_path: policy.yml
+#
+#   # The context prefix for status checks created by the bot.
+#   status_check_context: policy-bot
 
 # Options for locating the frontend files. By default, the server uses appropriate
 # paths for the binary distribution and Docker container. For local development,
 # uncomment this section to use the alternate paths below.
-# 
+#
 # 'static' is the file system path to the assembled CSS and JS assets.
 # 'templates' is the file system path to the Go template files.
 #

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/palantir/go-baseapp v0.2.4
-	github.com/palantir/go-githubapp v0.8.0
+	github.com/palantir/go-githubapp v0.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.18.0
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/palantir/go-baseapp v0.2.4 h1:OtF5jipUF62ZRjLMLODZ2Rq180Kaekqm4pNOUZdOfAU=
 github.com/palantir/go-baseapp v0.2.4/go.mod h1:TSsvmXBDAAu2wZJgWi1/nG+YM5xIOEsXFmLsNoGP5O4=
-github.com/palantir/go-githubapp v0.8.0 h1:CsFFCckWlS6QyjwbclqFU2lvL05MXFPc8mye/qxbre4=
-github.com/palantir/go-githubapp v0.8.0/go.mod h1:XjzQ7r4lLXwqj1MEUjmUD9xng9VYqGj3XfDYlGpqigw=
+github.com/palantir/go-githubapp v0.8.1 h1:+BBB794FIrR5OhqIM2+kMwjw0ZklV41XFlFxWWuMbIM=
+github.com/palantir/go-githubapp v0.8.1/go.mod h1:XjzQ7r4lLXwqj1MEUjmUD9xng9VYqGj3XfDYlGpqigw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -167,7 +167,6 @@ func (h *Details) render404(w http.ResponseWriter, owner, repo string, number in
 func getPolicyURL(pr *github.PullRequest, config FetchedConfig) string {
 	base := pr.GetBase().GetRepo().GetHTMLURL()
 	if u, _ := url.Parse(base); u != nil {
-		// TODO(bkeyes): this format is not guaranteed by 'go-githubapp/appconfig'
 		srcParts := strings.Split(config.Source, "@")
 		if len(srcParts) != 2 {
 			return base

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -16,194 +16,49 @@ package handler
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
 
 	"github.com/google/go-github/v37/github"
+	"github.com/palantir/go-githubapp/appconfig"
 	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/pull"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 	"gopkg.in/yaml.v2"
 )
 
 type FetchedConfig struct {
-	Owner  string
-	Repo   string
-	Ref    string
+	Config     *policy.Config
+	LoadError  error
+	ParseError error
+
+	Source string
 	Path   string
-	Config *policy.Config
-	Error  error
-}
-
-func (fc FetchedConfig) Missing() bool {
-	return fc.Config == nil && fc.Error == nil
-}
-
-func (fc FetchedConfig) Valid() bool {
-	return fc.Config != nil && fc.Error == nil
-}
-
-func (fc FetchedConfig) Invalid() bool {
-	return fc.Error != nil
-}
-
-func (fc FetchedConfig) String() string {
-	return fmt.Sprintf("%s/%s ref=%s", fc.Owner, fc.Repo, fc.Ref)
-}
-
-func (fc FetchedConfig) Description() string {
-	switch {
-	case fc.Missing():
-		return fmt.Sprintf("No policy found at %s", fc)
-	case fc.Invalid():
-		return fmt.Sprintf("Invalid configuration defined by %s", fc)
-	}
-	return fmt.Sprintf("Valid policy found for %s", fc)
 }
 
 type ConfigFetcher struct {
-	PolicyPath string
+	Loader *appconfig.Loader
 }
 
-// ConfigForPR fetches the policy configuration for a PR. It returns an error
-// only if the existence of the policy could not be determined. If the policy
-// does not exist or is invalid, the returned error is nil and the appropriate
-// fields are set on the FetchedConfig.
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) (FetchedConfig, error) {
+func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) FetchedConfig {
 	base, _ := prctx.Branches()
+
+	c, err := cf.Loader.LoadConfig(ctx, client, prctx.RepositoryOwner(), prctx.RepositoryName(), base)
 	fc := FetchedConfig{
-		Owner: prctx.RepositoryOwner(),
-		Repo:  prctx.RepositoryName(),
-		Ref:   base,
-		Path:  cf.PolicyPath,
+		Source: c.Source,
+		Path:   c.Path,
 	}
 
-	configBytes, err := cf.fetchConfig(ctx, client, fc.Owner, fc.Repo, fc.Ref)
-	if err != nil {
-		return fc, err
+	switch {
+	case err != nil:
+		fc.LoadError = err
+		return fc
+	case c.IsUndefined():
+		return fc
 	}
 
-	if configBytes == nil {
-		return fc, nil
+	var pc policy.Config
+	if err := yaml.UnmarshalStrict(c.Content, &pc); err != nil {
+		fc.ParseError = err
+	} else {
+		fc.Config = &pc
 	}
-
-	config, err := cf.unmarshalConfig(configBytes)
-	if err != nil {
-		fc.Error = err
-		return fc, nil
-	}
-
-	fc.Config = config
-	return fc, nil
-}
-
-func (cf *ConfigFetcher) fetchConfig(ctx context.Context, client *github.Client, owner, repo, ref string) ([]byte, error) {
-	logger := zerolog.Ctx(ctx)
-
-	configBytes, err := cf.fetchConfigContents(ctx, client, owner, repo, ref, cf.PolicyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var rawConfig map[string]interface{}
-	_ = yaml.Unmarshal(configBytes, &rawConfig)
-
-	if _, isRemote := rawConfig["remote"]; !isRemote {
-		logger.Debug().Msgf("Found local policy config in %s/%s@%s", owner, repo, ref)
-		return configBytes, nil
-	}
-	logger.Debug().Msgf("Found reference to remote policy in %s/%s@%s", owner, repo, ref)
-
-	var remoteConfig policy.RemoteConfig
-	if err := yaml.UnmarshalStrict(configBytes, &remoteConfig); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal reference to remote policy")
-	}
-
-	if remoteConfig.Path == "" {
-		remoteConfig.Path = cf.PolicyPath
-	}
-
-	remoteParts := strings.Split(remoteConfig.Remote, "/")
-	if len(remoteParts) != 2 {
-		return nil, errors.Errorf("failed to parse remote config location from %q", remoteConfig.Remote)
-	}
-
-	remoteOwner, remoteRepo := remoteParts[0], remoteParts[1]
-
-	remotePolicyBytes, err := cf.fetchConfigContents(ctx, client, remoteOwner, remoteRepo, remoteConfig.Ref, remoteConfig.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	return remotePolicyBytes, nil
-}
-
-// fetchConfigContents returns a nil slice if there is no policy
-func (cf *ConfigFetcher) fetchConfigContents(ctx context.Context, client *github.Client, owner, repo, ref, path string) ([]byte, error) {
-	logger := zerolog.Ctx(ctx)
-	logger.Debug().Msgf("attempting to fetch policy definition for %s/%s@%s/%s", owner, repo, ref, path)
-
-	opts := &github.RepositoryContentGetOptions{
-		Ref: ref,
-	}
-
-	file, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, opts)
-	if err != nil {
-		rerr, ok := err.(*github.ErrorResponse)
-		if ok && rerr.Response.StatusCode == http.StatusNotFound {
-			return nil, nil
-		}
-		if ok && isTooLargeError(rerr) {
-			// GetContents only supports file sizes up to 1 MB, DownloadContents supports files up to 100 MB (with an additional API call)
-			reader, _, err := client.Repositories.DownloadContents(ctx, owner, repo, path, opts)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to download content of %s/%s@%s/%s", owner, repo, ref, path)
-			}
-
-			defer func() {
-				if cerr := reader.Close(); cerr != nil {
-					logger.Error().Err(cerr).Msgf("failed to close reader for %s/%s@%s/%s", owner, repo, ref, path)
-				}
-			}()
-			downloadedContent, readErr := ioutil.ReadAll(reader)
-			if readErr != nil {
-				return nil, errors.Wrapf(readErr, "failed to read content of %s/%s/@%s/%s", owner, repo, ref, path)
-			}
-			return downloadedContent, nil
-		}
-		return nil, errors.Wrapf(err, "failed to fetch content of %s/%s@%s/%s", owner, repo, ref, path)
-	}
-
-	// file will be nil if the ref contains a directory at the expected file path
-	if file == nil {
-		return nil, nil
-	}
-
-	content, err := file.GetContent()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to decode content of %s/%s@%s/%s", owner, repo, ref, path)
-	}
-
-	return []byte(content), nil
-}
-
-func (cf *ConfigFetcher) unmarshalConfig(bytes []byte) (*policy.Config, error) {
-	var config policy.Config
-	if err := yaml.UnmarshalStrict(bytes, &config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshall policy")
-	}
-
-	return &config, nil
-}
-
-func isTooLargeError(errorResponse *github.ErrorResponse) bool {
-	for _, error := range errorResponse.Errors {
-		if error.Code == "too_large" {
-			return true
-		}
-	}
-	return false
+	return fc
 }

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gregjones/httpcache"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-baseapp/baseapp/datadog"
+	"github.com/palantir/go-githubapp/appconfig"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/palantir/go-githubapp/oauth2"
 	"github.com/palantir/policy-bot/server/handler"
@@ -125,7 +126,12 @@ func New(c *Config) (*Server, error) {
 
 		PullOpts: &c.Options,
 		ConfigFetcher: &handler.ConfigFetcher{
-			PolicyPath: c.Options.PolicyPath,
+			Loader: appconfig.NewLoader(
+				[]string{c.Options.PolicyPath},
+				appconfig.WithOwnerDefault(c.Options.SharedRepository, []string{
+					c.Options.SharedPolicyPath,
+				}),
+			),
 		},
 
 		AppName: app.GetSlug(),

--- a/vendor/github.com/palantir/go-githubapp/appconfig/appconfig.go
+++ b/vendor/github.com/palantir/go-githubapp/appconfig/appconfig.go
@@ -1,0 +1,299 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package appconfig loads repository configuration for GitHub apps. It
+// supports loading directly from a file in a repository, loading from remote
+// references, and loading an organization-level default. The config itself can
+// be in any format.
+package appconfig
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v37/github"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// RemoteRefParser attempts to parse a RemoteRef from bytes. The parser should
+// return nil with a nil error if b does not encode a RemoteRef and nil with a
+// non-nil error if b encodes an invalid RemoteRef.
+type RemoteRefParser func(path string, b []byte) (*RemoteRef, error)
+
+// RemoteRef identifies a configuration file in a different repository.
+type RemoteRef struct {
+	// The repository in "owner/name" format.
+	Remote string `yaml:"remote" json:"remote"`
+
+	// The path to the config file in the repository.
+	Path string `yaml:"path" json:"path"`
+
+	// The reference (branch, tag, or SHA) to read in the repository. If empty,
+	// use the default branch of the repository.
+	Ref string `yaml:"ref" json:"ref"`
+}
+
+func (r RemoteRef) SplitRemote() (owner, repo string, err error) {
+	slash := strings.IndexByte(r.Remote, '/')
+	if slash <= 0 || slash >= len(r.Remote)-1 {
+		return "", "", errors.Errorf("invalid remote value: %s", r.Remote)
+	}
+	return r.Remote[:slash], r.Remote[slash+1:], nil
+}
+
+// Config contains unparsed configuration data and metadata about where it was found.
+type Config struct {
+	Content []byte
+
+	Source   string
+	Path     string
+	IsRemote bool
+}
+
+// IsUndefined returns true if the Config's content is empty and there is no
+// metadata giving a source.
+func (c Config) IsUndefined() bool {
+	return len(c.Content) == 0 && c.Source == "" && c.Path == ""
+}
+
+// Loader loads configuration for repositories.
+type Loader struct {
+	paths []string
+
+	parser       RemoteRefParser
+	defaultRepo  string
+	defaultPaths []string
+}
+
+// NewLoader creates a Loader that loads configuration from paths.
+func NewLoader(paths []string, opts ...Option) *Loader {
+	defaultPaths := make([]string, len(paths))
+	for i, p := range paths {
+		defaultPaths[i] = strings.TrimPrefix(p, ".github/")
+	}
+
+	ld := Loader{
+		paths:        paths,
+		parser:       YAMLRemoteRefParser,
+		defaultRepo:  ".github",
+		defaultPaths: defaultPaths,
+	}
+
+	for _, opt := range opts {
+		opt(&ld)
+	}
+
+	return &ld
+}
+
+// LoadConfig loads configuration for the repository owner/repo. It first tries
+// the Loader's paths in order, following remote references if they exist. If
+// no configuration exists at any path in the repository, it tries to load
+// default configuration defined by owner for all repositories. If no default
+// configuration exists, it returns an undefined Config and a nil error.
+//
+// If error is non-nil, the Source and Path fields of the returned Config tell
+// which file LoadConfig was processing when it encountered the error.
+func (ld *Loader) LoadConfig(ctx context.Context, client *github.Client, owner, repo, ref string) (Config, error) {
+	logger := zerolog.Ctx(ctx)
+
+	c := Config{
+		Source: fmt.Sprintf("%s/%s@%s", owner, repo, ref),
+	}
+
+	for _, p := range ld.paths {
+		c.Path = p
+
+		logger.Debug().Msgf("Trying configuration at %s in %s", c.Path, c.Source)
+		content, exists, err := getFileContents(ctx, client, owner, repo, ref, p)
+		if err != nil {
+			return c, err
+		}
+		if !exists {
+			continue
+		}
+
+		// if remote refs are enabled, see if the file is a remote reference
+		if ld.parser != nil {
+			remote, err := ld.parser(p, content)
+			if err != nil {
+				return c, err
+			}
+			if remote != nil {
+				logger.Debug().Msgf("Found remote configuration at %s in %s", p, c.Source)
+				return ld.loadRemoteConfig(ctx, client, *remote, c)
+			}
+		}
+
+		// non-remote content found, don't try any other paths
+		logger.Debug().Msgf("Found configuration at %s in %s", c.Path, c.Source)
+		c.Content = content
+		return c, nil
+	}
+
+	// if the repository defined no configuration and org defaults are enabled,
+	// try falling back to the defaults
+	if ld.defaultRepo != "" && len(ld.defaultPaths) > 0 {
+		return ld.loadDefaultConfig(ctx, client, owner)
+	}
+
+	// couldn't find configuration anyhere, so return an empty/undefined one
+	return Config{}, nil
+}
+
+func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, remote RemoteRef, c Config) (Config, error) {
+	logger := zerolog.Ctx(ctx)
+
+	owner, repo, err := remote.SplitRemote()
+	if err != nil {
+		return c, err
+	}
+
+	c.Path = remote.Path
+	c.Source = fmt.Sprintf("%s/%s@%s", owner, repo, remote.Ref)
+	c.IsRemote = true
+
+	logger.Debug().Msgf("Trying remote configuration at %s in %s", c.Path, c.Source)
+	content, exists, err := getFileContents(ctx, client, owner, repo, remote.Ref, remote.Path)
+	if err != nil {
+		return c, err
+	}
+	if !exists {
+		// Referencing a remote file that does not exist is an error because
+		// this condition is annoying to debug otherwise. From the perspective
+		// of a repository, it appears that the application has a configuration
+		// file and it is easy to miss that e.g. the ref is wrong.
+		return c, errors.Errorf("invalid remote reference: file does not exist")
+	}
+
+	c.Content = content
+	return c, nil
+}
+
+func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, owner string) (Config, error) {
+	logger := zerolog.Ctx(ctx)
+
+	r, _, err := client.Repositories.Get(ctx, owner, ld.defaultRepo)
+	if err != nil {
+		if isNotFound(err) {
+			// if the owner has no default repo, return empty/undefined config
+			return Config{}, nil
+		}
+		c := Config{Source: fmt.Sprintf("%s/%s", owner, ld.defaultRepo)}
+		return c, errors.Wrap(err, "failed to get default repository")
+	}
+
+	ref := r.GetDefaultBranch()
+	c := Config{
+		Source: fmt.Sprintf("%s/%s@%s", owner, r.GetName(), ref),
+	}
+
+	for _, p := range ld.defaultPaths {
+		c.Path = p
+
+		logger.Debug().Msgf("Trying default configuration at %s in %s", c.Path, c.Source)
+		content, exists, err := getFileContents(ctx, client, owner, r.GetName(), ref, p)
+		if err != nil {
+			return c, err
+		}
+		if !exists {
+			continue
+		}
+
+		// non-remote content found, don't try any other paths
+		logger.Debug().Msgf("Found default configuration at %s in %s", c.Path, c.Source)
+		c.Content = content
+		return c, nil
+	}
+
+	// no default configuration, return an empty/undefined one
+	return Config{}, nil
+}
+
+// getFileContents returns the content of the file at path on ref in owner/repo
+// if it exists. Returns an empty slice and false if the file does not exist.
+func getFileContents(ctx context.Context, client *github.Client, owner, repo, ref, path string) ([]byte, bool, error) {
+	file, _, _, err := client.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{
+		Ref: ref,
+	})
+	if err != nil {
+		switch {
+		case isNotFound(err):
+			return nil, false, nil
+		case isTooLargeError(err):
+			b, err := getLargeFileContents(ctx, client, owner, repo, ref, path)
+			return b, true, err
+		}
+		return nil, false, errors.Wrap(err, "failed to read file")
+	}
+
+	// file will be nil if the path exists but is a directory
+	if file == nil {
+		return nil, false, nil
+	}
+
+	content, err := file.GetContent()
+	if err != nil {
+		return nil, true, errors.Wrap(err, "failed to decode file content")
+	}
+
+	return []byte(content), true, nil
+}
+
+// getLargeFileContents is similar to getFileContents, but works for files up
+// to 100MB. Unlike getFileContents, it returns an error if the file does not
+// exist.
+func getLargeFileContents(ctx context.Context, client *github.Client, owner, repo, ref, path string) ([]byte, error) {
+	body, res, err := client.Repositories.DownloadContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{
+		Ref: ref,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read file")
+	}
+	defer func() {
+		_ = body.Close()
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("failed to read file: unexpected status code %d", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read file")
+	}
+	return b, nil
+}
+
+func isNotFound(err error) bool {
+	if rerr, ok := err.(*github.ErrorResponse); ok {
+		return rerr.Response.StatusCode == http.StatusNotFound
+	}
+	return false
+}
+
+func isTooLargeError(err error) bool {
+	if rerr, ok := err.(*github.ErrorResponse); ok {
+		for _, err := range rerr.Errors {
+			if err.Code == "too_large" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/vendor/github.com/palantir/go-githubapp/appconfig/options.go
+++ b/vendor/github.com/palantir/go-githubapp/appconfig/options.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appconfig
+
+type Option func(*Loader)
+
+// WithRemoteRefParser sets the parser for encoded RemoteRefs. The default
+// parser uses YAML. Set a nil parser to disable remote references.
+func WithRemoteRefParser(parser RemoteRefParser) Option {
+	return func(ld *Loader) {
+		ld.parser = parser
+	}
+}
+
+// WithOwnerDefault sets the owner repository and paths to check when a
+// repository does not define its own configuration. By default, the repository
+// name is ".github" and the paths are those passed to the loader with the
+// ".github/" prefix removed. Set an empty repository name to disable
+// owner defaults.
+func WithOwnerDefault(name string, paths []string) Option {
+	return func(ld *Loader) {
+		ld.defaultRepo = name
+		ld.defaultPaths = paths
+	}
+}
+
+/*
+
+Not sure this is valuable yet, but leaving this option function as a starting
+point for a future implementation. See https://github.com/palantir/policy-bot/issues/111
+for some explanation of why this is desired.
+
+In the Loader implementation, if a ClientCreator and InstallationsService are
+set, the loadRemoteConfig method would use them to create a new client if the
+remote owner does not equal the starting owner.
+
+// WithPrivateRemotes enables loading remote configuration from private
+// repositories in different organizations. By default, only public
+// repositories can be remote targets.
+func WithPrivateRemotes(cc githubapp.ClientCreator, installs githubapp.InstallationsService) Option {
+	return func(ld *Loader) {}
+}
+*/

--- a/vendor/github.com/palantir/go-githubapp/appconfig/yaml.go
+++ b/vendor/github.com/palantir/go-githubapp/appconfig/yaml.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appconfig
+
+import (
+	"errors"
+
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLRemoteRefParser parses b as a YAML-encoded RemoteRef. It assumes all
+// parsing errors mean the content is not a RemoteRef.
+func YAMLRemoteRefParser(path string, b []byte) (*RemoteRef, error) {
+	var ref RemoteRef
+	if err := yaml.UnmarshalStrict(b, &ref); err != nil {
+		// assume errors mean this isn't a remote config
+		return nil, nil
+	}
+
+	if ref.Remote == "" {
+		return nil, errors.New("invalid remote reference: empty \"remote\" field")
+	}
+	if ref.Path == "" {
+		return nil, errors.New("invalid remote references: empty \"path\" field")
+	}
+	return &ref, nil
+}

--- a/vendor/github.com/palantir/go-githubapp/appconfig/yaml.go
+++ b/vendor/github.com/palantir/go-githubapp/appconfig/yaml.go
@@ -23,17 +23,27 @@ import (
 // YAMLRemoteRefParser parses b as a YAML-encoded RemoteRef. It assumes all
 // parsing errors mean the content is not a RemoteRef.
 func YAMLRemoteRefParser(path string, b []byte) (*RemoteRef, error) {
-	var ref RemoteRef
-	if err := yaml.UnmarshalStrict(b, &ref); err != nil {
+	var maybeRef struct {
+		Remote *string `yaml:"remote"`
+		Path   string  `yaml:"path"`
+		Ref    string  `yaml:"ref"`
+	}
+
+	if err := yaml.UnmarshalStrict(b, &maybeRef); err != nil {
 		// assume errors mean this isn't a remote config
 		return nil, nil
 	}
+	if maybeRef.Remote == nil {
+		return nil, nil
+	}
 
+	ref := RemoteRef{
+		Remote: *maybeRef.Remote,
+		Path:   maybeRef.Path,
+		Ref:    maybeRef.Ref,
+	}
 	if ref.Remote == "" {
 		return nil, errors.New("invalid remote reference: empty \"remote\" field")
-	}
-	if ref.Path == "" {
-		return nil, errors.New("invalid remote references: empty \"path\" field")
 	}
 	return &ref, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/inconshreveable/mousetrap
 github.com/palantir/go-baseapp/baseapp
 github.com/palantir/go-baseapp/baseapp/datadog
 github.com/palantir/go-baseapp/pkg/errfmt
-# github.com/palantir/go-githubapp v0.8.0
+# github.com/palantir/go-githubapp v0.8.1
 github.com/palantir/go-githubapp/appconfig
 github.com/palantir/go-githubapp/githubapp
 github.com/palantir/go-githubapp/oauth2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,6 +37,7 @@ github.com/palantir/go-baseapp/baseapp
 github.com/palantir/go-baseapp/baseapp/datadog
 github.com/palantir/go-baseapp/pkg/errfmt
 # github.com/palantir/go-githubapp v0.8.0
+github.com/palantir/go-githubapp/appconfig
 github.com/palantir/go-githubapp/githubapp
 github.com/palantir/go-githubapp/oauth2
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
Refactor configuration loading to use the `go-githubapp/appconfig` package. This mostly adds support for shared organization policies (in the `.github` repository by default), but should also make error messages more accurate.

It also changes the policy link in the details view to point to the resolved policy, instead of the local policy file.

I'll need to rebase this after #320 merges, but I didn't want to combine the `go-github` upgrade with the functionality changes. Also needs https://github.com/palantir/go-githubapp/pull/94 to merge to maintain current behavior with empty configuration files.