### PR TITLE
Update validate endpoint to check local and remote policies

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RemoteConfig allows the use of a remote policy file, rather than a local one. The Remote value
+// Deprecated: RemoteConfig allows the use of a remote policy file, rather than a local one. The Remote value
 // should follow the format `org/repo`. An example: `palantir/policy-bot`. The Path is optional,
 // with the default value being the configured default policy file location. The Ref is optional,
 // and the default branch of the Remote repository will be used.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Deprecated: RemoteConfig allows the use of a remote policy file, rather than a local one. The Remote value
+// RemoteConfig allows the use of a remote policy file, rather than a local one. The Remote value
 // should follow the format `org/repo`. An example: `palantir/policy-bot`. The Path is optional,
 // with the default value being the configured default policy file location. The Ref is optional,
 // and the default branch of the Remote repository will be used.

--- a/server/handler/validate.go
+++ b/server/handler/validate.go
@@ -76,11 +76,10 @@ func isValidLocalPolicy(requestPolicy []byte) (bool, string) {
 }
 
 func isValidRemotePolicy(requestPolicy []byte) (bool, string) {
-	var remoteConfig appconfig.RemoteRef
-
-	if err := yaml.UnmarshalStrict(requestPolicy, &remoteConfig); err != nil {
+	remoteRef, err := appconfig.YAMLRemoteRefParser("", requestPolicy)
+	if err != nil {
 		return false, err.Error()
 	}
 
-	return true, ""
+	return remoteRef != nil, ""
 }


### PR DESCRIPTION
Currently, policy-bot fails to validate remote policies. Instead, policy bot's validate endpoint should accept a remote config as valid. I noticed this once trying to use the new org default policies in #321 .

Perhaps we should also check that the remote policy is also valid?