### PR TITLE
chore: update doc for request review, add information note for team visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ For example, if a rule can be approved by any user with `admin` permission,
 only direct or team admins are selected for review. Users who inherit
 repository `admin` permissions as organization owners are not selected.
 
+The `teams` mode needs the team visibility to be set to `visibile` to enable this functionality for a given team.
+
 #### Automatically Requesting Reviewers Example
 
 Given the following example requirement rule,


### PR DESCRIPTION
When trying to use the request_review feature with one team of my organization, I've found that if the team is not `visibile` this feature does not work and don't add any reviewer to the pull request.