### PR TITLE
Add GitHub request cache size metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/palantir/go-baseapp v0.2.4
 	github.com/palantir/go-githubapp v0.9.1
 	github.com/pkg/errors v0.9.1
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/rs/zerolog v1.18.0
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20191127044304-8f68eb5628d0

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/rcrowley/go-metrics"
+)
+
+var (
+	registry metrics.Registry
+)
+
+func SetRegistry(r metrics.Registry) {
+	registry = r
+}
+
+// GitHubCacheApproxSize - registers a gauge with the registry that monitors the approximate GitHub request lrucache memory size
+func GitHubCacheApproxSize(sizeFn func() int64) metrics.Gauge {
+	return metrics.NewRegisteredFunctionalGauge("github.request_cache.approx_size", registry, sizeFn)
+}


### PR DESCRIPTION
Currently policy=bot leverages a lrucache to cache github responses.

Previously, we don't measure the approximate memory size in-use by the cache. This should resolve that and allow us to set the cache max size accordingly..
