### PR TITLE
fix: PullRequestState returns uppercase enums

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -194,11 +194,11 @@ func (ghc *GitHubContext) CreatedAt() time.Time {
 }
 
 func (ghc *GitHubContext) IsOpen() bool {
-	return ghc.pr.State == "open"
+	return strings.ToLower(ghc.pr.State) == "open"
 }
 
 func (ghc *GitHubContext) IsClosed() bool {
-	return ghc.pr.State == "closed"
+	return strings.ToLower(ghc.pr.State) == "closed"
 }
 
 func (ghc *GitHubContext) HeadSHA() string {


### PR DESCRIPTION
Not sure when/if this changed but the `IsOpen()` and `IsClosed()` functions are currently returning false even if the pull request is actually open or closed respectively because the enums returned by the graphql API return the state as uppercase (https://docs.github.com/en/graphql/reference/enums#pullrequeststate), this should keep things backwards compatible by always converting the state to lowercase before comparing it.