### PR TITLE
feat: add comment matching to github review approval with new option

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,14 @@ options:
     # See the Notes on YAML Syntax section of this README for more information.
     comment_patterns:
       - "^Signed-off by \\s+$"
-    # If true, GitHub reviews can be used for approval. Default is true.
+    # If true, GitHub reviews can be used for approval. All GitHub review approvals
+    # will be accepted as approval candidates. Default is true.
     github_review: true
+    # Just like the "comment_patterns" option, but for GitHub reviews. Only GitHub
+    # review approvals matching the included patterns will be accepted as
+    # approval candidates. Defaults to an empty list.
+    github_review_comment_patterns:
+      - '\b(?i)domain\s*lgtm\b'
 
 # "requires" specifies the approval requirements for the rule. If the block
 # does not exist, the rule is automatically approved.

--- a/policy/common/methods_test.go
+++ b/policy/common/methods_test.go
@@ -64,10 +64,23 @@ func TestCandidates(t *testing.T) {
 				CreatedAt: now.Add(3 * time.Minute),
 				Author:    "mhaypenny",
 				State:     pull.ReviewChangesRequested,
+				Body:      "pr needs work",
 			},
 			{
 				CreatedAt: now.Add(5 * time.Minute),
 				Author:    "ttest",
+				State:     pull.ReviewApproved,
+			},
+			{
+				CreatedAt: now.Add(7 * time.Minute),
+				Author:    "santaclaus",
+				Body:      "nice",
+				State:     pull.ReviewApproved,
+			},
+			{
+				CreatedAt: now.Add(9 * time.Minute),
+				Author:    "dasherdancer",
+				Body:      "nIcE",
 				State:     pull.ReviewApproved,
 			},
 		},
@@ -104,6 +117,25 @@ func TestCandidates(t *testing.T) {
 		assert.Equal(t, "mhaypenny", cs[0].User)
 	})
 
+	t.Run("githubReviewCommentPatterns", func(t *testing.T) {
+		m := &Methods{
+			GithubReview:      true,
+			GithubReviewState: pull.ReviewApproved,
+			GithubReviewCommentPatterns: []Regexp{
+				NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
+			},
+		}
+
+		cs, err := m.Candidates(ctx, prctx)
+		require.NoError(t, err)
+
+		sort.Sort(CandidatesByCreationTime(cs))
+
+		require.Len(t, cs, 2, "incorrect number of candidates found")
+		assert.Equal(t, "santaclaus", cs[0].User)
+		assert.Equal(t, "dasherdancer", cs[1].User)
+	})
+
 	t.Run("reviews", func(t *testing.T) {
 		m := &Methods{
 			GithubReview:      true,
@@ -131,9 +163,11 @@ func TestCandidates(t *testing.T) {
 
 		sort.Sort(CandidatesByCreationTime(cs))
 
-		require.Len(t, cs, 2, "incorrect number of candidates found")
+		require.Len(t, cs, 4, "incorrect number of candidates found")
 		assert.Equal(t, "mhaypenny", cs[0].User)
 		assert.Equal(t, "ttest", cs[1].User)
+		assert.Equal(t, "santaclaus", cs[2].User)
+		assert.Equal(t, "dasherdancer", cs[3].User)
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/palantir/policy-bot/issues/359

As discussed in the attached issue, this feature would support new method options for `github_review_comments:` and `github_review_comment_patterns:` creating parity with issue comment approval for github review approval comment bodies. This would help in use cases where github review approval alone isn't sufficient.

I went with nesting the logic in the existing reviews for loop but first checking to confirm the review state is approved. That would make this feature work if `github_review` is provided in the config and set to `true`, or not provided in the config defaulting to `true`. As written, this feature doesn't work if `github_review: false` explicitly in the config. That doesn't seem surprising behavior to me, but let me know if there's an approach that makes better sense to accomplish the same.