### PR TITLE
support env vars for options in server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,12 +569,6 @@ ignored. If this happens, you will need to reapprove the pull request.
 
 This feature has [security implications](#update-merge-conflicts).
 
-#### Private Repositories
-
-`policy-bot` works with private repositories, but currently does not support
-pull requests from private _forks_ of private repositories due to GitHub API
-limitations. Please file an issue if this functionality is important to you.
-
 #### Automatically Requesting Reviewers
 
 `policy-bot` can automatically request reviewers for all pending rules

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ define a `remote` key. Only 1 level of remote configuration is supported by desi
 
 ```yaml
 # The remote repository to read the policy file from. This is required, and must
-# be in the form of "org/repo-name". Must be a public repository.
+# be in the form of "org/repo-name". The policy bot github app must have read
+# access to this repository.
 remote: org/repo-name
 
 # The path to the policy config file in the remote repository. If none is
@@ -323,6 +324,7 @@ options:
   request_review:
     # False by default
     enabled: true
+
     # mode modifies how reviewers are selected. `all-users` will request all users
     # who are able to approve the pending rule. `random-users` selects a small
     # set of random users based on the required count of approvals. `teams` will 
@@ -340,6 +342,7 @@ options:
     comments:
       - ":+1:"
       - "👍"
+
     # If a comment matches a regular expression in this list, it counts as
     # approval. Defaults to an empty list.
     #
@@ -347,9 +350,11 @@ options:
     # See the Notes on YAML Syntax section of this README for more information.
     comment_patterns:
       - "^Signed-off by \\s+$"
+
     # If true, GitHub reviews can be used for approval. All GitHub review approvals
     # will be accepted as approval candidates. Default is true.
     github_review: true
+
     # Just like the "comment_patterns" option, but for GitHub reviews. Only GitHub
     # review approvals matching the included patterns will be accepted as
     # approval candidates. Defaults to an empty list.

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -15,9 +15,11 @@ server:
 logging:
   # If true, logs are printed in human-readable form. We recommend using
   # "false" to output JSON-formatted logs in production
+  # Can also be set by the POLICYBOT_LOG_PRETTY environment variable.
   text: false
   # Set a minimum logging level threshold
   # Choose from: debug, info, warn, error
+  # Can also be set by the POLICYBOT_LOG_LEVEL environment variable.
   level: debug
 
 # Options for the GitHub response cache. When the cache reaches max_size, the
@@ -78,17 +80,21 @@ sessions:
 # Options for application behavior. The defaults are shown below.
 #
 # options:
-#   # The path to the policy file in a repository.
+#   # The path to the policy file in a repository. Can also be set by the
+#   # POLICYBOT_POLICY_PATH environment variable.
 #   policy_path: .policy.yml
 #
 #   # The name of an organization repository to look in for a shared policy if
-#   # a repository does not define a policy file.
+#   # a repository does not define a policy file. Can also be set by the
+#   # POLICYBOT_SHARED_REPOSITORY environment variable.
 #   shared_repository: .github
 #
 #   # The path to the policy file in the shared organization repository.
+#   # Can also be set by the POLICYBOT_SHARED_POLICY_PATH environment variable.
 #   shared_policy_path: policy.yml
 #
-#   # The context prefix for status checks created by the bot.
+#   # The context prefix for status checks created by the bot. Can also be set by the
+#   # POLICYBOT_STATUS_CHECK_CONTEXT environment variable.
 #   status_check_context: policy-bot
 
 # Options for locating the frontend files. By default, the server uses appropriate

--- a/server/config.go
+++ b/server/config.go
@@ -65,8 +65,22 @@ func ParseConfig(bytes []byte) (*Config, error) {
 		return nil, errors.Wrapf(err, "failed unmarshalling yaml")
 	}
 
+	if v, ok := os.LookupEnv("POLICYBOT_POLICY_PATH"); ok {
+		c.Options.PolicyPath = v
+	}
+	if v, ok := os.LookupEnv("POLICYBOT_SHARED_REPOSITORY"); ok {
+		c.Options.SharedRepository = v
+	}
+	if v, ok := os.LookupEnv("POLICYBOT_SHARED_POLICY_PATH"); ok {
+		c.Options.SharedPolicyPath = v
+	}
+	if v, ok := os.LookupEnv("POLICYBOT_STATUS_CHECK_CONTEXT"); ok {
+		c.Options.StatusCheckContext = v
+	}
 	c.Options.FillDefaults()
+
 	c.Server.SetValuesFromEnv("POLICYBOT_")
+
 	c.Github.SetValuesFromEnv("")
 
 	if v, ok := os.LookupEnv("POLICYBOT_SESSIONS_KEY"); ok {

--- a/server/config.go
+++ b/server/config.go
@@ -65,22 +65,8 @@ func ParseConfig(bytes []byte) (*Config, error) {
 		return nil, errors.Wrapf(err, "failed unmarshalling yaml")
 	}
 
-	if v, ok := os.LookupEnv("POLICYBOT_POLICY_PATH"); ok {
-		c.Options.PolicyPath = v
-	}
-	if v, ok := os.LookupEnv("POLICYBOT_SHARED_REPOSITORY"); ok {
-		c.Options.SharedRepository = v
-	}
-	if v, ok := os.LookupEnv("POLICYBOT_SHARED_POLICY_PATH"); ok {
-		c.Options.SharedPolicyPath = v
-	}
-	if v, ok := os.LookupEnv("POLICYBOT_STATUS_CHECK_CONTEXT"); ok {
-		c.Options.StatusCheckContext = v
-	}
-	c.Options.FillDefaults()
-
+	c.Options.SetValuesFromEnv("POLICYBOT_OPTIONS_")
 	c.Server.SetValuesFromEnv("POLICYBOT_")
-
 	c.Github.SetValuesFromEnv("")
 
 	if v, ok := os.LookupEnv("POLICYBOT_SESSIONS_KEY"); ok {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -75,7 +76,7 @@ type PullEvaluationOptions struct {
 	Deprecated_AppName string `yaml:"app_name"`
 }
 
-func (p *PullEvaluationOptions) FillDefaults() {
+func (p *PullEvaluationOptions) fillDefaults() {
 	if p.PolicyPath == "" {
 		p.PolicyPath = DefaultPolicyPath
 	}
@@ -89,6 +90,14 @@ func (p *PullEvaluationOptions) FillDefaults() {
 	if p.StatusCheckContext == "" {
 		p.StatusCheckContext = DefaultStatusCheckContext
 	}
+}
+
+func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
+	setStringFromEnv("POLICY_PATH", prefix, &p.PolicyPath)
+	setStringFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
+	setStringFromEnv("SHARED_POLICY_PATH", prefix, &p.SharedPolicyPath)
+	setStringFromEnv("STATUS_CHECK_CONTEXT", prefix, &p.StatusCheckContext)
+	p.fillDefaults()
 }
 
 func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *github.Client, state, message string) {
@@ -380,4 +389,12 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 	}
 
 	return req
+}
+
+func setStringFromEnv(key, prefix string, value *string) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value = v
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Closes https://github.com/palantir/policy-bot/issues/363

As discussed in the attached issue, I've made an attempt at setting the policy path and shared options from env vars if they exist. If env vars are not set, then it should just fall back to the defaults. Let me know if there's a more clever way of accomplishing the same. I also updated the example config to reflect the possibilities.