### PR TITLE
fix: triggers should include all comments

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -82,10 +82,10 @@ func (r *Rule) Trigger() common.Trigger {
 
 	if r.Requires.Count > 0 {
 		m := r.Options.GetMethods()
-		if len(m.Comments) > 0 {
+		if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 			t |= common.TriggerComment
 		}
-		if m.GithubReview {
+		if m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
 			t |= common.TriggerReview
 		}
 	}


### PR DESCRIPTION
Noticed in my testing of https://github.com/palantir/policy-bot/pull/361 the code responsible for triggering evaluation was incomplete. Rules for methods that were more recently added weren't being evaluated until a user clicked on the details page in the github status link instead of at the time of the webhook event. This attempts to solve that.

Also added some tests for the Trigger method so that we can catch it in the future.