### PR TITLE
Add PR information to error object

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -158,24 +158,24 @@ func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *g
 func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger common.Trigger, loc pull.Locator) error {
 	client, err := b.NewInstallationClient(installationID)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed when evaluting PR: %s/%s/%d", loc.Owner, loc.Repo, loc.Number)
 	}
 
 	v4client, err := b.NewInstallationV4Client(installationID)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed when evaluting PR: %s/%s/%d", loc.Owner, loc.Repo, loc.Number)
 	}
 
 	mbrCtx := NewCrossOrgMembershipContext(ctx, client, loc.Owner, b.Installations, b.ClientCreator)
 	prctx, err := pull.NewGitHubContext(ctx, mbrCtx, client, v4client, loc)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed when evaluting PR: %s/%s/%d", loc.Owner, loc.Repo, loc.Number)
 	}
 
 	fetchedConfig := b.ConfigFetcher.ConfigForPR(ctx, prctx, client)
 	evaluator, err := b.ValidateFetchedConfig(ctx, prctx, client, fetchedConfig, trigger)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed when evaluting PR: %s/%s/%d", loc.Owner, loc.Repo, loc.Number)
 	}
 	if evaluator == nil {
 		return nil
@@ -183,7 +183,7 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 
 	result, err := b.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed when evaluting PR: %s/%s/%d", loc.Owner, loc.Repo, loc.Number)
 	}
 
 	return b.RequestReviewsForResult(ctx, prctx, client, trigger, result)


### PR DESCRIPTION
#### Currently
When there is an error during the `Handle` logic, the logged error does not contain the PR information since the logger writing the `error` object doesn't have those field configured. This means some errors will only have the GH delivery_id and type, but not the pull request that created it.

#### This PR
Wraps the `error` object with the PR locator information: `<owner>/<repo>/<PR>` as a way to reference back in the logs what PR caused this error.