### PR TITLE
Also post initial status on installation events

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -149,7 +149,7 @@ func New(c *Config) (*Server, error) {
 
 	dispatcher := githubapp.NewEventDispatcher(
 		[]githubapp.EventHandler{
-			&handler.InstallationRepositories{Base: basePolicyHandler},
+			&handler.Installation{Base: basePolicyHandler},
 			&handler.PullRequest{Base: basePolicyHandler},
 			&handler.PullRequestReview{Base: basePolicyHandler},
 			&handler.IssueComment{Base: basePolicyHandler},


### PR DESCRIPTION
The 'installation_repositories' event only fires when the repositories
of an existing installation change. We need to handle the 'installation'
event to post statuses on initial install.

Follow up to #370.