### PR TITLE
Fix panic on edit events in issue_comment handler

### DIFF
--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -114,7 +114,7 @@ func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Con
 	var originalBody string
 	switch event.GetAction() {
 	case "edited":
-		originalBody = *event.GetChanges().Body.From
+		originalBody = event.GetChanges().GetBody().GetFrom()
 
 	case "deleted":
 		originalBody = event.GetComment().GetBody()


### PR DESCRIPTION
For an unknown reason, GitHub Enterprise 3.2.7 is not including the
'changes" field in issue_comment payloads for edited comments. This
causes the handler to panic when it tried to access the previous body of
the comment. This field is still included on GitHub.com, so hopefully it
will be fixed in some future release.

For now, fix the panic by using the "safe" accessors, but at the cost of
not actually auditing the edit correctly. Hard failing if the old body
is missing will break a lot of legitimate workflows, particularly our
internal changelog generation app.

A quick survey of the API suggests you can only look up comment history
using the GraphQL API, and it gives you a diff instead of the previous
content. I'm not sure if the edit auditing functionality is important
enough to justify a fallback if the payload is missing fields. Now that
the 'ignore_edited_comments' property exists, users who really care
about this should probably use that instead.