### PR TITLE
Improve details UI for some predicates

### DIFF
--- a/policy/predicate/branch.go
+++ b/policy/predicate/branch.go
@@ -72,7 +72,7 @@ func (pred *FromBranch) Evaluate(ctx context.Context, prctx pull.Context) (*comm
 		Satisfied:       matches,
 		Description:     desc,
 		Values:          []string{sourceBranchName},
-		ValuePhrase:     "from branches",
+		ValuePhrase:     "source branches",
 		ConditionPhrase: "match the required pattern",
 		ConditionValues: []string{pred.Pattern.String()},
 	}

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -45,7 +45,7 @@ func (pred *ChangedFiles) Evaluate(ctx context.Context, prctx pull.Context) (*co
 
 	predicateResult := common.PredicateResult{
 		ValuePhrase:     "changed files",
-		ConditionPhrase: "match patterns",
+		ConditionPhrase: "match",
 		ConditionsMap: map[string][]string{
 			"path patterns":  paths,
 			"while ignoring": ignorePaths,

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -108,27 +108,31 @@
   {{ $s := (or (and .Error "error") (.Status | print)) }}
   <ul class="list-decimal list-outside pl-4 my-2">
   {{range .PredicateResults}}
-  <li>
-  The {{.ValuePhrase}}:
-  <ul class="list-disc list-outside pl-6 py-2">
-    {{range .Values}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
-  </ul>
-  {{if eq $s "skipped"}}do not {{end}}{{.ConditionPhrase}}
-  {{if .ConditionsMap}}
-  <dl class="pt-2">
-  {{range $k, $v := .ConditionsMap}}
-    {{if $v}}
-    <dt>{{$k}}</dt>
-    <dd>
-        <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
-    </dd>
-    {{end}}
-  {{end}}
-  </dl>
-  {{else if .ConditionValues}}
-    <ul class="list-disc list-outside pl-6 py-2">{{range .ConditionValues}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
-  {{end}}
-  </li>
+    <li>
+      {{if .Values}}
+        The {{.ValuePhrase}}:
+        <ul class="list-disc list-outside pl-6 py-2">
+          {{range .Values}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
+        </ul>
+        {{if eq $s "skipped"}}do not {{end}}{{.ConditionPhrase}}
+        {{if .ConditionsMap}}
+        <dl class="pt-2 pl-4">
+        {{range $k, $v := .ConditionsMap}}
+          {{if $v}}
+          <dt>{{$k}}</dt>
+          <dd>
+              <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+          </dd>
+          {{end}}
+        {{end}}
+        </dl>
+        {{else if .ConditionValues}}
+          <ul class="list-disc list-outside pl-6 py-2">{{range .ConditionValues}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+        {{end}}
+      {{else}}
+        There are no {{.ValuePhrase}}
+      {{end}}
+    </li>
   {{end}}
   </ul>
 {{end}}


### PR DESCRIPTION
These are some minor adjustments that came up in testing:

* Replace "from branches" with "source branches" to make the resulting sentence less awkward
* Add padding to condition maps and rephrase the changed files condition to separate the top-level condition phrase from the sub-phrases in the map
* Add a special case for predicates that have no values to avoid rendering an empty list. I don't think it is necessary to show the condition details when there are no values to compare with. An alternative would be to render something like `[no {{.ValuePhrase}}]` as the only list element when there are no values, but I thought that could potentially get confused with actual values.