### PR TITLE
Include permissions in required review details

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -154,19 +154,11 @@ func (r *Rule) getReviewRequestRule() *common.ReviewRequestRule {
 		mode = common.RequestModeRandomUsers
 	}
 
-	perms := append([]pull.Permission(nil), r.Requires.Permissions...)
-	if r.Requires.Admins {
-		perms = append(perms, pull.PermissionAdmin)
-	}
-	if r.Requires.WriteCollaborators {
-		perms = append(perms, pull.PermissionWrite)
-	}
-
 	return &common.ReviewRequestRule{
 		Users:         r.Requires.Users,
 		Teams:         r.Requires.Teams,
 		Organizations: r.Requires.Organizations,
-		Permissions:   perms,
+		Permissions:   r.Requires.GetPermissions(),
 		RequiredCount: r.Requires.Count,
 		Mode:          mode,
 	}

--- a/server/handler/frontend.go
+++ b/server/handler/frontend.go
@@ -93,10 +93,12 @@ func getRequires(result *common.Result, githubURL string) map[string][]Membershi
 	for _, team := range result.Requires.Teams {
 		teamName := strings.Split(team, "/")
 		membershipInfo["Teams"] = append(membershipInfo["Teams"], Membership{Name: team, Link: githubURL + "/orgs/" + teamName[0] + "/teams/" + teamName[1] + "/members"})
-
 	}
 	for _, user := range result.Requires.Users {
 		membershipInfo["Users"] = append(membershipInfo["Users"], Membership{Name: user, Link: githubURL + "/" + user})
+	}
+	for _, perm := range result.Requires.GetPermissions() {
+		membershipInfo["Users with Permission"] = append(membershipInfo["Users with Permission"], Membership{Name: perm.String()})
 	}
 	return membershipInfo
 }

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -141,10 +141,12 @@
   <b class="font-bold text-sm">This rule requires review from</b>
   <dl class="my-2">
   {{range $k, $v := getRequires .}}
-    <dt> {{$k}}</dt>
+    <dt>{{$k}}</dt>
     <dd>
-        <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono"><a href={{.Link}}>{{.Name}}</a></li>{{end}}</ul>
+      <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{template "membership" .}}</li>{{end}}</ul>
     </dd>
   {{end}}
   </dl>
 {{end}}
+
+{{define "membership"}}{{if .Link}}<a href="{{.Link}}">{{end}}{{.Name}}{{if .Link}}</a>{{end}}{{end}}


### PR DESCRIPTION
Ideally this would show the teams or users that have these permissions, but just displaying the permissions will be better than an empty spot in the UI.

Also remove an incorrect comment and add a helper function to translate the deprecated permissions to the new model since this happened in multiple places.

Fixes #416. Marking as a draft for now because I haven't tested it at all yet.