### PR TITLE
Standardize permission access

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -154,19 +154,11 @@ func (r *Rule) getReviewRequestRule() *common.ReviewRequestRule {
 		mode = common.RequestModeRandomUsers
 	}
 
-	perms := append([]pull.Permission(nil), r.Requires.Permissions...)
-	if r.Requires.Admins {
-		perms = append(perms, pull.PermissionAdmin)
-	}
-	if r.Requires.WriteCollaborators {
-		perms = append(perms, pull.PermissionWrite)
-	}
-
 	return &common.ReviewRequestRule{
 		Users:         r.Requires.Users,
 		Teams:         r.Requires.Teams,
 		Organizations: r.Requires.Organizations,
-		Permissions:   perms,
+		Permissions:   r.Requires.GetPermissions(),
 		RequiredCount: r.Requires.Count,
 		Mode:          mode,
 	}


### PR DESCRIPTION
Introduce a new function that returns deduplicated, ordered permissions,
combinging both the current and deprecated options. This is mostly in
prepration for adding permission display to the UI.