### PR TITLE
Add public_url env var to example config

### DIFF
--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -4,6 +4,7 @@ server:
   address: "0.0.0.0"
   port: 8080
   # The public URL, used for URL generation when the server is behind a proxy
+  # Can also be set by the POLICYBOT_PUBLIC_URL environment variable.
   public_url: http://localhost:8080
   # Uncomment the "tls_config" block to enable HTTPS support in the server.
   # The cert and key files must be usable by net/http.ListenAndServeTLS().


### PR DESCRIPTION
Adds an explanation on how to set the `public_url` config with an environment variable to the example config.
I ran into this when I recently deployed policy-bot and noticed it mentioned in an old PR [[#355](https://github.com/palantir/policy-bot/issues/355)]