### PR TITLE
Fix permissions for codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   analyze:
+    permissions:
+      security-events: write
+
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This was broken when we/I locked down action permissions. 