### PR TITLE
Fix commit caching for PRs with too many commits

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -282,12 +282,11 @@ func (ghc *GitHubContext) Commits() ([]*Commit, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(commits) >= MaxPullRequestCommits {
-			return nil, errors.Errorf("too many commits in pull request, maximum is %d", MaxPullRequestCommits)
-		}
-
 		backfillPushedAt(commits, ghc.pr.HeadRefOID)
 		ghc.commits = commits
+	}
+	if len(ghc.commits) >= MaxPullRequestCommits {
+		return nil, errors.Errorf("too many commits in pull request, maximum is %d", MaxPullRequestCommits)
 	}
 	return ghc.commits, nil
 }


### PR DESCRIPTION
Previously, when PRs exceeded the 250 commit limit, we would reload all
commits for each rule that did anything with commits. This is obviously
wasteful, so cache the commits regardless of number so we can return an
error immediately on future method calls.