### PR TITLE
Server config env documentation is wrong

### DIFF
--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -82,20 +82,20 @@ sessions:
 #
 # options:
 #   # The path to the policy file in a repository. Can also be set by the
-#   # POLICYBOT_POLICY_PATH environment variable.
+#   # POLICYBOT_OPTIONS_POLICY_PATH environment variable.
 #   policy_path: .policy.yml
 #
 #   # The name of an organization repository to look in for a shared policy if
 #   # a repository does not define a policy file. Can also be set by the
-#   # POLICYBOT_SHARED_REPOSITORY environment variable.
+#   # POLICYBOT_OPTIONS_SHARED_REPOSITORY environment variable.
 #   shared_repository: .github
 #
 #   # The path to the policy file in the shared organization repository.
-#   # Can also be set by the POLICYBOT_SHARED_POLICY_PATH environment variable.
+#   # Can also be set by the POLICYBOT_OPTIONS_SHARED_POLICY_PATH environment variable.
 #   shared_policy_path: policy.yml
 #
 #   # The context prefix for status checks created by the bot. Can also be set by the
-#   # POLICYBOT_STATUS_CHECK_CONTEXT environment variable.
+#   # POLICYBOT_OPTIONS_STATUS_CHECK_CONTEXT environment variable.
 #   status_check_context: policy-bot
 
 # Options for locating the frontend files. By default, the server uses appropriate


### PR DESCRIPTION
I was trying out the setup for the server, but I noticed changing some ENV's didn't have any impact.
More specific the ENV's under the options.

After looking at the code if found to set the options the ENV's need to start with `POLICYBOT_OPTIONS_`

https://github.com/palantir/policy-bot/blob/da581a398aa00701bd481bc9c4bd5f4e2fc831ec/server/config.go#L68

So in this PR I fixed the documentation.