### PR TITLE
Fix issue with method defaults

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -57,18 +57,19 @@ type RequestReview struct {
 
 func (opts *Options) GetMethods() *common.Methods {
 	methods := opts.Methods
-	defaultBool := true
+	defaultGithubReview := true
 	if methods == nil {
 		methods = &common.Methods{}
 	}
-	if len(methods.Comments) == 0 {
-		methods.Comments = []string{
+	if methods.Comments == nil {
+		defaultComments := []string{
 			":+1:",
 			"👍",
 		}
+		methods.Comments = &defaultComments
 	}
 	if methods.GithubReview == nil {
-		methods.GithubReview = &defaultBool
+		methods.GithubReview = &defaultGithubReview
 	}
 
 	methods.GithubReviewState = pull.ReviewApproved
@@ -86,10 +87,10 @@ func (r *Rule) Trigger() common.Trigger {
 
 	if r.Requires.Count > 0 {
 		m := r.Options.GetMethods()
-		if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+		if m.Comments != nil && len(*m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 			t |= common.TriggerComment
 		}
-		if *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+		if m.GithubReview != nil && *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
 			t |= common.TriggerReview
 		}
 	}

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -57,7 +57,6 @@ type RequestReview struct {
 
 func (opts *Options) GetMethods() *common.Methods {
 	methods := opts.Methods
-	defaultGithubReview := true
 	if methods == nil {
 		methods = &common.Methods{}
 	}
@@ -69,6 +68,7 @@ func (opts *Options) GetMethods() *common.Methods {
 		methods.Comments = &defaultComments
 	}
 	if methods.GithubReview == nil {
+		defaultGithubReview := true
 		methods.GithubReview = &defaultGithubReview
 	}
 

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -61,11 +61,10 @@ func (opts *Options) GetMethods() *common.Methods {
 		methods = &common.Methods{}
 	}
 	if methods.Comments == nil {
-		defaultComments := []string{
+		methods.Comments = []string{
 			":+1:",
 			"👍",
 		}
-		methods.Comments = &defaultComments
 	}
 	if methods.GithubReview == nil {
 		defaultGithubReview := true
@@ -87,7 +86,7 @@ func (r *Rule) Trigger() common.Trigger {
 
 	if r.Requires.Count > 0 {
 		m := r.Options.GetMethods()
-		if m.Comments != nil && len(*m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+		if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 			t |= common.TriggerComment
 		}
 		if m.GithubReview != nil && *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -57,13 +57,24 @@ type RequestReview struct {
 
 func (opts *Options) GetMethods() *common.Methods {
 	methods := opts.Methods
+	defaultBool := true
 	if methods == nil {
 		methods = &common.Methods{
 			Comments: []string{
 				":+1:",
 				"👍",
 			},
-			GithubReview: true,
+			GithubReview: &defaultBool,
+		}
+	} else {
+		if len(methods.Comments) == 0 {
+			methods.Comments = []string{
+				":+1:",
+				"👍",
+			}
+		}
+		if methods.GithubReview == nil {
+			methods.GithubReview = &defaultBool
 		}
 	}
 
@@ -85,7 +96,7 @@ func (r *Rule) Trigger() common.Trigger {
 		if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 			t |= common.TriggerComment
 		}
-		if m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+		if *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
 			t |= common.TriggerReview
 		}
 	}

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -59,23 +59,16 @@ func (opts *Options) GetMethods() *common.Methods {
 	methods := opts.Methods
 	defaultBool := true
 	if methods == nil {
-		methods = &common.Methods{
-			Comments: []string{
-				":+1:",
-				"👍",
-			},
-			GithubReview: &defaultBool,
+		methods = &common.Methods{}
+	}
+	if len(methods.Comments) == 0 {
+		methods.Comments = []string{
+			":+1:",
+			"👍",
 		}
-	} else {
-		if len(methods.Comments) == 0 {
-			methods.Comments = []string{
-				":+1:",
-				"👍",
-			}
-		}
-		if methods.GithubReview == nil {
-			methods.GithubReview = &defaultBool
-		}
+	}
+	if methods.GithubReview == nil {
+		methods.GithubReview = &defaultBool
 	}
 
 	methods.GithubReviewState = pull.ReviewApproved

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -506,12 +506,13 @@ func TestTrigger(t *testing.T) {
 	})
 
 	t.Run("triggerCommentOnComments", func(t *testing.T) {
+		comments := []string{
+			"lgtm",
+		}
 		r := &Rule{
 			Options: Options{
 				Methods: &common.Methods{
-					Comments: []string{
-						"lgtm",
-					},
+					Comments: &comments,
 				},
 			},
 			Requires: Requires{
@@ -542,11 +543,11 @@ func TestTrigger(t *testing.T) {
 	})
 
 	t.Run("triggerReviewForGithubReview", func(t *testing.T) {
-		defaultBool := true
+		defaultGithubReview := true
 		r := &Rule{
 			Options: Options{
 				Methods: &common.Methods{
-					GithubReview: &defaultBool,
+					GithubReview: &defaultGithubReview,
 				},
 			},
 			Requires: Requires{

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -506,13 +506,12 @@ func TestTrigger(t *testing.T) {
 	})
 
 	t.Run("triggerCommentOnComments", func(t *testing.T) {
-		comments := []string{
-			"lgtm",
-		}
 		r := &Rule{
 			Options: Options{
 				Methods: &common.Methods{
-					Comments: &comments,
+					Comments: []string{
+						"lgtm",
+					},
 				},
 			},
 			Requires: Requires{

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -542,10 +542,11 @@ func TestTrigger(t *testing.T) {
 	})
 
 	t.Run("triggerReviewForGithubReview", func(t *testing.T) {
+		defaultBool := true
 		r := &Rule{
 			Options: Options{
 				Methods: &common.Methods{
-					GithubReview: true,
+					GithubReview: &defaultBool,
 				},
 			},
 			Requires: Requires{

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -103,7 +103,7 @@ func TestRules(t *testing.T) {
 				AllowContributor: true,
 				// InvalidateOnPush: true,
 				Methods: &common.Methods{
-					Comments:     &comments,
+					Comments:     comments,
 					GithubReview: &defaultGithubReview,
 				},
 			},
@@ -128,7 +128,7 @@ methods:
   comments: ["+1"]
 `
 	expectedMethods := &common.Methods{
-		Comments:     &comments,
+		Comments:     comments,
 		GithubReview: &defaultGithubReview,
 	}
 	var options *Options
@@ -136,7 +136,7 @@ methods:
 
 	methods := options.GetMethods()
 
-	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
+	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 	optionsText = `
@@ -148,7 +148,7 @@ methods:
 `
 	falseGithubReview := false
 	expectedMethods = &common.Methods{
-		Comments:     &defaultComments,
+		Comments:     defaultComments,
 		GithubReview: &falseGithubReview,
 	}
 
@@ -157,7 +157,7 @@ methods:
 
 	methods = optionsTwo.GetMethods()
 
-	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
+	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 	optionsText = `
@@ -166,7 +166,7 @@ allow_contributor: true
 invalidate_on_push: true
 `
 	expectedMethods = &common.Methods{
-		Comments:     &defaultComments,
+		Comments:     defaultComments,
 		GithubReview: &defaultGithubReview,
 	}
 	var optionsThree *Options
@@ -174,7 +174,7 @@ invalidate_on_push: true
 
 	methods = optionsThree.GetMethods()
 
-	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
+	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 }

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -63,7 +63,12 @@ func TestRules(t *testing.T) {
 	var rules []*Rule
 	require.NoError(t, yaml.UnmarshalStrict([]byte(ruleText), &rules))
 
-	defaultBool := true
+	defaultGithubReview := true
+	defaultComments := []string{
+		":+1:",
+		"👍",
+	}
+	comments := []string{"+1"}
 	expected := []*Rule{
 		{
 			Name: "rule1",
@@ -98,8 +103,8 @@ func TestRules(t *testing.T) {
 				AllowContributor: true,
 				// InvalidateOnPush: true,
 				Methods: &common.Methods{
-					Comments:     []string{"+1"},
-					GithubReview: &defaultBool,
+					Comments:     &comments,
+					GithubReview: &defaultGithubReview,
 				},
 			},
 			Requires: Requires{
@@ -123,15 +128,15 @@ methods:
   comments: ["+1"]
 `
 	expectedMethods := &common.Methods{
-		Comments:     []string{"+1"},
-		GithubReview: &defaultBool,
+		Comments:     &comments,
+		GithubReview: &defaultGithubReview,
 	}
 	var options *Options
 	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &options))
 
 	methods := options.GetMethods()
 
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
+	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 	optionsText = `
@@ -139,15 +144,12 @@ allow_author: true
 allow_contributor: true
 invalidate_on_push: true
 methods:
-  github_review: true
+  github_review: false
 `
-	trueBool := true
+	falseGithubReview := false
 	expectedMethods = &common.Methods{
-		Comments: []string{
-			":+1:",
-			"👍",
-		},
-		GithubReview: &trueBool,
+		Comments:     &defaultComments,
+		GithubReview: &falseGithubReview,
 	}
 
 	var optionsTwo *Options
@@ -155,7 +157,7 @@ methods:
 
 	methods = optionsTwo.GetMethods()
 
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
+	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 	optionsText = `
@@ -163,12 +165,16 @@ allow_author: true
 allow_contributor: true
 invalidate_on_push: true
 `
+	expectedMethods = &common.Methods{
+		Comments:     &defaultComments,
+		GithubReview: &defaultGithubReview,
+	}
 	var optionsThree *Options
 	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &optionsThree))
 
 	methods = optionsThree.GetMethods()
 
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
+	require.True(t, reflect.DeepEqual(*expectedMethods.Comments, *methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
 
 }

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -157,6 +157,20 @@ methods:
 
 	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
 	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
+
+	optionsText = `
+allow_author: true
+allow_contributor: true
+invalidate_on_push: true
+`
+	var optionsThree *Options
+	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &optionsThree))
+
+	methods = optionsThree.GetMethods()
+
+	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
+	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
+
 }
 
 type mockRequirement struct {

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Methods struct {
-	Comments                    *[]string `yaml:"comments,omitempty"`
-	CommentPatterns             []Regexp  `yaml:"comment_patterns,omitempty"`
-	GithubReview                *bool     `yaml:"github_review,omitempty"`
-	GithubReviewCommentPatterns []Regexp  `yaml:"github_review_comment_patterns,omitempty"`
+	Comments                    []string `yaml:"comments,omitempty"`
+	CommentPatterns             []Regexp `yaml:"comment_patterns,omitempty"`
+	GithubReview                *bool    `yaml:"github_review,omitempty"`
+	GithubReviewCommentPatterns []Regexp `yaml:"github_review_comment_patterns,omitempty"`
 
 	// If GithubReview is true, GithubReviewState is the state a review must
 	// have to be considered a candidated. It is currently excluded from
@@ -55,7 +55,7 @@ func (cs CandidatesByCreationTime) Less(i, j int) bool {
 func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candidate, error) {
 	var candidates []*Candidate
 
-	if m.Comments != nil && len(*m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+	if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 		comments, err := prctx.Comments()
 		if err != nil {
 			return nil, err
@@ -120,11 +120,9 @@ func deduplicateCandidates(all []*Candidate) []*Candidate {
 }
 
 func (m *Methods) CommentMatches(commentBody string) bool {
-	if m.Comments != nil {
-		for _, comment := range *m.Comments {
-			if strings.Contains(commentBody, comment) {
-				return true
-			}
+	for _, comment := range m.Comments {
+		if strings.Contains(commentBody, comment) {
+			return true
 		}
 	}
 	for _, pattern := range m.CommentPatterns {

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Methods struct {
-	Comments                    []string `yaml:"comments,omitempty"`
-	CommentPatterns             []Regexp `yaml:"comment_patterns,omitempty"`
-	GithubReview                *bool    `yaml:"github_review,omitempty"`
-	GithubReviewCommentPatterns []Regexp `yaml:"github_review_comment_patterns,omitempty"`
+	Comments                    *[]string `yaml:"comments,omitempty"`
+	CommentPatterns             []Regexp  `yaml:"comment_patterns,omitempty"`
+	GithubReview                *bool     `yaml:"github_review,omitempty"`
+	GithubReviewCommentPatterns []Regexp  `yaml:"github_review_comment_patterns,omitempty"`
 
 	// If GithubReview is true, GithubReviewState is the state a review must
 	// have to be considered a candidated. It is currently excluded from
@@ -55,7 +55,7 @@ func (cs CandidatesByCreationTime) Less(i, j int) bool {
 func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candidate, error) {
 	var candidates []*Candidate
 
-	if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+	if m.Comments != nil && len(*m.Comments) > 0 || len(m.CommentPatterns) > 0 {
 		comments, err := prctx.Comments()
 		if err != nil {
 			return nil, err
@@ -72,7 +72,7 @@ func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candid
 		}
 	}
 
-	if *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+	if m.GithubReview != nil && *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
 		reviews, err := prctx.Reviews()
 		if err != nil {
 			return nil, err
@@ -120,9 +120,11 @@ func deduplicateCandidates(all []*Candidate) []*Candidate {
 }
 
 func (m *Methods) CommentMatches(commentBody string) bool {
-	for _, comment := range m.Comments {
-		if strings.Contains(commentBody, comment) {
-			return true
+	if m.Comments != nil {
+		for _, comment := range *m.Comments {
+			if strings.Contains(commentBody, comment) {
+				return true
+			}
 		}
 	}
 	for _, pattern := range m.CommentPatterns {

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -25,7 +25,7 @@ import (
 type Methods struct {
 	Comments                    []string `yaml:"comments,omitempty"`
 	CommentPatterns             []Regexp `yaml:"comment_patterns,omitempty"`
-	GithubReview                bool     `yaml:"github_review,omitempty"`
+	GithubReview                *bool    `yaml:"github_review,omitempty"`
 	GithubReviewCommentPatterns []Regexp `yaml:"github_review_comment_patterns,omitempty"`
 
 	// If GithubReview is true, GithubReviewState is the state a review must
@@ -72,7 +72,7 @@ func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candid
 		}
 	}
 
-	if m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+	if *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
 		reviews, err := prctx.Reviews()
 		if err != nil {
 			return nil, err

--- a/policy/common/methods_test.go
+++ b/policy/common/methods_test.go
@@ -87,9 +87,8 @@ func TestCandidates(t *testing.T) {
 	}
 
 	t.Run("comments", func(t *testing.T) {
-		comments := []string{":+1:", ":lgtm:"}
 		m := &Methods{
-			Comments: &comments,
+			Comments: []string{":+1:", ":lgtm:"},
 		}
 
 		cs, err := m.Candidates(ctx, prctx)
@@ -156,9 +155,8 @@ func TestCandidates(t *testing.T) {
 
 	t.Run("deduplicate", func(t *testing.T) {
 		githubReview := true
-		comments := []string{":+1:", ":lgtm:"}
 		m := &Methods{
-			Comments:          &comments,
+			Comments:          []string{":+1:", ":lgtm:"},
 			GithubReview:      &githubReview,
 			GithubReviewState: pull.ReviewApproved,
 		}

--- a/policy/common/methods_test.go
+++ b/policy/common/methods_test.go
@@ -87,8 +87,10 @@ func TestCandidates(t *testing.T) {
 	}
 
 	t.Run("comments", func(t *testing.T) {
+		defaultBool := true
 		m := &Methods{
-			Comments: []string{":+1:", ":lgtm:"},
+			Comments:     []string{":+1:", ":lgtm:"},
+			GithubReview: &defaultBool,
 		}
 
 		cs, err := m.Candidates(ctx, prctx)
@@ -102,7 +104,9 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("commentPatterns", func(t *testing.T) {
+		defaultBool := true
 		m := &Methods{
+			GithubReview: &defaultBool,
 			CommentPatterns: []Regexp{
 				NewCompiledRegexp(regexp.MustCompile("^(?i:looks good to me)")),
 			},
@@ -118,8 +122,9 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("githubReviewCommentPatterns", func(t *testing.T) {
+		defaultBool := true
 		m := &Methods{
-			GithubReview:      true,
+			GithubReview:      &defaultBool,
 			GithubReviewState: pull.ReviewApproved,
 			GithubReviewCommentPatterns: []Regexp{
 				NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
@@ -137,8 +142,9 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("reviews", func(t *testing.T) {
+		defaultBool := true
 		m := &Methods{
-			GithubReview:      true,
+			GithubReview:      &defaultBool,
 			GithubReviewState: pull.ReviewChangesRequested,
 		}
 
@@ -152,9 +158,10 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("deduplicate", func(t *testing.T) {
+		defaultBool := true
 		m := &Methods{
 			Comments:          []string{":+1:", ":lgtm:"},
-			GithubReview:      true,
+			GithubReview:      &defaultBool,
 			GithubReviewState: pull.ReviewApproved,
 		}
 

--- a/policy/common/methods_test.go
+++ b/policy/common/methods_test.go
@@ -87,10 +87,9 @@ func TestCandidates(t *testing.T) {
 	}
 
 	t.Run("comments", func(t *testing.T) {
-		defaultBool := true
+		comments := []string{":+1:", ":lgtm:"}
 		m := &Methods{
-			Comments:     []string{":+1:", ":lgtm:"},
-			GithubReview: &defaultBool,
+			Comments: &comments,
 		}
 
 		cs, err := m.Candidates(ctx, prctx)
@@ -104,9 +103,7 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("commentPatterns", func(t *testing.T) {
-		defaultBool := true
 		m := &Methods{
-			GithubReview: &defaultBool,
 			CommentPatterns: []Regexp{
 				NewCompiledRegexp(regexp.MustCompile("^(?i:looks good to me)")),
 			},
@@ -122,9 +119,9 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("githubReviewCommentPatterns", func(t *testing.T) {
-		defaultBool := true
+		githubReview := true
 		m := &Methods{
-			GithubReview:      &defaultBool,
+			GithubReview:      &githubReview,
 			GithubReviewState: pull.ReviewApproved,
 			GithubReviewCommentPatterns: []Regexp{
 				NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
@@ -142,9 +139,9 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("reviews", func(t *testing.T) {
-		defaultBool := true
+		githubReview := true
 		m := &Methods{
-			GithubReview:      &defaultBool,
+			GithubReview:      &githubReview,
 			GithubReviewState: pull.ReviewChangesRequested,
 		}
 
@@ -158,10 +155,11 @@ func TestCandidates(t *testing.T) {
 	})
 
 	t.Run("deduplicate", func(t *testing.T) {
-		defaultBool := true
+		githubReview := true
+		comments := []string{":+1:", ":lgtm:"}
 		m := &Methods{
-			Comments:          []string{":+1:", ":lgtm:"},
-			GithubReview:      &defaultBool,
+			Comments:          &comments,
+			GithubReview:      &githubReview,
 			GithubReviewState: pull.ReviewApproved,
 		}
 

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -44,12 +44,13 @@ type Methods struct {
 func (opts *Options) GetDisapproveMethods() *common.Methods {
 	m := opts.Methods.Disapprove
 	if m == nil {
+		defaultBool := true
 		m = &common.Methods{
 			Comments: []string{
 				":-1:",
 				"👎",
 			},
-			GithubReview: true,
+			GithubReview: &defaultBool,
 		}
 	}
 
@@ -60,12 +61,13 @@ func (opts *Options) GetDisapproveMethods() *common.Methods {
 func (opts *Options) GetRevokeMethods() *common.Methods {
 	m := opts.Methods.Revoke
 	if m == nil {
+		defaultBool := true
 		m = &common.Methods{
 			Comments: []string{
 				":+1:",
 				"👍",
 			},
-			GithubReview: true,
+			GithubReview: &defaultBool,
 		}
 	}
 
@@ -87,7 +89,7 @@ func (p *Policy) Trigger() common.Trigger {
 		if len(dm.Comments) > 0 || len(rm.Comments) > 0 {
 			t |= common.TriggerComment
 		}
-		if dm.GithubReview || rm.GithubReview {
+		if *dm.GithubReview || *rm.GithubReview {
 			t |= common.TriggerReview
 		}
 	}

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -45,12 +45,11 @@ func (opts *Options) GetDisapproveMethods() *common.Methods {
 	m := opts.Methods.Disapprove
 	if m == nil {
 		githubReview := true
-		comments := []string{
-			":-1:",
-			"👎",
-		}
 		m = &common.Methods{
-			Comments:     &comments,
+			Comments: []string{
+				":-1:",
+				"👎",
+			},
 			GithubReview: &githubReview,
 		}
 	}
@@ -63,12 +62,11 @@ func (opts *Options) GetRevokeMethods() *common.Methods {
 	m := opts.Methods.Revoke
 	if m == nil {
 		githubReview := true
-		comments := []string{
-			":+1:",
-			"👍",
-		}
 		m = &common.Methods{
-			Comments:     &comments,
+			Comments: []string{
+				":+1:",
+				"👍",
+			},
 			GithubReview: &githubReview,
 		}
 	}
@@ -88,7 +86,7 @@ func (p *Policy) Trigger() common.Trigger {
 		dm := p.Options.GetDisapproveMethods()
 		rm := p.Options.GetRevokeMethods()
 
-		if dm.Comments != nil && len(*dm.Comments) > 0 || rm.Comments != nil && len(*rm.Comments) > 0 {
+		if len(dm.Comments) > 0 || len(rm.Comments) > 0 {
 			t |= common.TriggerComment
 		}
 		if dm.GithubReview != nil && *dm.GithubReview || rm.GithubReview != nil && *rm.GithubReview {

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -44,13 +44,14 @@ type Methods struct {
 func (opts *Options) GetDisapproveMethods() *common.Methods {
 	m := opts.Methods.Disapprove
 	if m == nil {
-		defaultBool := true
+		githubReview := true
+		comments := []string{
+			":-1:",
+			"👎",
+		}
 		m = &common.Methods{
-			Comments: []string{
-				":-1:",
-				"👎",
-			},
-			GithubReview: &defaultBool,
+			Comments:     &comments,
+			GithubReview: &githubReview,
 		}
 	}
 
@@ -61,13 +62,14 @@ func (opts *Options) GetDisapproveMethods() *common.Methods {
 func (opts *Options) GetRevokeMethods() *common.Methods {
 	m := opts.Methods.Revoke
 	if m == nil {
-		defaultBool := true
+		githubReview := true
+		comments := []string{
+			":+1:",
+			"👍",
+		}
 		m = &common.Methods{
-			Comments: []string{
-				":+1:",
-				"👍",
-			},
-			GithubReview: &defaultBool,
+			Comments:     &comments,
+			GithubReview: &githubReview,
 		}
 	}
 
@@ -86,10 +88,10 @@ func (p *Policy) Trigger() common.Trigger {
 		dm := p.Options.GetDisapproveMethods()
 		rm := p.Options.GetRevokeMethods()
 
-		if len(dm.Comments) > 0 || len(rm.Comments) > 0 {
+		if dm.Comments != nil && len(*dm.Comments) > 0 || rm.Comments != nil && len(*rm.Comments) > 0 {
 			t |= common.TriggerComment
 		}
-		if *dm.GithubReview || *rm.GithubReview {
+		if dm.GithubReview != nil && *dm.GithubReview || rm.GithubReview != nil && *rm.GithubReview {
 			t |= common.TriggerReview
 		}
 	}


### PR DESCRIPTION
When certain attributes are defined under 'methods', the other undefined attributes don't line up with the promised defaults. This PR resolves this issue by checking whether certain attributes were not specified and then adds defaults for them.

Closes #434 