### PR TITLE
Add a simulate page

### DIFF
--- a/server/assets/js/footer-link.js
+++ b/server/assets/js/footer-link.js
@@ -1,0 +1,17 @@
+(function() {
+    function addSimulateRedirect(){
+        const buttonId = "details-to-simulate"
+        function redirectToSimulate(event) {
+            const currentPath = location.href
+            let simulatePath = currentPath.replace("details", "simulate")
+            document.location = simulatePath
+        }
+        document.getElementById(buttonId).addEventListener("click", redirectToSimulate)
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        addSimulateRedirect()
+    }, false);
+
+
+})();

--- a/server/assets/js/prefill.js
+++ b/server/assets/js/prefill.js
@@ -1,0 +1,23 @@
+(function() {
+    function prefillSimulation(){
+        function prefillParam(param){
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            if (urlParams.has(param)) {
+                let paramValue = urlParams.get(param)
+                document.getElementById(param).value = paramValue
+            }
+        }
+
+        const BRANCH = "branch"
+        const USERNAME = "username"
+
+        prefillParam(BRANCH)
+        prefillParam(USERNAME)
+    }
+    document.addEventListener('DOMContentLoaded', function() {
+        prefillSimulation()
+    }, false);
+
+
+})();

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -239,7 +239,7 @@ func (b *Base) EvaluateConfig(ctx context.Context, prctx pull.Context, client *g
 	return result
 }
 
-func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc *FetchedConfig, result common.Result) (common.Result, error) {
+func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, client *github.Client, fc *FetchedConfig, result common.Result) (common.Result, error) {
 	logger := zerolog.Ctx(ctx)
 	statusDescription := result.StatusDescription
 
@@ -274,9 +274,8 @@ func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, cli
 
 func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc *FetchedConfig) (common.Result, error) {
 	res := b.EvaluateConfig(ctx, prctx, client, evaluator, fc)
-	var result, err = b.PostEvaluatedResults(ctx, prctx, client, evaluator, fc, res)
 
-	return result, err
+	return b.PostEvaluatedResults(ctx, prctx, client, fc, res)
 }
 
 func (b *Base) RequestReviewsForResult(ctx context.Context, prctx pull.Context, client *github.Client, trigger common.Trigger, result common.Result) error {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -114,7 +114,7 @@ func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *githu
 	}
 
 	publicURL := strings.TrimSuffix(b.BaseConfig.PublicURL, "/")
-	detailsURL := fmt.Sprintf("%s/details/%s/%s/%DetailsData", publicURL, owner, repo, prctx.Number())
+	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, prctx.Number())
 
 	contextWithBranch := fmt.Sprintf("%s: %s", b.PullOpts.StatusCheckContext, base)
 	status := &github.RepoStatus{
@@ -189,7 +189,7 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 	return b.RequestReviewsForResult(ctx, prctx, client, trigger, result)
 }
 
-func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, fc FetchedConfig, trigger common.Trigger) (common.Evaluator, error) {
+func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, fc *FetchedConfig, trigger common.Trigger) (common.Evaluator, error) {
 	logger := zerolog.Ctx(ctx)
 
 	switch {
@@ -233,13 +233,13 @@ func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, cl
 	return evaluator, nil
 }
 
-func (b *Base) EvaluateConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc FetchedConfig) common.Result {
+func (b *Base) EvaluateConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc *FetchedConfig) common.Result {
 	result := evaluator.Evaluate(ctx, prctx)
 
 	return result
 }
 
-func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc FetchedConfig, result common.Result) (common.Result, error) {
+func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc *FetchedConfig, result common.Result) (common.Result, error) {
 	logger := zerolog.Ctx(ctx)
 	statusDescription := result.StatusDescription
 
@@ -272,7 +272,7 @@ func (b *Base) PostEvaluatedResults(ctx context.Context, prctx pull.Context, cli
 	return result, nil
 }
 
-func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc FetchedConfig) (common.Result, error) {
+func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc *FetchedConfig) (common.Result, error) {
 	res := b.EvaluateConfig(ctx, prctx, client, evaluator, fc)
 	var result, err = b.PostEvaluatedResults(ctx, prctx, client, evaluator, fc, res)
 

--- a/server/handler/base_details.go
+++ b/server/handler/base_details.go
@@ -48,10 +48,10 @@ type DetailsData struct {
 	PolicyURL        string
 }
 
-func (h *DetailsBase) getURLParams(w http.ResponseWriter, r *http.Request) (string, string, int, error) {
+func (h *DetailsBase) getPrDetails(w http.ResponseWriter, r *http.Request) (string, string, int, error) {
 	owner := pat.Param(r, "owner")
 	repo := pat.Param(r, "repo")
-	//number :=
+
 	number, err := strconv.Atoi(pat.Param(r, "number"))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid pull request number: %v", err), http.StatusBadRequest)
@@ -65,7 +65,6 @@ func (h *DetailsBase) generatePrContext(ctx context.Context, owner string, repo 
 	installation, err := h.Installations.GetByOwner(ctx, owner)
 	if err != nil {
 		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
-			//h.render404(w, owner, repo, number)
 			return nil, nil
 		}
 		return nil, err
@@ -123,7 +122,6 @@ func (h *DetailsBase) getPolicyConfig(ctx context.Context, prCtx pull.Context, b
 
 func (h *DetailsBase) generateEvaluationDetails(w http.ResponseWriter, r *http.Request, policyConfig *FetchedConfig, prCtx pull.Context) (*DetailsData, *github.Client, common.Evaluator, error) {
 	ctx := r.Context()
-	//logger := zerolog.Ctx(ctx)
 
 	owner := prCtx.RepositoryOwner()
 	repo := prCtx.RepositoryName()
@@ -132,7 +130,6 @@ func (h *DetailsBase) generateEvaluationDetails(w http.ResponseWriter, r *http.R
 	installation, err := h.Installations.GetByOwner(ctx, owner)
 	if err != nil {
 		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
-			h.render404(w, owner, repo, number)
 			return nil, nil, nil, errors.Wrap(err, "Unable to find installation")
 		}
 		return nil, nil, nil, err
@@ -205,7 +202,6 @@ func (h *DetailsBase) render(w http.ResponseWriter, templateName string, data in
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
 
-	//fmt.Println(data)
 	return h.Templates.ExecuteTemplate(w, templateName, data)
 }
 

--- a/server/handler/base_details.go
+++ b/server/handler/base_details.go
@@ -1,0 +1,229 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"goji.io/pat"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/alexedwards/scs"
+	"github.com/bluekeyes/templatetree"
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type DetailsBase struct {
+	Base
+	Sessions  *scs.Manager
+	Templates templatetree.HTMLTree
+}
+
+type DetailsData struct {
+	Error            error
+	IsTemporaryError bool
+	Result           *common.Result
+	PullRequest      *github.PullRequest
+	User             string
+	PolicyURL        string
+}
+
+func (h *DetailsBase) getUrlParams(w http.ResponseWriter, r *http.Request) (string, string, int, error) {
+	owner := pat.Param(r, "owner")
+	repo := pat.Param(r, "repo")
+	//number :=
+	number, err := strconv.Atoi(pat.Param(r, "number"))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid pull request number: %v", err), http.StatusBadRequest)
+		return "", "", -1, err
+	}
+
+	return owner, repo, number, nil
+}
+
+func (h *DetailsBase) generatePrContext(ctx context.Context, owner string, repo string, number int) (pull.Context, error) {
+	installation, err := h.Installations.GetByOwner(ctx, owner)
+	if err != nil {
+		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
+			//h.render404(w, owner, repo, number)
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	client, err := h.ClientCreator.NewInstallationClient(installation.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create github client")
+	}
+
+	v4client, err := h.ClientCreator.NewInstallationV4Client(installation.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create github client")
+	}
+
+	pr, _, err := client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		if isNotFound(err) {
+			//h.render404(w, owner, repo, number)
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "failed to get pull request")
+	}
+	mbrCtx := NewCrossOrgMembershipContext(ctx, client, owner, h.Installations, h.ClientCreator)
+
+	prCtx, err := pull.NewGitHubContext(ctx, mbrCtx, client, v4client, pull.Locator{
+		Owner:  owner,
+		Repo:   repo,
+		Number: number,
+		Value:  pr,
+	})
+
+	return prCtx, err
+}
+
+func (h *DetailsBase) getPolicyConfig(ctx context.Context, prCtx pull.Context, branch string) (FetchedConfig, error) {
+	owner := prCtx.RepositoryOwner()
+
+	installation, err := h.Installations.GetByOwner(ctx, owner)
+	if err != nil {
+		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
+			//h.render404(w, owner, repo, number)
+			err = errors.Wrap(err, "failed to get github installation")
+		}
+	}
+	client, err := h.ClientCreator.NewInstallationClient(installation.ID)
+	if err != nil {
+		err = errors.Wrap(err, "failed to get github installaion")
+		//return nil, errors.Wrap(err, "failed to create github client")
+	}
+
+	config := h.ConfigFetcher.ConfigForPRBranch(ctx, prCtx, client, branch)
+
+	return config, err
+}
+
+func (h *DetailsBase) generateEvaluationDetails(w http.ResponseWriter, r *http.Request, policyConfig FetchedConfig, prCtx pull.Context) (*DetailsData, *github.Client, common.Evaluator, error) {
+	ctx := r.Context()
+	//logger := zerolog.Ctx(ctx)
+
+	owner := prCtx.RepositoryOwner()
+	repo := prCtx.RepositoryName()
+	number := prCtx.Number()
+
+	installation, err := h.Installations.GetByOwner(ctx, owner)
+	if err != nil {
+		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
+			h.render404(w, owner, repo, number)
+			return nil, nil, nil, errors.Wrap(err, "Unable to find installation")
+		}
+		return nil, nil, nil, err
+	}
+
+	client, err := h.ClientCreator.NewInstallationClient(installation.ID)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to create github client")
+	}
+
+	sess := h.Sessions.Load(r)
+	user, err := sess.GetString(SessionKeyUsername)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to read sessions")
+	}
+
+	level, _, err := client.Repositories.GetPermissionLevel(ctx, owner, repo, user)
+	if err != nil {
+		if isNotFound(err) {
+			h.render404(w, owner, repo, number)
+			return nil, nil, nil, nil
+		}
+		return nil, nil, nil, errors.Wrap(err, "failed to get user permission level")
+	}
+
+	// if the user does not have permission, pretend the repo/PR doesn't exist
+	if level.GetPermission() == "none" {
+		h.render404(w, owner, repo, number)
+		return nil, nil, nil, nil
+	}
+
+	pr, _, err := client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		if isNotFound(err) {
+			h.render404(w, owner, repo, number)
+			return nil, nil, nil, nil
+		}
+		return nil, nil, nil, errors.Wrap(err, "failed to get pull request")
+	}
+
+	var data DetailsData
+
+	data.PullRequest = pr
+	data.User = user
+
+	data.PolicyURL = getPolicyURL(pr, policyConfig)
+
+	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prCtx, client, policyConfig, common.TriggerAll)
+	if err != nil {
+		data.Error = err
+		return &data, nil, nil, nil
+	}
+	if evaluator == nil {
+		data.Error = errors.Errorf("Invalid policy at %s: %s", policyConfig.Source, policyConfig.Path)
+		return &data, nil, nil, nil
+	}
+
+	return &data, client, evaluator, nil
+}
+
+func (h *DetailsBase) render404(w http.ResponseWriter, owner, repo string, number int) {
+	msg := fmt.Sprintf(
+		"Not Found: %s/%s#%DetailsData\n\nThe repository or pull request does not exist, you do not have permission, or policy-bot is not installed.",
+		owner, repo, number,
+	)
+	http.Error(w, msg, http.StatusNotFound)
+}
+
+func (h *DetailsBase) render(w http.ResponseWriter, templateName string, data interface{}) error {
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+
+	//fmt.Println(data)
+	return h.Templates.ExecuteTemplate(w, templateName, data)
+}
+
+func getPolicyURL(pr *github.PullRequest, config FetchedConfig) string {
+	base := pr.GetBase().GetRepo().GetHTMLURL()
+	if u, _ := url.Parse(base); u != nil {
+		srcParts := strings.Split(config.Source, "@")
+		if len(srcParts) != 2 {
+			return base
+		}
+		u.Path = path.Join(srcParts[0], "blob", srcParts[1], config.Path)
+		return u.String()
+	}
+	return base
+}
+
+func isNotFound(err error) bool {
+	rerr, ok := err.(*github.ErrorResponse)
+	return ok && rerr.Response.StatusCode == http.StatusNotFound
+}

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -26,7 +26,7 @@ type Details struct {
 func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	owner, repo, number, err := h.getURLParams(w, r)
+	owner, repo, number, err := h.getPrDetails(w, r)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,10 @@ func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 		return errors.Wrap(err, "failed to get policy config")
 	}
 
-	details, client, evaluator, _ := h.generateEvaluationDetails(w, r, policyConfig, prCtx)
+	details, client, evaluator, err := h.generateEvaluationDetails(w, r, policyConfig, prCtx)
+	if err != nil {
+		h.render404(w, owner, repo, number)
+	}
 
 	result, _ := h.Base.EvaluateFetchedConfig(ctx, prCtx, client, evaluator, policyConfig)
 	details.Result = &result

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -15,169 +15,30 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
-	"path"
-	"strconv"
-	"strings"
-
-	"github.com/alexedwards/scs"
-	"github.com/bluekeyes/templatetree"
-	"github.com/google/go-github/v45/github"
-	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/palantir/policy-bot/policy/common"
-	"github.com/palantir/policy-bot/pull"
-	"github.com/pkg/errors"
-	"goji.io/pat"
 )
 
 type Details struct {
-	Base
-	Sessions  *scs.Manager
-	Templates templatetree.HTMLTree
+	DetailsBase
 }
 
 func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	owner := pat.Param(r, "owner")
-	repo := pat.Param(r, "repo")
-
-	number, err := strconv.Atoi(pat.Param(r, "number"))
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Invalid pull request number: %v", err), http.StatusBadRequest)
-		return nil
-	}
-
-	installation, err := h.Installations.GetByOwner(ctx, owner)
-	if err != nil {
-		if _, notFound := err.(githubapp.InstallationNotFound); notFound {
-			h.render404(w, owner, repo, number)
-			return nil
-		}
-		return err
-	}
-
-	client, err := h.ClientCreator.NewInstallationClient(installation.ID)
-	if err != nil {
-		return errors.Wrap(err, "failed to create github client")
-	}
-
-	v4client, err := h.ClientCreator.NewInstallationV4Client(installation.ID)
-	if err != nil {
-		return errors.Wrap(err, "failed to create github client")
-	}
-
-	sess := h.Sessions.Load(r)
-	user, err := sess.GetString(SessionKeyUsername)
-	if err != nil {
-		return errors.Wrap(err, "failed to read sessions")
-	}
-
-	level, _, err := client.Repositories.GetPermissionLevel(ctx, owner, repo, user)
-	if err != nil {
-		if isNotFound(err) {
-			h.render404(w, owner, repo, number)
-			return nil
-		}
-		return errors.Wrap(err, "failed to get user permission level")
-	}
-
-	// if the user does not have permission, pretend the repo/PR doesn't exist
-	if level.GetPermission() == "none" {
-		h.render404(w, owner, repo, number)
-		return nil
-	}
-
-	pr, _, err := client.PullRequests.Get(ctx, owner, repo, number)
-	if err != nil {
-		if isNotFound(err) {
-			h.render404(w, owner, repo, number)
-			return nil
-		}
-		return errors.Wrap(err, "failed to get pull request")
-	}
-
-	ctx, _ = h.PreparePRContext(ctx, installation.ID, pr)
-
-	mbrCtx := NewCrossOrgMembershipContext(ctx, client, owner, h.Installations, h.ClientCreator)
-	prctx, err := pull.NewGitHubContext(ctx, mbrCtx, client, v4client, pull.Locator{
-		Owner:  owner,
-		Repo:   repo,
-		Number: number,
-		Value:  pr,
-	})
+	owner, repo, number, err := h.getUrlParams(w, r)
 	if err != nil {
 		return err
 	}
 
-	var data struct {
-		Error            error
-		IsTemporaryError bool
-		Result           *common.Result
-		PullRequest      *github.PullRequest
-		User             string
-		PolicyURL        string
-	}
+	prCtx, err := h.generatePrContext(ctx, owner, repo, number)
+	branch, _ := prCtx.Branches()
 
-	data.PullRequest = pr
-	data.User = user
+	policyConfig, _ := h.getPolicyConfig(ctx, prCtx, branch)
+	details, client, evaluator, _ := h.generateEvaluationDetails(w, r, policyConfig, prCtx)
 
-	config := h.ConfigFetcher.ConfigForPR(ctx, prctx, client)
-	data.PolicyURL = getPolicyURL(pr, config)
-
-	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, config, common.TriggerAll)
-	if err != nil {
-		data.Error = err
-		return h.render(w, data)
-	}
-	if evaluator == nil {
-		data.Error = errors.Errorf("Invalid policy at %s: %s", config.Source, config.Path)
-		return h.render(w, data)
-	}
-
-	result, err := h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, config)
-	data.Result = &result
-
-	if err != nil {
-		if _, ok := errors.Cause(err).(*pull.TemporaryError); ok {
-			data.IsTemporaryError = true
-		}
-		data.Error = err
-	}
-
-	return h.render(w, data)
-}
-
-func (h *Details) render(w http.ResponseWriter, data interface{}) error {
+	result, err := h.Base.EvaluateFetchedConfig(ctx, prCtx, client, evaluator, policyConfig)
+	details.Result = &result
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
-	return h.Templates.ExecuteTemplate(w, "details.html.tmpl", data)
-}
-
-func (h *Details) render404(w http.ResponseWriter, owner, repo string, number int) {
-	msg := fmt.Sprintf(
-		"Not Found: %s/%s#%d\n\nThe repository or pull request does not exist, you do not have permission, or policy-bot is not installed.",
-		owner, repo, number,
-	)
-	http.Error(w, msg, http.StatusNotFound)
-}
-
-func getPolicyURL(pr *github.PullRequest, config FetchedConfig) string {
-	base := pr.GetBase().GetRepo().GetHTMLURL()
-	if u, _ := url.Parse(base); u != nil {
-		srcParts := strings.Split(config.Source, "@")
-		if len(srcParts) != 2 {
-			return base
-		}
-		u.Path = path.Join(srcParts[0], "blob", srcParts[1], config.Path)
-		return u.String()
-	}
-	return base
-}
-
-func isNotFound(err error) bool {
-	rerr, ok := err.(*github.ErrorResponse)
-	return ok && rerr.Response.StatusCode == http.StatusNotFound
+	return h.render(w, "details.html.tmpl", details)
 }

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -36,7 +36,7 @@ type ConfigFetcher struct {
 	Loader *appconfig.Loader
 }
 
-func (cf *ConfigFetcher) ConfigForPRBranch(ctx context.Context, prctx pull.Context, client *github.Client, branch string) FetchedConfig {
+func (cf *ConfigFetcher) ConfigForPRBranch(ctx context.Context, prctx pull.Context, client *github.Client, branch string) *FetchedConfig {
 	c, err := cf.Loader.LoadConfig(ctx, client, prctx.RepositoryOwner(), prctx.RepositoryName(), branch)
 	fc := FetchedConfig{
 		Source: c.Source,
@@ -46,9 +46,9 @@ func (cf *ConfigFetcher) ConfigForPRBranch(ctx context.Context, prctx pull.Conte
 	switch {
 	case err != nil:
 		fc.LoadError = err
-		return fc
+		return &fc
 	case c.IsUndefined():
-		return fc
+		return &fc
 	}
 
 	var pc policy.Config
@@ -57,10 +57,10 @@ func (cf *ConfigFetcher) ConfigForPRBranch(ctx context.Context, prctx pull.Conte
 	} else {
 		fc.Config = &pc
 	}
-	return fc
+	return &fc
 }
 
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) FetchedConfig {
+func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) *FetchedConfig {
 	base, _ := prctx.Branches()
 
 	return cf.ConfigForPRBranch(ctx, prctx, client, base)

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -16,7 +16,6 @@ package handler
 
 import (
 	"context"
-
 	"github.com/google/go-github/v45/github"
 	"github.com/palantir/go-githubapp/appconfig"
 	"github.com/palantir/policy-bot/policy"
@@ -37,10 +36,8 @@ type ConfigFetcher struct {
 	Loader *appconfig.Loader
 }
 
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) FetchedConfig {
-	base, _ := prctx.Branches()
-
-	c, err := cf.Loader.LoadConfig(ctx, client, prctx.RepositoryOwner(), prctx.RepositoryName(), base)
+func (cf *ConfigFetcher) ConfigForPRBranch(ctx context.Context, prctx pull.Context, client *github.Client, branch string) FetchedConfig {
+	c, err := cf.Loader.LoadConfig(ctx, client, prctx.RepositoryOwner(), prctx.RepositoryName(), branch)
 	fc := FetchedConfig{
 		Source: c.Source,
 		Path:   c.Path,
@@ -61,4 +58,10 @@ func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, cl
 		fc.Config = &pc
 	}
 	return fc
+}
+
+func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) FetchedConfig {
+	base, _ := prctx.Branches()
+
+	return cf.ConfigForPRBranch(ctx, prctx, client, base)
 }

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"github.com/palantir/policy-bot/pull"
+	"net/http"
+	"time"
+)
+
+type Simulate struct {
+	DetailsBase
+}
+
+type fakePrContext struct {
+	pull.Context
+
+	additionalApprovals []string
+}
+
+func (f *fakePrContext) Reviews() ([]*pull.Review, error) {
+	reviews, err := f.Context.Reviews()
+
+	for _, username := range f.additionalApprovals {
+		reviews = append(reviews, &pull.Review{CreatedAt: time.Now(), UpdatedAt: time.Now(), Author: username, State: pull.ReviewApproved})
+	}
+
+	return reviews, err
+}
+
+func new(ctx pull.Context) *fakePrContext {
+	return &fakePrContext{Context: ctx}
+}
+
+func (f *fakePrContext) addApproval(username string) {
+	f.additionalApprovals = append(f.additionalApprovals, username)
+}
+
+func (h *Simulate) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	owner, repo, number, err := h.getUrlParams(w, r)
+	if err != nil {
+		return err
+	}
+
+	queryParams := r.URL.Query()
+	prCtx, err := h.generatePrContext(ctx, owner, repo, number)
+	var branch, username string
+
+	if queryParams.Has("branch") {
+		branch = queryParams.Get("branch")
+	} else {
+		branch, _ = prCtx.Branches()
+	}
+
+	if queryParams.Has("username") && queryParams.Get("username") != "" {
+		username = queryParams.Get("username")
+		fakePrContext := new(prCtx)
+		fakePrContext.addApproval(username)
+		prCtx = fakePrContext
+	}
+
+	policyConfig, _ := h.getPolicyConfig(ctx, prCtx, branch)
+	details, client, evaluator, _ := h.generateEvaluationDetails(w, r, policyConfig, prCtx)
+
+	result := h.Base.EvaluateConfig(ctx, prCtx, client, evaluator, policyConfig)
+	details.Result = &result
+
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	return h.render(w, "simulate.html.tmpl", details)
+}

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
 	"net/http"
 	"time"
 )
@@ -51,7 +52,7 @@ func (f *fakePrContext) addApproval(username string) {
 func (h *Simulate) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 
-	owner, repo, number, err := h.getUrlParams(w, r)
+	owner, repo, number, err := h.getURLParams(w, r)
 	if err != nil {
 		return err
 	}
@@ -74,6 +75,10 @@ func (h *Simulate) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	policyConfig, _ := h.getPolicyConfig(ctx, prCtx, branch)
+	if err != nil {
+		h.render404(w, owner, repo, number)
+		return errors.Wrap(err, "failed to get policy config")
+	}
 	details, client, evaluator, _ := h.generateEvaluationDetails(w, r, policyConfig, prCtx)
 
 	result := h.Base.EvaluateConfig(ctx, prCtx, client, evaluator, policyConfig)

--- a/server/server.go
+++ b/server/server.go
@@ -217,12 +217,26 @@ func New(c *Config) (*Server, error) {
 
 	details := goji.SubMux()
 	details.Use(handler.RequireLogin(sessions, basePath))
-	details.Handle(pat.Get("/:owner/:repo/:number"), hatpear.Try(&handler.Details{
-		Base:      basePolicyHandler,
-		Sessions:  sessions,
-		Templates: templates,
-	}))
+	details.Handle(pat.Get("/:owner/:repo/:number"), hatpear.Try(
+		&handler.Details{
+			DetailsBase: handler.DetailsBase{
+				Base:      basePolicyHandler,
+				Sessions:  sessions,
+				Templates: templates,
+			}}))
 	mux.Handle(pat.New("/details/*"), details)
+
+	simulate := goji.SubMux()
+	simulate.Use(handler.RequireLogin(sessions, basePath))
+	simulate.Handle(pat.Get("/:owner/:repo/:number"), hatpear.Try(
+		&handler.Simulate{
+			DetailsBase: handler.DetailsBase{
+				Base:      basePolicyHandler,
+				Sessions:  sessions,
+				Templates: templates,
+			}}))
+
+	mux.Handle(pat.New("/simulate/*"), simulate)
 
 	return &Server{
 		config: c,

--- a/server/templates/base-details.html.tmpl
+++ b/server/templates/base-details.html.tmpl
@@ -1,0 +1,156 @@
+{{/* templatetree:extends page.html.tmpl */}}
+{{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
+
+{{define "scripts"}}
+<script defer src="{{ resource "js/filter.js" }}"></script>
+{{end}}
+
+{{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
+
+{{define "body"}}
+  {{block "top" .}}{{end}}
+  {{block "details" .}}{{end}}
+  {{ block "footer" .}}{{end}}
+{{end}}
+
+{{define "details"}}
+  {{if .Error}}
+    <div class="status-banner error">
+      <h2 class="mb-1 text-lg font-bold">Error</h2>
+      <p>{{.Error}}</p>
+      {{if .IsTemporaryError}}
+        <p class="status-temporary">This error may be temporary. Wait 30 seconds and refresh this page to retry.</p>
+      {{end}}
+    </div>
+  {{else}}
+    {{ $s := (or (and .Result.Error "error") (.Result.Status | print)) }}
+    <div class="status-banner {{$s}} flex flex-wrap items-center justify-between">
+      <div>
+        <h2 class="mb-1 text-lg font-bold">Status: {{$s | titlecase}}</h2>
+        <p>{{or .Result.Error .Result.StatusDescription}}</p>
+      </div>
+      <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
+        <div class="toggle">
+          <input id="filter-toggle" type="checkbox" autocomplete="off" />
+          <label for="filter-toggle">Hide skipped rules</label>
+        </div>
+      </div>
+    </div>
+    <div class="pl-8 overflow-auto flex-grow">
+      <ul class="tree px-4 pb-4">
+        {{range .Result.Children | sortByStatus}}{{template "result" .}}{{end}}
+      </ul>
+    </div>
+  {{end}}
+{{end}}
+
+
+{{define "result"}}
+  {{ $s := (or (and .Error "error") (.Status | print)) }}
+  <li data-status="{{$s}}">
+    <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
+      {{template "result-details" .}}
+      {{if (or (.PredicateResults) (hasRequires .Requires) (hasRequiresPermissions .Requires))}}
+        <details class="bg-light-gray5 p-2 mt-2 text-sm">
+          <summary class="text-dark-gray3 font-semibold">Details</summary>
+          <div class="border-t border-light-gray3 mt-2 overflow-x-auto whitespace-nowrap">
+            {{if .PredicateResults}}
+              <div class="pt-2">
+                {{template "result-predicates-details" .}}
+              </div>
+            {{end}}
+            {{if (hasRequires .Requires)}}
+              <div class="pt-2">
+                {{template "result-requires-details" .}}
+              </div>
+            {{end}}
+            {{if (hasRequiresPermissions .Requires)}}
+              <div class="pt-2">
+                {{template "result-requires-permissions-details" .}}
+              </div>
+            {{end}}
+          </div>
+        </details>
+      {{end}}
+    </div>
+    {{if .Children}}
+      <ul class="tree">
+        {{range .Children | sortByStatus}}{{template "result" .}}{{end}}
+      </ul>
+    {{end}}
+  </li>
+{{end}}
+
+{{define "result-details"}}
+  {{ $s := (or (and .Error "error") (.Status | print)) }}
+  <p class="mb-2 flex items-center">
+    <b class="font-bold">{{.Name}}</b>
+    <span class="flex-none status-badge {{$s}}">{{$s | titlecase}}</span>
+  </p>
+  {{if (and .Description (ne $s "skipped"))}}
+    <p class="mb-2 text-dark-gray3 text-sm">{{.Description}}</p>
+  {{end}}
+  <p class="text-dark-gray3 text-sm">{{or .Error .StatusDescription}}</p>
+{{end}}
+
+{{define "result-predicates-details"}}
+  {{ $s := (or (and .Error "error") (.Status | print)) }}
+  {{if eq $s "skipped"}}
+    <b class="font-bold">This rule is skipped because</b>
+  {{else}}
+    <b class="font-bold">This rule is selected because</b>
+  {{end}}
+  {{template "result-predicates-info" .}}
+{{end}}
+
+{{define "result-predicates-info"}}
+  {{ $s := (or (and .Error "error") (.Status | print)) }}
+  <ul class="list-decimal list-outside pl-4 my-2">
+    {{range .PredicateResults}}
+      <li>
+        {{if .Values}}
+          The {{.ValuePhrase}}:
+          <ul class="list-disc list-outside pl-6 py-2">
+            {{range .Values}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
+          </ul>
+          {{if eq $s "skipped"}}do not {{end}}{{.ConditionPhrase}}
+          {{if .ConditionsMap}}
+            <dl class="pt-2 pl-4">
+              {{range $k, $v := .ConditionsMap}}
+                {{if $v}}
+                  <dt>{{$k}}</dt>
+                  <dd>
+                    <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+                  </dd>
+                {{end}}
+              {{end}}
+            </dl>
+          {{else if .ConditionValues}}
+            <ul class="list-disc list-outside pl-6 py-2">{{range .ConditionValues}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+          {{end}}
+        {{else}}
+          There are no {{.ValuePhrase}}
+        {{end}}
+      </li>
+    {{end}}
+  </ul>
+{{end}}
+
+{{define "result-requires-details"}}
+  <b class="font-bold text-sm">This rule requires review from</b>
+  <dl class="my-2">
+    {{range $k, $v := getRequires .}}
+      <dt> {{$k}}</dt>
+      <dd>
+        <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono"><a href={{.Link}}>{{.Name}}</a></li>{{end}}</ul>
+      </dd>
+    {{end}}
+  </dl>
+{{end}}
+
+{{define "result-requires-permissions-details"}}
+  <b class="font-bold text-sm">This rule requires review from users with the following permissions</b>
+  <ul class="list-disc list-outside pl-6 py-2">
+    {{range getPermissions .}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
+  </ul>
+{{end}}

--- a/server/templates/base-details.html.tmpl
+++ b/server/templates/base-details.html.tmpl
@@ -3,6 +3,7 @@
 
 {{define "scripts"}}
 <script defer src="{{ resource "js/filter.js" }}"></script>
+ <script defer src="{{ resource "js/footer-link.js" }}"></script>
 {{end}}
 
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -1,12 +1,14 @@
-{{/* templatetree:extends page.html.tmpl */}}
+{{/* templatetree:extends base-details.html.tmpl */}}
 {{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
 
 {{define "scripts"}}
-<script defer src="{{ resource "js/filter.js" }}"></script>
+  <script defer src="{{ resource "js/filter.js" }}"></script>
+  <script defer src="{{ resource "js/footer-link.js" }}"></script>
 {{end}}
 
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
-{{define "body"}}
+
+{{define "top"}}
   <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">
     <a href="{{.PolicyURL}}" title="View the policy definition on GitHub"
        class="px-2 py-1 text-xs text-dark-gray3 bg-light-gray3 border border-light-gray2 rounded-sm truncate max-w-full hover:bg-light-gray2 no-underline hover:no-underline">
@@ -21,142 +23,10 @@
       {{.User}}
     </span>
   </header>
-  {{if .Error}}
-    <div class="status-banner error">
-      <h2 class="mb-1 text-lg font-bold">Error</h2>
-      <p>{{.Error}}</p>
-      {{if .IsTemporaryError}}
-          <p class="status-temporary">This error may be temporary. Wait 30 seconds and refresh this page to retry.</p>
-      {{end}}
-    </div>
-  {{else}}
-    {{ $s := (or (and .Result.Error "error") (.Result.Status | print)) }}
-    <div class="status-banner {{$s}} flex flex-wrap items-center justify-between">
-      <div>
-        <h2 class="mb-1 text-lg font-bold">Status: {{$s | titlecase}}</h2>
-        <p>{{or .Result.Error .Result.StatusDescription}}</p>
-      </div>
-      <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
-        <div class="toggle">
-            <input id="filter-toggle" type="checkbox" autocomplete="off" />
-            <label for="filter-toggle">Hide skipped rules</label>
-        </div>
-      </div>
-    </div>
-    <div class="pl-8 overflow-auto flex-grow">
-      <ul class="tree px-4 pb-4">
-          {{range .Result.Children | sortByStatus}}{{template "result" .}}{{end}}
-      </ul>
-    </div>
-  {{end}}
 {{end}}
 
-{{define "result"}}
-{{ $s := (or (and .Error "error") (.Status | print)) }}
-<li data-status="{{$s}}">
-  <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
-    {{template "result-details" .}}
-    {{if (or (.PredicateResults) (hasRequires .Requires) (hasRequiresPermissions .Requires))}}
-    <details class="bg-light-gray5 p-2 mt-2 text-sm">
-      <summary class="text-dark-gray3 font-semibold">Details</summary>
-      <div class="border-t border-light-gray3 mt-2 overflow-x-auto whitespace-nowrap">
-       {{if .PredicateResults}}
-          <div class="pt-2">
-            {{template "result-predicates-details" .}}
-          </div>
-        {{end}}
-        {{if (hasRequires .Requires)}}
-          <div class="pt-2">
-          {{template "result-requires-details" .}}
-          </div>
-        {{end}}
-        {{if (hasRequiresPermissions .Requires)}}
-          <div class="pt-2">
-          {{template "result-requires-permissions-details" .}}
-          </div>
-        {{end}}
-      </div>
-    </details>
-    {{end}}
-  </div>
-  {{if .Children}}
-  <ul class="tree">
-    {{range .Children | sortByStatus}}{{template "result" .}}{{end}}
-  </ul>
-  {{end}}
-</li>
-{{end}}
-
-{{define "result-details"}}
-  {{ $s := (or (and .Error "error") (.Status | print)) }}
-  <p class="mb-2 flex items-center">
-    <b class="font-bold">{{.Name}}</b>
-    <span class="flex-none status-badge {{$s}}">{{$s | titlecase}}</span>
-  </p>
-  {{if (and .Description (ne $s "skipped"))}}
-  <p class="mb-2 text-dark-gray3 text-sm">{{.Description}}</p>
-  {{end}}
-  <p class="text-dark-gray3 text-sm">{{or .Error .StatusDescription}}</p>
-{{end}}
-
-{{define "result-predicates-details"}}
-  {{ $s := (or (and .Error "error") (.Status | print)) }}
-  {{if eq $s "skipped"}}
-    <b class="font-bold">This rule is skipped because</b>
-  {{else}}
-    <b class="font-bold">This rule is selected because</b>
-  {{end}}
-  {{template "result-predicates-info" .}}
-{{end}}
-
-{{define "result-predicates-info"}}
-  {{ $s := (or (and .Error "error") (.Status | print)) }}
-  <ul class="list-decimal list-outside pl-4 my-2">
-  {{range .PredicateResults}}
-    <li>
-      {{if .Values}}
-        The {{.ValuePhrase}}:
-        <ul class="list-disc list-outside pl-6 py-2">
-          {{range .Values}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
-        </ul>
-        {{if eq $s "skipped"}}do not {{end}}{{.ConditionPhrase}}
-        {{if .ConditionsMap}}
-        <dl class="pt-2 pl-4">
-        {{range $k, $v := .ConditionsMap}}
-          {{if $v}}
-          <dt>{{$k}}</dt>
-          <dd>
-              <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
-          </dd>
-          {{end}}
-        {{end}}
-        </dl>
-        {{else if .ConditionValues}}
-          <ul class="list-disc list-outside pl-6 py-2">{{range .ConditionValues}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
-        {{end}}
-      {{else}}
-        There are no {{.ValuePhrase}}
-      {{end}}
-    </li>
-  {{end}}
-  </ul>
-{{end}}
-
-{{define "result-requires-details"}}
-  <b class="font-bold text-sm">This rule requires review from</b>
-  <dl class="my-2">
-  {{range $k, $v := getRequires .}}
-    <dt> {{$k}}</dt>
-    <dd>
-        <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono"><a href={{.Link}}>{{.Name}}</a></li>{{end}}</ul>
-    </dd>
-  {{end}}
-  </dl>
-{{end}}
-
-{{define "result-requires-permissions-details"}}
-  <b class="font-bold text-sm">This rule requires review from users with the following permissions</b>
-  <ul class="list-disc list-outside pl-6 py-2">
-    {{range getPermissions .}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
-  </ul>
+{{define "footer"}}
+  <footer class="bg-white shadow-sm w-full z-10">
+    <button id="details-to-simulate" class="bg-blue3 hover:bg-blue5 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="button">Simulate changes on this PR</button>
+  </footer>
 {{end}}

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -1,12 +1,4 @@
 {{/* templatetree:extends base-details.html.tmpl */}}
-{{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
-
-{{define "scripts"}}
-  <script defer src="{{ resource "js/filter.js" }}"></script>
-  <script defer src="{{ resource "js/footer-link.js" }}"></script>
-{{end}}
-
-{{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
 
 {{define "top"}}
   <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">

--- a/server/templates/simulate.html.tmpl
+++ b/server/templates/simulate.html.tmpl
@@ -1,0 +1,62 @@
+{{/* templatetree:extends base-details.html.tmpl */}}
+{{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
+
+{{define "scripts"}}
+  <script defer src="{{ resource "js/filter.js" }}"></script>
+  <script defer src="{{ resource "js/prefill.js" }}"></script>
+{{end}}
+
+{{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
+
+{{define "top"}}
+  <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">
+    <a href="{{.PolicyURL}}" title="View the policy definition on GitHub"
+       class="px-2 py-1 text-xs text-dark-gray3 bg-light-gray3 border border-light-gray2 rounded-sm truncate max-w-full hover:bg-light-gray2 no-underline hover:no-underline">
+      {{.PullRequest.GetBase.GetRepo.GetFullName}}: {{.PullRequest.GetBase.GetRef}}
+    </a>
+    <h1 class="text-xl font-normal tracking-tight text-center">
+      <a href="{{.PullRequest.GetHTMLURL}}" title="View the pull request on GitHub" class="text-blue3 hover:text-blue4 no-underline">
+        #{{.PullRequest.GetNumber}}</a>:
+      {{.PullRequest.GetTitle}}
+    </h1>
+    <span class="text-xs text-dark-gray3 truncate max-w-full">
+      {{.User}}
+    </span>
+  </header>
+  <div class="bg-light-gray3 border-b border-gray3">
+    <div class="pl-5 pt-5">
+      <form class="w-full max-w-md" method="get">
+        <div class="md:flex md:items-center mb-6">
+          <div class="w-full text-xl">
+            Simulation Details
+          </div>
+        </div>
+        <div class="md:items-center mb-2">
+          <div class="md:w-1/4">
+            <label class="block text-gray-700 text-sm font-bold mb-2" for="branch">Repo Branch</label>
+          </div>
+          <div class="md:w-3/4">
+            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="branch" name="branch" type="text">
+            <p class="pb-2 pl-2 pt-1 text-gray2 text-sm">The branch of this repository to find .policy.yml</p>
+          </div>
+        </div>
+        <div class="md:items-center mb-2">
+          <div class="md:w-1/4">
+            <label class="block text-gray-700 text-sm font-bold mb-2" for="username">Username</label>
+          </div>
+          <div class="md:w-3/4">
+            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="username" name="username" type="text">
+            <p class="pb-2 pl-2 pt-1 text-gray2 text-sm">A user to simulate an approval from</p>
+          </div>
+        </div>
+        <div class="md:items-center mb-6">
+          <div class="md:w-1/3"></div>
+          <div class="md:w-2/3">
+            <input class="bg-blue3 hover:bg-blue5 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" type="submit" value="Submit">
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+{{end}}
+

--- a/server/templates/simulate.html.tmpl
+++ b/server/templates/simulate.html.tmpl
@@ -1,10 +1,4 @@
 {{/* templatetree:extends base-details.html.tmpl */}}
-{{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Details | PolicyBot{{end}}
-
-{{define "scripts"}}
-  <script defer src="{{ resource "js/filter.js" }}"></script>
-  <script defer src="{{ resource "js/prefill.js" }}"></script>
-{{end}}
 
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
 
@@ -36,7 +30,7 @@
             <label class="block text-gray-700 text-sm font-bold mb-2" for="branch">Repo Branch</label>
           </div>
           <div class="md:w-3/4">
-            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="branch" name="branch" type="text">
+            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="branch" name="branch" type="text" data-queryparam="branch">
             <p class="pb-2 pl-2 pt-1 text-gray2 text-sm">The branch of this repository to find .policy.yml</p>
           </div>
         </div>
@@ -45,7 +39,7 @@
             <label class="block text-gray-700 text-sm font-bold mb-2" for="username">Username</label>
           </div>
           <div class="md:w-3/4">
-            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="username" name="username" type="text">
+            <input class="w-full shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="username" name="username" type="text" data-queryparam="username">
             <p class="pb-2 pl-2 pt-1 text-gray2 text-sm">A user to simulate an approval from</p>
           </div>
         </div>


### PR DESCRIPTION
This allows a user to:
- Input a branch that has a policy file. The simulate page will evaluate
  that policy file on the given PR
- In put a user to simulate a fake approval for. The simulate page will
  evaluate the PR as if the user had submitted an approval
- Or both!

Abstracted away the majority of functionality into  a BaseDetails
handler. This allows consumers to submit a policy and a user to override
the defaults done by the Details handler. The Details page still exists
since it currently sends the information back to GitHub.

Here is a sample of the simulate page on a test repository: 
![Screen Shot 2022-07-28 at 6 30 14 PM](https://user-images.githubusercontent.com/2712921/181658930-285f341f-e501-4e1f-a2f5-eae78f501814.png)