### PR TITLE
Add EvalContext to reduce handler duplication

### DIFF
--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -16,31 +16,17 @@ package handler
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/common"
-	"github.com/palantir/policy-bot/policy/reviewer"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"github.com/shurcooL/githubv4"
 )
 
 const (
-	DefaultPolicyPath       = ".policy.yml"
-	DefaultSharedRepository = ".github"
-	DefaultSharedPolicyPath = "policy.yml"
-
-	DefaultStatusCheckContext = "policy-bot"
-
 	LogKeyGitHubSHA = "github_sha"
 )
 
@@ -55,96 +41,11 @@ type Base struct {
 	AppName string
 }
 
-type PullEvaluationOptions struct {
-	PolicyPath string `yaml:"policy_path"`
-
-	SharedRepository string `yaml:"shared_repository"`
-	SharedPolicyPath string `yaml:"shared_policy_path"`
-
-	// StatusCheckContext will be used to create the status context. It will be used in the following
-	// pattern: <StatusCheckContext>: <Base Branch Name>
-	StatusCheckContext string `yaml:"status_check_context"`
-
-	// PostInsecureStatusChecks enables the sending of a second status using just StatusCheckContext as the context,
-	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
-	// context behaviour, and will be removed in 2.0
-	PostInsecureStatusChecks bool `yaml:"post_insecure_status_checks"`
-
-	// This field is unused but is left to avoid breaking configuration files:
-	// yaml.UnmarshalStrict returns an error for unmapped fields
-	//
-	// TODO(bkeyes): remove in version 2.0
-	Deprecated_AppName string `yaml:"app_name"`
-}
-
-func (p *PullEvaluationOptions) fillDefaults() {
-	if p.PolicyPath == "" {
-		p.PolicyPath = DefaultPolicyPath
-	}
-	if p.SharedRepository == "" {
-		p.SharedRepository = DefaultSharedRepository
-	}
-	if p.SharedPolicyPath == "" {
-		p.SharedPolicyPath = DefaultSharedPolicyPath
-	}
-
-	if p.StatusCheckContext == "" {
-		p.StatusCheckContext = DefaultStatusCheckContext
-	}
-}
-
-func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
-	setStringFromEnv("POLICY_PATH", prefix, &p.PolicyPath)
-	setStringFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
-	setStringFromEnv("SHARED_POLICY_PATH", prefix, &p.SharedPolicyPath)
-	setStringFromEnv("STATUS_CHECK_CONTEXT", prefix, &p.StatusCheckContext)
-	p.fillDefaults()
-}
-
-func (b *Base) PostStatus(ctx context.Context, prctx pull.Context, client *github.Client, state, message string) {
-	logger := zerolog.Ctx(ctx)
-
-	owner := prctx.RepositoryOwner()
-	repo := prctx.RepositoryName()
-	sha := prctx.HeadSHA()
-	base, _ := prctx.Branches()
-
-	if !prctx.IsOpen() {
-		logger.Info().Msg("Skipping status update because PR state is not open")
-		return
-	}
-
-	publicURL := strings.TrimSuffix(b.BaseConfig.PublicURL, "/")
-	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, prctx.Number())
-
-	contextWithBranch := fmt.Sprintf("%s: %s", b.PullOpts.StatusCheckContext, base)
-	status := &github.RepoStatus{
-		Context:     &contextWithBranch,
-		State:       &state,
-		Description: &message,
-		TargetURL:   &detailsURL,
-	}
-
-	if err := b.PostGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-		logger.Err(errors.WithStack(err)).Msg("Failed to post repo status")
-		return
-	}
-
-	if b.PullOpts.PostInsecureStatusChecks {
-		status.Context = &b.PullOpts.StatusCheckContext
-		if err := b.PostGitHubRepoStatus(ctx, client, owner, repo, sha, status); err != nil {
-			logger.Err(errors.WithStack(err)).Msg("Failed to post repo status with StatusCheckContext")
-		}
-	}
-
-	return
-}
-
-func (b *Base) PostGitHubRepoStatus(ctx context.Context, client *github.Client, owner, repo, ref string, status *github.RepoStatus) error {
-	logger := zerolog.Ctx(ctx)
-	logger.Info().Msgf("Setting %q status on %s to %s: %s", status.GetContext(), ref, status.GetState(), status.GetDescription())
+// PostStatus posts a GitHub commit status with consistent logging.
+func PostStatus(ctx context.Context, client *github.Client, owner, repo, ref string, status *github.RepoStatus) error {
+	zerolog.Ctx(ctx).Info().Msgf("Setting %q status on %s to %s: %s", status.GetContext(), ref, status.GetState(), status.GetDescription())
 	_, _, err := client.Repositories.CreateStatus(ctx, owner, repo, ref, status)
-	return err
+	return errors.WithStack(err)
 }
 
 func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *github.PullRequest) (context.Context, zerolog.Logger) {
@@ -156,360 +57,41 @@ func (b *Base) PreparePRContext(ctx context.Context, installationID int64, pr *g
 	return ctx, logger
 }
 
-func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger common.Trigger, loc pull.Locator) error {
+func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pull.Locator) (*EvalContext, error) {
 	client, err := b.NewInstallationClient(installationID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	v4client, err := b.NewInstallationV4Client(installationID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	mbrCtx := NewCrossOrgMembershipContext(ctx, client, loc.Owner, b.Installations, b.ClientCreator)
 	prctx, err := pull.NewGitHubContext(ctx, mbrCtx, client, v4client, loc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fetchedConfig := b.ConfigFetcher.ConfigForPR(ctx, prctx, client)
-	evaluator, err := b.ValidateFetchedConfig(ctx, prctx, client, fetchedConfig, trigger)
+
+	return &EvalContext{
+		Client:   client,
+		V4Client: v4client,
+
+		Options:   b.PullOpts,
+		PublicURL: b.BaseConfig.PublicURL,
+
+		PullContext: prctx,
+		Config:      fetchedConfig,
+	}, nil
+}
+
+func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger common.Trigger, loc pull.Locator) error {
+	evalCtx, err := b.NewEvalContext(ctx, installationID, loc)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create evaluation context")
 	}
-	if evaluator == nil {
-		return nil
-	}
-
-	result, err := b.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fetchedConfig)
-	if err != nil {
-		return err
-	}
-
-	err = b.RequestReviewsForResult(ctx, prctx, client, trigger, result)
-	if err != nil {
-		return err
-	}
-
-	err = b.dismissStaleReviewsForResult(ctx, prctx, v4client, result)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (b *Base) ValidateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, fc FetchedConfig, trigger common.Trigger) (common.Evaluator, error) {
-	logger := zerolog.Ctx(ctx)
-
-	switch {
-	case fc.LoadError != nil:
-		msg := fmt.Sprintf("Error loading policy from %s", fc.Source)
-		logger.Warn().Err(fc.LoadError).Msg(msg)
-
-		b.PostStatus(ctx, prctx, client, "error", msg)
-		return nil, errors.Wrapf(fc.LoadError, "failed to load policy: %s: %s", fc.Source, fc.Path)
-
-	case fc.ParseError != nil:
-		msg := fmt.Sprintf("Invalid policy in %s: %s", fc.Source, fc.Path)
-		logger.Warn().Err(fc.ParseError).Msg(msg)
-
-		b.PostStatus(ctx, prctx, client, "error", msg)
-		return nil, errors.Wrapf(fc.ParseError, "failed to parse policy: %s: %s", fc.Source, fc.Path)
-
-	case fc.Config == nil:
-		logger.Debug().Msg("No policy defined for repository")
-		return nil, nil
-	}
-
-	evaluator, err := policy.ParsePolicy(fc.Config)
-	if err != nil {
-		msg := fmt.Sprintf("Invalid policy in %s: %s", fc.Source, fc.Path)
-		logger.Warn().Err(err).Msg(msg)
-
-		b.PostStatus(ctx, prctx, client, "error", msg)
-		return nil, errors.Wrapf(err, "failed to create evaluator: %s: %s", fc.Source, fc.Path)
-	}
-
-	policyTrigger := evaluator.Trigger()
-	if !trigger.Matches(policyTrigger) {
-		logger.Debug().
-			Str("event_trigger", trigger.String()).
-			Str("policy_trigger", policyTrigger.String()).
-			Msg("No evaluation necessary for this trigger, skipping")
-		return nil, nil
-	}
-
-	return evaluator, nil
-}
-
-func (b *Base) EvaluateFetchedConfig(ctx context.Context, prctx pull.Context, client *github.Client, evaluator common.Evaluator, fc FetchedConfig) (common.Result, error) {
-	logger := zerolog.Ctx(ctx)
-
-	result := evaluator.Evaluate(ctx, prctx)
-	if result.Error != nil {
-		msg := fmt.Sprintf("Error evaluating policy in %s: %s", fc.Source, fc.Path)
-		logger.Warn().Err(result.Error).Msg(msg)
-
-		b.PostStatus(ctx, prctx, client, "error", msg)
-		return result, result.Error
-	}
-
-	statusDescription := result.StatusDescription
-
-	var statusState string
-	switch result.Status {
-	case common.StatusApproved:
-		statusState = "success"
-	case common.StatusDisapproved:
-		statusState = "failure"
-	case common.StatusPending:
-		statusState = "pending"
-	case common.StatusSkipped:
-		statusState = "error"
-		statusDescription = "All rules were skipped. At least one rule must match."
-	default:
-		err := errors.Errorf("Evaluation resulted in unexpected status: %s", result.Status)
-		return result, err
-	}
-
-	b.PostStatus(ctx, prctx, client, statusState, statusDescription)
-
-	return result, nil
-}
-
-func (b *Base) RequestReviewsForResult(ctx context.Context, prctx pull.Context, client *github.Client, trigger common.Trigger, result common.Result) error {
-	logger := zerolog.Ctx(ctx)
-
-	if prctx.IsDraft() || result.Status != common.StatusPending {
-		return nil
-	}
-
-	// As of 2021-05-19, there are no predicates that use comments or reviews
-	// to enable or disable rules. This means these events will never cause a
-	// change in reviewer assignment and we can skip the whole process.
-	reviewTrigger := ^(common.TriggerComment | common.TriggerReview)
-	if !trigger.Matches(reviewTrigger) {
-		return nil
-	}
-
-	if reqs := reviewer.FindRequests(&result); len(reqs) > 0 {
-		logger.Debug().Msgf("Found %d pending rules with review requests enabled", len(reqs))
-		return b.requestReviews(ctx, prctx, client, reqs)
-	}
-
-	logger.Debug().Msgf("No pending rules have review requests enabled, skipping reviewer assignment")
-	return nil
-}
-
-func (b *Base) requestReviews(ctx context.Context, prctx pull.Context, client *github.Client, reqs []*common.Result) error {
-	const maxDelayMillis = 2500
-
-	logger := zerolog.Ctx(ctx)
-
-	// Seed the random source with the PR creation time so that repeated
-	// evaluations produce the same set of reviewers. This is required to avoid
-	// duplicate requests on later evaluations.
-	r := rand.New(rand.NewSource(prctx.CreatedAt().UnixNano()))
-	selection, err := reviewer.SelectReviewers(ctx, prctx, reqs, r)
-	if err != nil {
-		return errors.Wrap(err, "failed to select reviewers")
-	}
-
-	if selection.IsEmpty() {
-		logger.Debug().Msg("No eligible users or teams found for review")
-		return nil
-	}
-
-	// This is a terrible strategy to avoid conflicts between closely spaced
-	// events assigning the same reviewers, but I expect it to work alright in
-	// practice and it avoids any kind of coordination backend:
-	//
-	// Wait a random amount of time to space out events then check for existing
-	// reviewers and apply the difference. The idea is to order two competing
-	// events such that one observes the applied reviewers of the other.
-	//
-	// Use the global random source instead of the per-PR source so that two
-	// events for the same PR don't wait for the same amount of time.
-	delay := time.Duration(rand.Intn(maxDelayMillis)) * time.Millisecond
-	logger.Debug().Msgf("Waiting for %s to spread out reviewer processing", delay)
-	time.Sleep(delay)
-
-	// Get existing reviewers _after_ computing the selection and sleeping in
-	// case something assigned reviewers (or left reviews) in the meantime.
-	reviewers, err := prctx.RequestedReviewers()
-	if err != nil {
-		return err
-	}
-
-	// After a user leaves a review, GitHub removes the user from the request
-	// list. If the review didn't actually change the state of the requesting
-	// rule, policy-bot may request the same user again. To avoid this, include
-	// any reviews on the head commit in the set of existing reviewers to avoid
-	// re-requesting them until the content changes.
-	head := prctx.HeadSHA()
-	reviews, err := prctx.Reviews()
-	if err != nil {
-		return err
-	}
-	for _, r := range reviews {
-		if r.SHA == head {
-			reviewers = append(reviewers, &pull.Reviewer{
-				Type: pull.ReviewerUser,
-				Name: r.Author,
-			})
-
-			for _, team := range r.Teams {
-				reviewers = append(reviewers, &pull.Reviewer{
-					Type: pull.ReviewerTeam,
-					Name: team,
-				})
-			}
-		}
-	}
-
-	if diff := selection.Difference(reviewers); !diff.IsEmpty() {
-		req := selectionToReviewersRequest(diff)
-		logger.Debug().
-			Strs("users", req.Reviewers).
-			Strs("teams", req.TeamReviewers).
-			Msgf("Requesting reviews from %d users and %d teams", len(req.Reviewers), len(req.TeamReviewers))
-
-		_, _, err = client.PullRequests.RequestReviewers(ctx, prctx.RepositoryOwner(), prctx.RepositoryName(), prctx.Number(), req)
-		return errors.Wrap(err, "failed to request reviewers")
-	}
-
-	logger.Debug().Msg("All selected reviewers are already assigned or were explicitly removed")
-	return nil
-}
-
-func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
-	req := github.ReviewersRequest{}
-
-	if len(s.Users) > 0 {
-		req.Reviewers = s.Users
-	} else {
-		req.Reviewers = []string{}
-	}
-
-	if len(s.Teams) > 0 {
-		req.TeamReviewers = s.Teams
-	} else {
-		req.TeamReviewers = []string{}
-	}
-
-	return req
-}
-
-func (b *Base) findResultsWithAllowedCandidates(result *common.Result) []*common.Result {
-	var results []*common.Result
-	for _, c := range result.Children {
-		results = append(results, b.findResultsWithAllowedCandidates(c)...)
-	}
-
-	if len(result.Children) == 0 && len(result.AllowedCandidates) > 0 && result.Error == nil {
-		results = append(results, result)
-	}
-
-	return results
-}
-
-func (b *Base) reviewIsAllowed(review *pull.Review, allowedCandidates []*common.Candidate) bool {
-	for _, candidate := range allowedCandidates {
-		if review.ID == candidate.ReviewID {
-			return true
-		}
-	}
-
-	return false
-}
-
-// We already know that these are discarded review candidates for one of three reasons
-// so first we check for edited and then we check to see if its a review thats at least
-// 5 seconds old and we know that it was invalidated by a new commit, and then finally
-// if it was missing a github review comment pattern that was required.
-//
-// This is brittle and may need refactoring in future versions because it assumes the bot
-// will take less than 5 seconds to respond, but thought that having a dismissal reason
-// was valuable.
-func (b *Base) reasonForDismissedReview(review *pull.Review) string {
-	if !review.LastEditedAt.IsZero() {
-		return "was edited"
-	}
-
-	if review.CreatedAt.Before(time.Now().Add(-5 * time.Second)) {
-		return "was invalidated by another commit"
-	}
-
-	return "didn't include a valid comment pattern"
-}
-
-func (b *Base) dismissStaleReviewsForResult(ctx context.Context, prctx pull.Context, v4client *githubv4.Client, result common.Result) error {
-	logger := zerolog.Ctx(ctx)
-
-	var allowedCandidates []*common.Candidate
-
-	results := b.findResultsWithAllowedCandidates(&result)
-	for _, res := range results {
-		for _, candidate := range res.AllowedCandidates {
-			if candidate.Type != common.ReviewCandidate {
-				continue
-			}
-			allowedCandidates = append(allowedCandidates, candidate)
-		}
-	}
-
-	reviews, err := prctx.Reviews()
-	if err != nil {
-		return err
-	}
-
-	for _, r := range reviews {
-		if r.State != pull.ReviewApproved {
-			continue
-		}
-
-		if b.reviewIsAllowed(r, allowedCandidates) {
-			continue
-		}
-
-		reason := b.reasonForDismissedReview(r)
-		message := fmt.Sprintf("Dismissed because the approval %s", reason)
-		logger.Info().Msgf("Dismissing stale review %s because it %s", r.ID, reason)
-		err := b.dismissPullRequestReview(ctx, v4client, r.ID, message)
-		if err != nil {
-			logger.Err(err).Msg("Failed to dismiss stale review")
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (b *Base) dismissPullRequestReview(ctx context.Context, v4client *githubv4.Client, reviewID string, message string) error {
-	var m struct {
-		DismissPullRequestReview struct {
-			ClientMutationID *githubv4.String
-		} `graphql:"dismissPullRequestReview(input: $input)"`
-	}
-
-	input := githubv4.DismissPullRequestReviewInput{
-		PullRequestReviewID: githubv4.String(reviewID),
-		Message:             githubv4.String(message),
-	}
-
-	if err := v4client.Mutate(ctx, &m, input, nil); err != nil {
-		return errors.Wrapf(err, "failed to dismiss pull request review %s", reviewID)
-	}
-
-	return nil
-}
-
-func setStringFromEnv(key, prefix string, value *string) bool {
-	if v, ok := os.LookupEnv(prefix + key); ok {
-		*value = v
-		return true
-	}
-	return false
+	return evalCtx.Evaluate(ctx, trigger)
 }

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -1,0 +1,212 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/policy-bot/policy"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/shurcooL/githubv4"
+)
+
+// EvalContext contains common fields and methods used to evaluate policy
+// requests. Handlers construct an EvalContext once they decide to handle a
+// request or event, then call the appropriate methods for each stage of
+// evaluation. Handlers with no special requirements can simply call Evaluate.
+type EvalContext struct {
+	Client   *github.Client
+	V4Client *githubv4.Client
+
+	Options   *PullEvaluationOptions
+	PublicURL string
+
+	PullContext pull.Context
+	Config      FetchedConfig
+
+	// If true, store statuses in the Status field instead of posting them to
+	// GitHub. Only the last status is saved, so when this option is enabled,
+	// callers should check for a non-nil status after each method call.
+	SkipPostStatus bool
+	Status         *github.RepoStatus
+}
+
+// Evaluate runs the full process for evaluating a pull request.
+func (ec *EvalContext) Evaluate(ctx context.Context, trigger common.Trigger) error {
+	evaluator, err := ec.ParseConfig(ctx, trigger)
+	if err != nil {
+		return err
+	}
+	if evaluator == nil {
+		return nil
+	}
+
+	result, err := ec.EvaluatePolicy(ctx, evaluator)
+	if err != nil {
+		return err
+	}
+
+	ec.RunPostEvaluateActions(ctx, result, trigger)
+	return nil
+}
+
+// ParseConfig checks and validates the configuration in the EvalContext and
+// returns a non-nil Evaluator if the policy exists, is valid, and requires
+// evaluation for the trigger.
+func (ec *EvalContext) ParseConfig(ctx context.Context, trigger common.Trigger) (common.Evaluator, error) {
+	logger := zerolog.Ctx(ctx)
+
+	fc := ec.Config
+	switch {
+	case fc.LoadError != nil:
+		msg := fmt.Sprintf("Error loading policy from %s", fc.Source)
+		logger.Warn().Err(fc.LoadError).Msg(msg)
+
+		ec.PostStatus(ctx, "error", msg)
+		return nil, errors.Wrapf(fc.LoadError, "failed to load policy: %s: %s", fc.Source, fc.Path)
+
+	case fc.ParseError != nil:
+		msg := fmt.Sprintf("Invalid policy in %s: %s", fc.Source, fc.Path)
+		logger.Warn().Err(fc.ParseError).Msg(msg)
+
+		ec.PostStatus(ctx, "error", msg)
+		return nil, errors.Wrapf(fc.ParseError, "failed to parse policy: %s: %s", fc.Source, fc.Path)
+
+	case fc.Config == nil:
+		logger.Debug().Msg("No policy defined for repository")
+		return nil, nil
+	}
+
+	evaluator, err := policy.ParsePolicy(fc.Config)
+	if err != nil {
+		msg := fmt.Sprintf("Invalid policy in %s: %s", fc.Source, fc.Path)
+		logger.Warn().Err(err).Msg(msg)
+
+		ec.PostStatus(ctx, "error", msg)
+		return nil, errors.Wrapf(err, "failed to create evaluator: %s: %s", fc.Source, fc.Path)
+	}
+
+	policyTrigger := evaluator.Trigger()
+	if !trigger.Matches(policyTrigger) {
+		logger.Debug().
+			Str("event_trigger", trigger.String()).
+			Str("policy_trigger", policyTrigger.String()).
+			Msg("No evaluation necessary for this trigger, skipping")
+		return nil, nil
+	}
+
+	return evaluator, nil
+}
+
+// EvaluatePolicy evaluates the policy for a PR and generates a result. The
+// evaluator must be non-nil, meaning callers should check the output of
+// ParseConfig before calling this method.
+func (ec *EvalContext) EvaluatePolicy(ctx context.Context, evaluator common.Evaluator) (common.Result, error) {
+	logger := zerolog.Ctx(ctx)
+
+	result := evaluator.Evaluate(ctx, ec.PullContext)
+	if result.Error != nil {
+		msg := fmt.Sprintf("Error evaluating policy in %s: %s", ec.Config.Source, ec.Config.Path)
+		logger.Warn().Err(result.Error).Msg(msg)
+
+		ec.PostStatus(ctx, "error", msg)
+		return result, result.Error
+	}
+
+	statusDescription := result.StatusDescription
+
+	var statusState string
+	switch result.Status {
+	case common.StatusApproved:
+		statusState = "success"
+	case common.StatusDisapproved:
+		statusState = "failure"
+	case common.StatusPending:
+		statusState = "pending"
+	case common.StatusSkipped:
+		statusState = "error"
+		statusDescription = "All rules were skipped. At least one rule must match."
+	default:
+		err := errors.Errorf("Evaluation resulted in unexpected status: %s", result.Status)
+		return result, err
+	}
+
+	ec.PostStatus(ctx, statusState, statusDescription)
+	return result, nil
+}
+
+// RunPostEvaluateActions executes additional actions that should happen after
+// evaluation completes, like assigning reviewers or dismissing reviews. These
+// actions happen after a status is posted to GitHub for the main evaluation.
+//
+// Post-evaluate actions are best effort, so this function logs failures
+// instead of returning an error.
+func (ec *EvalContext) RunPostEvaluateActions(ctx context.Context, result common.Result, trigger common.Trigger) {
+	logger := zerolog.Ctx(ctx)
+
+	if err := ec.requestReviewsForResult(ctx, trigger, result); err != nil {
+		logger.Error().Err(err).Msg("Failed to request reviewers")
+	}
+
+	if err := ec.dismissStaleReviewsForResult(ctx, result); err != nil {
+		logger.Error().Err(err).Msg("Failed to dismiss stale reviews")
+	}
+}
+
+// PostStatus posts a status for the evaluated PR.
+func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
+	logger := zerolog.Ctx(ctx)
+
+	owner := ec.PullContext.RepositoryOwner()
+	repo := ec.PullContext.RepositoryName()
+	sha := ec.PullContext.HeadSHA()
+	base, _ := ec.PullContext.Branches()
+
+	publicURL := strings.TrimSuffix(ec.PublicURL, "/")
+	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, ec.PullContext.Number())
+
+	status := github.RepoStatus{
+		State:       &state,
+		Context:     github.String(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
+		Description: &message,
+		TargetURL:   &detailsURL,
+	}
+
+	if ec.SkipPostStatus {
+		ec.Status = &status
+		return
+	}
+
+	if !ec.PullContext.IsOpen() {
+		logger.Info().Msg("Skipping status update because PR state is not open")
+		return
+	}
+
+	if err := PostStatus(ctx, ec.Client, owner, repo, sha, &status); err != nil {
+		logger.Err(err).Msg("Failed to post repo status")
+	}
+	if ec.Options.PostInsecureStatusChecks {
+		status.Context = github.String(ec.Options.StatusCheckContext)
+		if err := PostStatus(ctx, ec.Client, owner, repo, sha, &status); err != nil {
+			logger.Err(err).Msg("Failed to post insecure repo status")
+		}
+	}
+}

--- a/server/handler/eval_context_dismissal.go
+++ b/server/handler/eval_context_dismissal.go
@@ -1,0 +1,128 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/shurcooL/githubv4"
+)
+
+func (ec *EvalContext) dismissStaleReviewsForResult(ctx context.Context, result common.Result) error {
+	logger := zerolog.Ctx(ctx)
+
+	var allowedCandidates []*common.Candidate
+
+	results := findResultsWithAllowedCandidates(&result)
+	for _, res := range results {
+		for _, candidate := range res.AllowedCandidates {
+			if candidate.Type != common.ReviewCandidate {
+				continue
+			}
+			allowedCandidates = append(allowedCandidates, candidate)
+		}
+	}
+
+	reviews, err := ec.PullContext.Reviews()
+	if err != nil {
+		return err
+	}
+
+	for _, r := range reviews {
+		if r.State != pull.ReviewApproved {
+			continue
+		}
+
+		if reviewIsAllowed(r, allowedCandidates) {
+			continue
+		}
+
+		reason := reasonForDismissedReview(r)
+		message := fmt.Sprintf("Dismissed because the approval %s", reason)
+		logger.Info().Msgf("Dismissing stale review %s because it %s", r.ID, reason)
+		if err := dismissPullRequestReview(ctx, ec.V4Client, r.ID, message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func findResultsWithAllowedCandidates(result *common.Result) []*common.Result {
+	var results []*common.Result
+	for _, c := range result.Children {
+		results = append(results, findResultsWithAllowedCandidates(c)...)
+	}
+
+	if len(result.Children) == 0 && len(result.AllowedCandidates) > 0 && result.Error == nil {
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func reviewIsAllowed(review *pull.Review, allowedCandidates []*common.Candidate) bool {
+	for _, candidate := range allowedCandidates {
+		if review.ID == candidate.ReviewID {
+			return true
+		}
+	}
+	return false
+}
+
+// We already know that these are discarded review candidates for one of three reasons
+// so first we check for edited and then we check to see if its a review thats at least
+// 5 seconds old and we know that it was invalidated by a new commit, and then finally
+// if it was missing a github review comment pattern that was required.
+//
+// This is brittle and may need refactoring in future versions because it assumes the bot
+// will take less than 5 seconds to respond, but thought that having a dismissal reason
+// was valuable.
+func reasonForDismissedReview(review *pull.Review) string {
+	if !review.LastEditedAt.IsZero() {
+		return "was edited"
+	}
+
+	if review.CreatedAt.Before(time.Now().Add(-5 * time.Second)) {
+		return "was invalidated by another commit"
+	}
+
+	return "didn't include a valid comment pattern"
+}
+
+func dismissPullRequestReview(ctx context.Context, v4client *githubv4.Client, reviewID string, message string) error {
+	var m struct {
+		DismissPullRequestReview struct {
+			ClientMutationID *githubv4.String
+		} `graphql:"dismissPullRequestReview(input: $input)"`
+	}
+
+	input := githubv4.DismissPullRequestReviewInput{
+		PullRequestReviewID: githubv4.String(reviewID),
+		Message:             githubv4.String(message),
+	}
+
+	if err := v4client.Mutate(ctx, &m, input, nil); err != nil {
+		return errors.Wrapf(err, "failed to dismiss pull request review %s", reviewID)
+	}
+
+	return nil
+}

--- a/server/handler/eval_context_reviewers.go
+++ b/server/handler/eval_context_reviewers.go
@@ -1,0 +1,155 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/policy/reviewer"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+func (ec *EvalContext) requestReviewsForResult(ctx context.Context, trigger common.Trigger, result common.Result) error {
+	logger := zerolog.Ctx(ctx)
+
+	if ec.PullContext.IsDraft() || result.Status != common.StatusPending {
+		return nil
+	}
+
+	// As of 2021-05-19, there are no predicates that use comments or reviews
+	// to enable or disable rules. This means these events will never cause a
+	// change in reviewer assignment and we can skip the whole process.
+	reviewTrigger := ^(common.TriggerComment | common.TriggerReview)
+	if !trigger.Matches(reviewTrigger) {
+		return nil
+	}
+
+	if reqs := reviewer.FindRequests(&result); len(reqs) > 0 {
+		logger.Debug().Msgf("Found %d pending rules with review requests enabled", len(reqs))
+		return ec.requestReviews(ctx, reqs)
+	}
+
+	logger.Debug().Msgf("No pending rules have review requests enabled, skipping reviewer assignment")
+	return nil
+}
+
+func (ec *EvalContext) requestReviews(ctx context.Context, reqs []*common.Result) error {
+	const maxDelayMillis = 2500
+
+	logger := zerolog.Ctx(ctx)
+
+	// Seed the random source with the PR creation time so that repeated
+	// evaluations produce the same set of reviewers. This is required to avoid
+	// duplicate requests on later evaluations.
+	r := rand.New(rand.NewSource(ec.PullContext.CreatedAt().UnixNano()))
+	selection, err := reviewer.SelectReviewers(ctx, ec.PullContext, reqs, r)
+	if err != nil {
+		return errors.Wrap(err, "failed to select reviewers")
+	}
+
+	if selection.IsEmpty() {
+		logger.Debug().Msg("No eligible users or teams found for review")
+		return nil
+	}
+
+	// This is a terrible strategy to avoid conflicts between closely spaced
+	// events assigning the same reviewers, but I expect it to work alright in
+	// practice and it avoids any kind of coordination backend:
+	//
+	// Wait a random amount of time to space out events then check for existing
+	// reviewers and apply the difference. The idea is to order two competing
+	// events such that one observes the applied reviewers of the other.
+	//
+	// Use the global random source instead of the per-PR source so that two
+	// events for the same PR don't wait for the same amount of time.
+	delay := time.Duration(rand.Intn(maxDelayMillis)) * time.Millisecond
+	logger.Debug().Msgf("Waiting for %s to spread out reviewer processing", delay)
+	time.Sleep(delay)
+
+	// Get existing reviewers _after_ computing the selection and sleeping in
+	// case something assigned reviewers (or left reviews) in the meantime.
+	reviewers, err := ec.PullContext.RequestedReviewers()
+	if err != nil {
+		return err
+	}
+
+	// After a user leaves a review, GitHub removes the user from the request
+	// list. If the review didn't actually change the state of the requesting
+	// rule, policy-bot may request the same user again. To avoid this, include
+	// any reviews on the head commit in the set of existing reviewers to avoid
+	// re-requesting them until the content changes.
+	head := ec.PullContext.HeadSHA()
+	reviews, err := ec.PullContext.Reviews()
+	if err != nil {
+		return err
+	}
+	for _, r := range reviews {
+		if r.SHA == head {
+			reviewers = append(reviewers, &pull.Reviewer{
+				Type: pull.ReviewerUser,
+				Name: r.Author,
+			})
+
+			for _, team := range r.Teams {
+				reviewers = append(reviewers, &pull.Reviewer{
+					Type: pull.ReviewerTeam,
+					Name: team,
+				})
+			}
+		}
+	}
+
+	if diff := selection.Difference(reviewers); !diff.IsEmpty() {
+		req := selectionToReviewersRequest(diff)
+		logger.Debug().
+			Strs("users", req.Reviewers).
+			Strs("teams", req.TeamReviewers).
+			Msgf("Requesting reviews from %d users and %d teams", len(req.Reviewers), len(req.TeamReviewers))
+
+		owner := ec.PullContext.RepositoryOwner()
+		name := ec.PullContext.RepositoryName()
+		number := ec.PullContext.Number()
+
+		_, _, err = ec.Client.PullRequests.RequestReviewers(ctx, owner, name, number, req)
+		return errors.Wrap(err, "failed to request reviewers")
+	}
+
+	logger.Debug().Msg("All selected reviewers are already assigned or were explicitly removed")
+	return nil
+}
+
+func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
+	req := github.ReviewersRequest{}
+
+	if len(s.Users) > 0 {
+		req.Reviewers = s.Users
+	} else {
+		req.Reviewers = []string{}
+	}
+
+	if len(s.Teams) > 0 {
+		req.TeamReviewers = s.Teams
+	} else {
+		req.TeamReviewers = []string{}
+	}
+
+	return req
+}

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -1,0 +1,80 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"os"
+)
+
+const (
+	DefaultPolicyPath         = ".policy.yml"
+	DefaultSharedRepository   = ".github"
+	DefaultSharedPolicyPath   = "policy.yml"
+	DefaultStatusCheckContext = "policy-bot"
+)
+
+type PullEvaluationOptions struct {
+	PolicyPath string `yaml:"policy_path"`
+
+	SharedRepository string `yaml:"shared_repository"`
+	SharedPolicyPath string `yaml:"shared_policy_path"`
+
+	// StatusCheckContext will be used to create the status context. It will be used in the following
+	// pattern: <StatusCheckContext>: <Base Branch Name>
+	StatusCheckContext string `yaml:"status_check_context"`
+
+	// PostInsecureStatusChecks enables the sending of a second status using just StatusCheckContext as the context,
+	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
+	// context behaviour, and will be removed in 2.0
+	PostInsecureStatusChecks bool `yaml:"post_insecure_status_checks"`
+
+	// This field is unused but is left to avoid breaking configuration files:
+	// yaml.UnmarshalStrict returns an error for unmapped fields
+	//
+	// TODO(bkeyes): remove in version 2.0
+	Deprecated_AppName string `yaml:"app_name"`
+}
+
+func (p *PullEvaluationOptions) fillDefaults() {
+	if p.PolicyPath == "" {
+		p.PolicyPath = DefaultPolicyPath
+	}
+	if p.SharedRepository == "" {
+		p.SharedRepository = DefaultSharedRepository
+	}
+	if p.SharedPolicyPath == "" {
+		p.SharedPolicyPath = DefaultSharedPolicyPath
+	}
+
+	if p.StatusCheckContext == "" {
+		p.StatusCheckContext = DefaultStatusCheckContext
+	}
+}
+
+func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
+	setStringFromEnv("POLICY_PATH", prefix, &p.PolicyPath)
+	setStringFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
+	setStringFromEnv("SHARED_POLICY_PATH", prefix, &p.SharedPolicyPath)
+	setStringFromEnv("STATUS_CHECK_CONTEXT", prefix, &p.StatusCheckContext)
+	p.fillDefaults()
+}
+
+func setStringFromEnv(key, prefix string, value *string) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		*value = v
+		return true
+	}
+	return false
+}

--- a/server/handler/installation.go
+++ b/server/handler/installation.go
@@ -106,7 +106,7 @@ func (h *Installation) postRepoInstallationStatus(ctx context.Context, client *g
 		State:       &state,
 		Description: &message,
 	}
-	if err := h.PostGitHubRepoStatus(ctx, client, owner, repo, head, status); err != nil {
+	if err := PostStatus(ctx, client, owner, repo, head, status); err != nil {
 		logger.Err(errors.WithStack(err)).Msg("Failed to post repo status")
 	}
 }

--- a/server/handler/issue_comment.go
+++ b/server/handler/issue_comment.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-github/v45/github"
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/approval"
 	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
@@ -58,11 +57,6 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		return err
 	}
 
-	v4client, err := h.NewInstallationV4Client(installationID)
-	if err != nil {
-		return err
-	}
-
 	pr, _, err := client.PullRequests.Get(ctx, owner, repo.GetName(), number)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get pull request %s/%s#%d", owner, repo.GetName(), number)
@@ -70,8 +64,7 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 
 	ctx, logger := h.PreparePRContext(ctx, installationID, pr)
 
-	mbrCtx := NewCrossOrgMembershipContext(ctx, client, owner, h.Installations, h.ClientCreator)
-	prctx, err := pull.NewGitHubContext(ctx, mbrCtx, client, v4client, pull.Locator{
+	evalCtx, err := h.NewEvalContext(ctx, installationID, pull.Locator{
 		Owner:  owner,
 		Repo:   repo.GetName(),
 		Number: number,
@@ -81,18 +74,17 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		return err
 	}
 
-	fc := h.ConfigFetcher.ConfigForPR(ctx, prctx, client)
 	switch {
-	case fc.LoadError != nil || fc.ParseError != nil:
+	case evalCtx.Config.LoadError != nil || evalCtx.Config.ParseError != nil:
 		logger.Warn().Str(LogKeyAudit, "issue_comment").Msg("Skipping tampering check because the policy is not valid")
-	case fc.Config != nil:
-		tampered := h.detectAndLogTampering(ctx, prctx, client, event, fc.Config)
+	case evalCtx.Config.Config != nil:
+		tampered := h.detectAndLogTampering(ctx, evalCtx, event)
 		if tampered {
 			return nil
 		}
 	}
 
-	evaluator, err := h.Base.ValidateFetchedConfig(ctx, prctx, client, fc, common.TriggerComment)
+	evaluator, err := evalCtx.ParseConfig(ctx, common.TriggerComment)
 	if err != nil {
 		return err
 	}
@@ -100,15 +92,16 @@ func (h *IssueComment) Handle(ctx context.Context, eventType, deliveryID string,
 		return nil
 	}
 
-	result, err := h.Base.EvaluateFetchedConfig(ctx, prctx, client, evaluator, fc)
+	result, err := evalCtx.EvaluatePolicy(ctx, evaluator)
 	if err != nil {
 		return err
 	}
 
-	return h.Base.RequestReviewsForResult(ctx, prctx, client, common.TriggerComment, result)
+	evalCtx.RunPostEvaluateActions(ctx, result, common.TriggerComment)
+	return nil
 }
 
-func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Context, client *github.Client, event github.IssueCommentEvent, config *policy.Config) bool {
+func (h *IssueComment) detectAndLogTampering(ctx context.Context, evalCtx *EvalContext, event github.IssueCommentEvent) bool {
 	logger := zerolog.Ctx(ctx)
 
 	var originalBody string
@@ -129,11 +122,11 @@ func (h *IssueComment) detectAndLogTampering(ctx context.Context, prctx pull.Con
 		return false
 	}
 
-	if h.affectsApproval(originalBody, config.ApprovalRules) {
+	if h.affectsApproval(originalBody, evalCtx.Config.Config.ApprovalRules) {
 		msg := fmt.Sprintf("Entity %s edited approval comment by %s", eventAuthor, commentAuthor)
 		logger.Warn().Str(LogKeyAudit, "issue_comment").Msg(msg)
 
-		h.PostStatus(ctx, prctx, client, "failure", msg)
+		evalCtx.PostStatus(ctx, "failure", msg)
 		return true
 	}
 
@@ -147,6 +140,5 @@ func (h *IssueComment) affectsApproval(actualComment string, rules []*approval.R
 			return true
 		}
 	}
-
 	return false
 }


### PR DESCRIPTION
Previously, we defined a bunch of common functionality for evaluating PRs on the Base handler. This worked, but had a few flaws:

* When a handler needed to drop to a lower level to insert logic between steps, there was a lot of client construction boilerplate. This is not totally eliminated, but is reduced.

* As new side-effects are added, it was easy to miss calling them from places that had dropped down to the lower-level functions. For example, when adding review dismissal, we missed called it from the comment handler.

* Functions took a lot of similar arguments that could be defined on a single struct and shared.

* There was no easy way to evalute a PR without posting status check

* The Base handler was getting hard to read with all the evaluation functionality mixed in.

The EvalContext type contains all the configuration and clients needed to evaluate a single PR for a request. Most handlers call Base.Evaluate like before, but when dropping to a lower level, handlers now create and use an EvalContext. Once created, they call 3 methods in sequence adding whatever extra logic is needed in between.