### PR TITLE
Ignore review events triggered by Policy Bot

### DIFF
--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -39,6 +39,11 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 		return errors.Wrap(err, "failed to parse pull request review event payload")
 	}
 
+	// Ignore events triggered by policy-bot (e.g. for dismissing stale reviews)
+	if event.GetSender().GetLogin() == h.AppName+"[bot]" {
+		return nil
+	}
+
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 


### PR DESCRIPTION
This prevents re-running evaluation in response to Policy Bot dismissing stale reviews. Because the stale reviews did not impact the policy status at the time of dismissal, there is no need to evaluate again without them.