### PR TITLE
Improve details view for required approvals

### DIFF
--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -60,27 +60,25 @@
     <details class="bg-light-gray5 p-2 mt-2 text-sm">
       <summary class="text-dark-gray3 font-semibold">Details</summary>
       <div class="border-t border-light-gray3 mt-2 overflow-x-auto whitespace-nowrap">
-       {{if .PredicateResults}}
+        {{if .PredicateResults}}
           <div class="pt-2">
             {{template "result-predicates-details" .}}
           </div>
         {{end}}
-        <div class="pt-2">
-        {{template "result-requires-count" .}}
-        </div>
-        {{if (hasActors .Requires)}}
-          <div class="pt-2">
-          {{template "result-actors-details" .}}
-          </div>
+        {{if ne $s "skipped"}}{{/* only show approval details for active rules */}}
+          {{if gt .Requires.Count 0 }}{{/* only show approval details if they're required */}}
+            <div class="pt-2">
+            {{template "result-approver-details" .}}
+            </div>
+            <div class="pt-2">
+            {{template "result-methods-details" .}}
+            </div>
+          {{else}}
+            <div class="pt-2">
+              <b class="font-bold text-sm">This rule is automatically approved and requires no reviews</b>
+            </div>
+          {{end}}
         {{end}}
-        {{if (hasActorsPermissions .Requires)}}
-          <div class="pt-2">
-          {{template "result-actors-permissions-details" .}}
-          </div>
-        {{end}}
-        <div class="pt-2">
-        {{template "result-methods-details" .}}
-        </div>
       </div>
     </details>
     {{end}}
@@ -148,40 +146,42 @@
   </ul>
 {{end}}
 
-{{define "result-requires-count"}}
-  <b class="font-bold text-sm">This rule requires at least this many reviews</b>
-  <dl class="my-2">
-    <dt> {{.Requires.Count}}</dt>
-  </dl>
-{{end}}
-
 {{define "result-methods-details"}}
-  <b class="font-bold text-sm">This rule requires review using any of these methods</b>
+  <b class="font-bold text-sm">Approvals may use any of these methods:</b>
   <dl class="my-2">
   {{range $k, $v := getMethods .}}
-    <dt> {{$k}}</dt>
+    <dt>{{$k}}:</dt>
     <dd>
-        <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+      <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
     </dd>
   {{end}}
   </dl>
 {{end}}
 
-{{define "result-actors-details"}}
-  <b class="font-bold text-sm">This rule requires review from</b>
-  <dl class="my-2">
-  {{range $k, $v := getActors .}}
-    <dt> {{$k}}</dt>
-    <dd>
+{{define "result-approver-details"}}
+  {{$hasActors := hasActors .Requires}}
+  {{$hasPerms := hasActorsPermissions .Requires}}
+  {{if or $hasActors $hasPerms}}
+    <b class="font-bold text-sm">{{template "result-reviews-count" .Requires}} from:</b>
+    <dl class="my-2">
+    {{if $hasActors}}
+    {{range $k, $v := getActors .}}
+      <dt>{{$k}}:</dt>
+      <dd>
         <ul class="list-disc list-outside pl-6 py-2">{{range $v}}<li class="font-mono text-sm-mono"><a href={{.Link}}>{{.Name}}</a></li>{{end}}</ul>
-    </dd>
+      </dd>
+    {{end}}
+    {{end}}
+    {{if $hasPerms}}
+      <dt>Users with the permissions:</dt>
+      <dd>
+        <ul class="list-disc list-outside pl-6 py-2">{{range getPermissions .}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+      </dd>
+    {{end}}
+    </dl>
+  {{else}}
+    <b class="font-bold text-sm">{{template "result-reviews-count" .Requires}}</b>
   {{end}}
-  </dl>
 {{end}}
 
-{{define "result-actors-permissions-details"}}
-  <b class="font-bold text-sm">This rule requires review from users with these permissions</b>
-  <ul class="list-disc list-outside pl-6 py-2">
-    {{range getPermissions .}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}
-  </ul>
-{{end}}
+{{define "result-reviews-count"}}This rule requires at least {{.Count}} approval{{if gt .Count 1}}s{{end}}{{end}}


### PR DESCRIPTION
This makes several improvements to the rule details UI for required approvals and methods:

* Hide details about required approvals and methods when rules are skipped or when they require no approval
* Combine the required approval count with the header for approver details instead of using a separate section.
* Combine membership requirements and permission requirements in to a single section
* Update the phrasing of section headers for readability