### PR TITLE
Increase max delay for commit retries

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -806,7 +806,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 	// Retry with exponential backoff until it works or we hit the max total
 	// latency to avoid users thinking the bot got stuck or dropped an event.
 	const baseDelay = 1 * time.Second
-	const maxLatency = 20 * time.Second
+	const maxLatency = 35 * time.Second
 
 	start := time.Now()
 	for delay := baseDelay; true; delay *= 2 {
@@ -821,7 +821,7 @@ func (ghc *GitHubContext) loadCommits() ([]*Commit, error) {
 		if time.Since(start)+delay >= maxLatency {
 			break
 		}
-		log.Debug().Dur("delay", delay).Str("sha", ghc.pr.HeadRefOID).Msg("Head commit is missing pushed data, sleeping and trying again")
+		log.Debug().Dur("delay", delay).Str("sha", ghc.pr.HeadRefOID).Msg("Head commit is missing pushed date, sleeping and trying again")
 		time.Sleep(delay)
 	}
 


### PR DESCRIPTION
While the 20s max delay seems to work most of the time, since deploying this, about 5% of requests that needed retries still failed. Increase the latency to 35s to allow one more retry with some buffer for request times.