### PR TITLE
feat: add merge group handler in support of github merge queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ The app requires these permissions:
 | Checks | Read-only | Read check run results |
 | Repository administration | Read-only | Read admin team(s) membership |
 | Issues | Read-only | Read pull request comments |
+| Merge Queues | Read-only | Read repository merge queues |
 | Repository metadata | Read-only | Basic repository data |
 | Pull requests | Read & write | Receive pull request events, read metadata. Assign reviewers |
 | Commit status | Read & write | Post commit statuses |
@@ -769,6 +770,7 @@ The app should be subscribed to these events:
 
 * Check run
 * Issue comment
+* Merge groups
 * Pull request
 * Pull request review
 * Status

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -74,7 +74,11 @@ func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pul
 		return nil, err
 	}
 
-	fetchedConfig := b.ConfigFetcher.ConfigForPR(ctx, prctx, client)
+	baseBranch, _ := prctx.Branches()
+	owner := prctx.RepositoryOwner()
+	repository := prctx.RepositoryName()
+
+	fetchedConfig := b.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
 
 	return &EvalContext{
 		Client:   client,

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -20,7 +20,6 @@ import (
 	"github.com/google/go-github/v50/github"
 	"github.com/palantir/go-githubapp/appconfig"
 	"github.com/palantir/policy-bot/policy"
-	"github.com/palantir/policy-bot/pull"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,10 +36,9 @@ type ConfigFetcher struct {
 	Loader *appconfig.Loader
 }
 
-func (cf *ConfigFetcher) ConfigForPR(ctx context.Context, prctx pull.Context, client *github.Client) FetchedConfig {
-	base, _ := prctx.Branches()
+func (cf *ConfigFetcher) ConfigForRepositoryBranch(ctx context.Context, client *github.Client, owner string, repository string, branch string) FetchedConfig {
 
-	c, err := cf.Loader.LoadConfig(ctx, client, prctx.RepositoryOwner(), prctx.RepositoryName(), base)
+	c, err := cf.Loader.LoadConfig(ctx, client, owner, repository, branch)
 	fc := FetchedConfig{
 		Source: c.Source,
 		Path:   c.Path,

--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -36,7 +36,7 @@ type ConfigFetcher struct {
 	Loader *appconfig.Loader
 }
 
-func (cf *ConfigFetcher) ConfigForRepositoryBranch(ctx context.Context, client *github.Client, owner string, repository string, branch string) FetchedConfig {
+func (cf *ConfigFetcher) ConfigForRepositoryBranch(ctx context.Context, client *github.Client, owner, repository, branch string) FetchedConfig {
 
 	c, err := cf.Loader.LoadConfig(ctx, client, owner, repository, branch)
 	fc := FetchedConfig{

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -87,7 +87,7 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 	}
 
 	if err := PostStatus(ctx, client, owner, repository, headSHA, status); err != nil {
-		logger.Err(errors.WithStack(err)).Msg("Failed to post repo status")
+		logger.Err(errors.WithStack(err)).Msg("Failed to post status check for merge group")
 	}
 
 	return nil

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Palantir Technologies, Inc.
+// Copyright 2023 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -33,7 +33,7 @@ func (h *MergeGroup) Handles() []string { return []string{"merge_group"} }
 
 // Handle merge_group
 // https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#merge_group
-func (h *MergeGroup) Handle(ctx context.Context, payload []byte) error {
+func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, payload []byte) error {
 	var event github.MergeGroupEvent
 	repository := event.GetRepo().GetName()
 	owner := event.GetOrg().GetName()

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -52,10 +52,6 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 		return err
 	}
 
-	if err != nil {
-		return errors.Wrap(err, "failed to create evaluation context")
-	}
-
 	repository := event.GetRepo().GetName()
 	owner := event.GetRepo().GetOwner().GetLogin()
 	mergeGroup := event.GetMergeGroup()

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type MergeGroup struct {
+	Base
+}
+
+func (h *MergeGroup) Handles() []string { return []string{"merge_group"} }
+
+// Handle merge_group
+// https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads#merge_group
+func (h *MergeGroup) Handle(ctx context.Context, payload []byte) error {
+	var event github.MergeGroupEvent
+	repository := event.GetRepo().GetName()
+	owner := event.GetOrg().GetName()
+	mergeGroup := event.GetMergeGroup()
+	baseBranch := mergeGroup.GetBaseRef()
+	headSHA := mergeGroup.GetHeadSHA()
+
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return errors.Wrap(err, "failed to parse merge group event payload")
+	}
+
+	if event.GetAction() != "checks_requested" {
+		return nil
+	}
+
+	logger := zerolog.Ctx(ctx)
+	installationID := githubapp.GetInstallationIDFromEvent(&event)
+	client, err := h.NewInstallationClient(installationID)
+	if err != nil {
+		return err
+	}
+
+	c, err := h.ConfigFetcher.Loader.LoadConfig(ctx, client, owner, repository, baseBranch)
+	fc := FetchedConfig{
+		Source: c.Source,
+		Path:   c.Path,
+	}
+
+	switch {
+	case err != nil:
+		fc.LoadError = err
+		msg := fmt.Sprintf("No policy defined on base branch: %s for repository: %s", baseBranch, repository)
+		logger.Warn().Err(errors.WithStack(err)).Msg(msg)
+		return nil
+	case c.IsUndefined():
+		return nil
+	}
+
+	contextWithBranch := fmt.Sprintf("%s: %s", h.PullOpts.StatusCheckContext, baseBranch)
+	state := "success"
+	message := fmt.Sprintf("%s previously approved original pull request.", h.AppName)
+	status := &github.RepoStatus{
+		Context:     &contextWithBranch,
+		State:       &state,
+		Description: &message,
+	}
+
+	if err := PostStatus(ctx, client, owner, repository, headSHA, status); err != nil {
+		logger.Err(errors.WithStack(err)).Msg("Failed to post repo status")
+	}
+
+	return nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,7 @@ func New(c *Config) (*Server, error) {
 	dispatcher := githubapp.NewEventDispatcher(
 		[]githubapp.EventHandler{
 			&handler.Installation{Base: basePolicyHandler},
+			&handler.MergeGroup{Base: basePolicyHandler},
 			&handler.PullRequest{Base: basePolicyHandler},
 			&handler.PullRequestReview{Base: basePolicyHandler},
 			&handler.IssueComment{Base: basePolicyHandler},


### PR DESCRIPTION
Closes https://github.com/palantir/policy-bot/issues/548

Adds support for github merge queues by unconditionally posting a successful status check on the merge group branch when policy bot sees a `merge_group` github webhook event.

Worked together with @btrautmann to get this done. Let us know if something like this is what you had in mind as a solution for this.

