### PR TITLE
Restore support for SSH signatures

### DIFF
--- a/policy/predicate/signature_test.go
+++ b/policy/predicate/signature_test.go
@@ -30,7 +30,7 @@ func TestHasValidSignatures(t *testing.T) {
 
 	testCases := []SignatureTestCase{
 		{
-			"ValidSignature",
+			"ValidGpgSignature",
 			&pulltest.Context{
 				AuthorValue: "mhaypenny",
 				CommitsValue: []*pull.Commit{
@@ -44,6 +44,31 @@ func TestHasValidSignatures(t *testing.T) {
 							Signer:  "ttest",
 							State:   "VALID",
 							KeyID:   "3AA5C34371567BD2",
+						},
+					},
+				},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"abcdef123456789"},
+				ConditionValues: []string{"valid signatures"},
+			},
+		},
+		{
+			"ValidSshSignature",
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+						Signature: &pull.Signature{
+							Type:           pull.SignatureSSH,
+							IsValid:        true,
+							Signer:         "ttest",
+							State:          "VALID",
+							KeyFingerprint: "Hello",
 						},
 					},
 				},

--- a/pull/context.go
+++ b/pull/context.go
@@ -173,14 +173,16 @@ type SignatureType string
 const (
 	SignatureGpg   SignatureType = "GpgSignature"
 	SignatureSmime SignatureType = "SmimeSignature"
+	SignatureSSH   SignatureType = "SshSignature"
 )
 
 type Signature struct {
-	Type    SignatureType
-	IsValid bool
-	KeyID   string
-	Signer  string
-	State   string
+	Type           SignatureType
+	IsValid        bool
+	KeyID          string
+	KeyFingerprint string
+	Signer         string
+	State          string
 }
 
 type Comment struct {

--- a/pull/github.go
+++ b/pull/github.go
@@ -1210,6 +1210,7 @@ type v4GitSignature struct {
 	Type  string           `graphql:"__typename"`
 	GPG   v4GpgSignature   `graphql:"... on GpgSignature"`
 	SMIME v4SmimeSignature `graphql:"... on SmimeSignature"`
+	SSH   v4SshSignature   `graphql:"... on SshSignature"`
 }
 
 func (s *v4GitSignature) ToSignature() *Signature {
@@ -1228,6 +1229,14 @@ func (s *v4GitSignature) ToSignature() *Signature {
 			Signer:  s.SMIME.Signer.GetV3Login(),
 			State:   s.SMIME.State,
 			Type:    SignatureSmime,
+		}
+	case SignatureSSH:
+		return &Signature{
+			IsValid:        s.SSH.IsValid,
+			KeyFingerprint: s.SSH.KeyFingerprint,
+			Signer:         s.SSH.Signer.GetV3Login(),
+			State:          s.SSH.State,
+			Type:           SignatureSSH,
 		}
 	default:
 		return nil
@@ -1248,6 +1257,17 @@ type v4GpgSignature struct {
 	Email             string
 	IsValid           bool
 	KeyID             string
+	Payload           string
+	Signature         string
+	Signer            *v4Actor
+	State             string
+	WasSignedByGitHub bool
+}
+
+type v4SshSignature struct {
+	Email             string
+	IsValid           bool
+	KeyFingerprint    string
 	Payload           string
 	Signature         string
 	Signer            *v4Actor


### PR DESCRIPTION
The required API for this feature is only available in GitHub Enterprise 3.7 or newer, so merging this means we will drop support for GHE 3.6 and older. Given GHE 3.8 has been available for a few months, I think this is reasonable.

Closes #508.