### PR TITLE
Improve review dismissal behavior

### DIFF
--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -74,8 +74,19 @@ type Result struct {
 	Requires          Requires
 	Methods           *Methods
 
+	// Approvers contains the candidates that satisfied the rule.
+	Approvers []*Candidate
+
+	// Dismissals contains candidates that should be discarded because they
+	// cannot satisfy any future evaluations.
+	Dismissals []*Dismissal
+
 	ReviewRequestRule *ReviewRequestRule
-	AllowedCandidates []*Candidate
 
 	Children []*Result
+}
+
+type Dismissal struct {
+	Candidate *Candidate
+	Reason    string
 }


### PR DESCRIPTION
Existing dismissal logic compares all reviews on the PR to the set of reviews that might satisfy any rule. This does not work well when policies combine rules that invalidate on push with rules that do not.

In this situation, reviews are not dismissed when new commits are pushed because they might satisfy the rules that do not invalidate. Instead, a user's review is dismissed when they submit a second review. This is because we only consider the most recent review from a user, which means their previous review doesn't count for any rules and is eligible to be dismissed.

We chose this approach to try to dismiss reviews that did not match required comment patterns, but ended up removing that before merging the feature.

This commit switched back to the original approach, which is to collect specific reviews to dismiss, rather than trying to infer what is safe to dismiss. This should be more reliable and is easier to reason about.

### Testing / Edge Cases

I've tested a few different scenarios with my local dev instance and I think it works correctly. There are probably a few edge cases that will still show up (the space of all policies and review orders is large), but I think this is strictly more correct than the current behavior.

Two quirks I observed so far:

1. If a single approval satisfies rules A and B where A is invalidated by pushes and B is not, pushing a new commit will not dismiss the review (because it still satisfies B). This is the intended behavior, but it could confuse people. I think in practice conflicting rules like this are behind predicates.
2. If you're in the situation in (1), the PR is reapproved, and then you push a change that skips B, only the most recent approval is dismissed. There's still an older approval hanging around (it doesn't affect the Policy Bot status) because of the [deduplicateCandidates](https://github.com/palantir/policy-bot/blob/9aee3c7274e46af6463738ba5e8bd815365da257/policy/common/methods.go#L134) function, which only keeps the most recent candidate from a user. I think this is probably fine for now - changing it would mean auditing the approval logic to make sure it accounts for duplicates instead.

### Future Extensions

I don't remember if Policy Bot has permission to edit comments already, but we could probably make this work for comments as well. It could edit the comment to add a line at the bottom explaining that the comment is now invalid.