### PR TITLE
Exclude policy-bot pages from search indexing

### DIFF
--- a/server/templates/page.html.tmpl
+++ b/server/templates/page.html.tmpl
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>{{block "title" .}}PolicyBot{{end}}</title>


### PR DESCRIPTION
The only public page (the landing page) doesn't have any useful information for search engines and is likely to expose internal domains in search results if it is indexed.

Fixes #586.