### PR TITLE
Allow server env var prefix to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,10 @@ We provide both a Docker container and a binary distribution of the server:
 
 A sample configuration file is provided at `config/policy-bot.example.yml`.
 Certain values may also be set by environment variables; these are noted in the
-comments in the sample configuration file.
+comments in the sample configuration file. By default, the environment
+variables for server values are prefixed with `POLICYBOT_` (e.g.
+`POLICYBOT_PORT`). This prefix can be overridden by setting the
+`POLICYBOT_ENV_PREFIX` environment variable.
 
 ### GitHub App Configuration
 

--- a/server/config.go
+++ b/server/config.go
@@ -81,12 +81,17 @@ func ParseConfig(bytes []byte) (*Config, error) {
 		return nil, errors.Wrapf(err, "failed unmarshalling yaml")
 	}
 
-	c.Options.SetValuesFromEnv(DefaultEnvPrefix + "OPTIONS_")
-	c.Server.SetValuesFromEnv(DefaultEnvPrefix)
-	c.Logging.SetValuesFromEnv(DefaultEnvPrefix)
+	envPrefix := DefaultEnvPrefix
+	if v, ok := os.LookupEnv("POLICYBOT_ENV_PREFIX"); ok {
+		envPrefix = v
+	}
+
+	c.Options.SetValuesFromEnv(envPrefix + "OPTIONS_")
+	c.Server.SetValuesFromEnv(envPrefix)
+	c.Logging.SetValuesFromEnv(envPrefix)
 	c.Github.SetValuesFromEnv("")
 
-	if v, ok := os.LookupEnv(DefaultEnvPrefix + "SESSIONS_KEY"); ok {
+	if v, ok := os.LookupEnv(envPrefix + "SESSIONS_KEY"); ok {
 		c.Sessions.Key = v
 	}
 


### PR DESCRIPTION
As suggested [here](https://github.com/palantir/policy-bot/issues/475#issuecomment-1256583755), use a `POLICYBOT_ENV_PREFIX` environment variable to override the prefix for server configuration values. This makes it possible to run the Docker container on Heroku, where it is expected that the container will listen on the port specified in the PORT environment variable. This PR is basically a clone of [the same PR for the Bulldozer repo](https://github.com/palantir/bulldozer/pull/229).