### PR TITLE
Implemented RequestedCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,12 +357,11 @@ options:
     # Defaults to 'random-users'.
     mode: all-users|random-users|teams
     
-    # requested_count modifies how many users are requested to review the pr. If 
-    # requested_count is not set or set to 0 it will use requires.count
-    # Settings this is usefull when you want to request more reviewers than the 
-    # required count if you are using mode: random-users. 
-    # Defaults to '0'
-    requested_count: 0
+    # count sets the number of users requested to review the pull request when
+    # using the `random-users` mode. If count is not set or set to 0, request the
+    # number of users set by requires.count. Setting this is useful when you want
+    # to request more reviewers than the required count. Defaults to 0.
+    count: 0
 
   # "methods" defines how users may express approval.
   methods:

--- a/README.md
+++ b/README.md
@@ -356,6 +356,13 @@ options:
     # at least until https://github.com/palantir/policy-bot/issues/165 is fixed.
     # Defaults to 'random-users'.
     mode: all-users|random-users|teams
+    
+    # requested_count modifies how many users are requested to review the pr. If 
+    # requested_count is not set or set to 0 it will use requires.count
+    # Settings this is usefull when you want to request more reviewers than the 
+    # required count if you are using mode: random-users. 
+    # Defaults to '0'
+    requested_count: 0
 
   # "methods" defines how users may express approval.
   methods:

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -52,8 +52,9 @@ type Options struct {
 }
 
 type RequestReview struct {
-	Enabled bool               `yaml:"enabled"`
-	Mode    common.RequestMode `yaml:"mode"`
+	Enabled        bool               `yaml:"enabled"`
+	Mode           common.RequestMode `yaml:"mode"`
+	RequestedCount int                `yaml:"requested_count"`
 }
 
 func (opts *Options) GetMethods() *common.Methods {
@@ -168,13 +169,19 @@ func (r *Rule) getReviewRequestRule() *common.ReviewRequestRule {
 		mode = common.RequestModeRandomUsers
 	}
 
+	requestedCount := r.Options.RequestReview.RequestedCount
+	if requestedCount == 0 {
+		requestedCount = r.Requires.Count
+	}
+
 	return &common.ReviewRequestRule{
-		Users:         r.Requires.Actors.Users,
-		Teams:         r.Requires.Actors.Teams,
-		Organizations: r.Requires.Actors.Organizations,
-		Permissions:   r.Requires.Actors.GetPermissions(),
-		RequiredCount: r.Requires.Count,
-		Mode:          mode,
+		Users:          r.Requires.Actors.Users,
+		Teams:          r.Requires.Actors.Teams,
+		Organizations:  r.Requires.Actors.Organizations,
+		Permissions:    r.Requires.Actors.GetPermissions(),
+		RequiredCount:  r.Requires.Count,
+		RequestedCount: requestedCount,
+		Mode:           mode,
 	}
 }
 

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -52,9 +52,9 @@ type Options struct {
 }
 
 type RequestReview struct {
-	Enabled        bool               `yaml:"enabled"`
-	Mode           common.RequestMode `yaml:"mode"`
-	RequestedCount int                `yaml:"requested_count"`
+	Enabled bool               `yaml:"enabled"`
+	Mode    common.RequestMode `yaml:"mode"`
+	Count   int                `yaml:"count"`
 }
 
 func (opts *Options) GetMethods() *common.Methods {
@@ -169,7 +169,7 @@ func (r *Rule) getReviewRequestRule() *common.ReviewRequestRule {
 		mode = common.RequestModeRandomUsers
 	}
 
-	requestedCount := r.Options.RequestReview.RequestedCount
+	requestedCount := r.Options.RequestReview.Count
 	if requestedCount == 0 {
 		requestedCount = r.Requires.Count
 	}

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -50,11 +50,12 @@ const (
 )
 
 type ReviewRequestRule struct {
-	Teams         []string
-	Users         []string
-	Organizations []string
-	Permissions   []pull.Permission
-	RequiredCount int
+	Teams          []string
+	Users          []string
+	Organizations  []string
+	Permissions    []pull.Permission
+	RequiredCount  int
+	RequestedCount int
 
 	Mode RequestMode
 }

--- a/policy/reviewer/reviewer.go
+++ b/policy/reviewer/reviewer.go
@@ -269,7 +269,7 @@ func selectUserReviewers(ctx context.Context, prctx pull.Context, selection *Sel
 		selection.Users = append(selection.Users, possibleReviewers...)
 
 	case common.RequestModeRandomUsers:
-		count := result.ReviewRequestRule.RequiredCount
+		count := result.ReviewRequestRule.RequestedCount
 		selectedUsers := selectRandomUsers(count, possibleReviewers, r)
 
 		logger.Debug().Msgf("Found %d eligible reviewers; randomly selecting %d", len(possibleReviewers), count)


### PR DESCRIPTION
Made a small change in sugested implementation, instead of `requested_reviewers` i used `requested_count` which more clearly points to a number. 

Fixes: https://github.com/palantir/policy-bot/issues/634