### PR TITLE
Upgrade to templatetree to 0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/alexedwards/scs v1.4.1
 	github.com/bluekeyes/hatpear v0.1.1
-	github.com/bluekeyes/templatetree v0.1.0
+	github.com/bluekeyes/templatetree v0.5.0
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
 	github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11
 	github.com/google/go-github/v56 v56.0.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/bluekeyes/hatpear v0.1.1 h1:FA5diKynoYJi6YVTJPEDbe4MG6eA8h+7LYHUlm8bppc=
 github.com/bluekeyes/hatpear v0.1.1/go.mod h1:2bh+rl4wLhqzzL0hT7Q4SVGXIivrE8oKgH2WYM3ubt0=
-github.com/bluekeyes/templatetree v0.1.0 h1:XKehBOS8+QciDUgjQJbqOxOJkZTpXWvZVcPAXDZf2TQ=
-github.com/bluekeyes/templatetree v0.1.0/go.mod h1:F0jp7CTgfIsYPrplxgA43Ipv/lQG0c75DtpFO98fvAQ=
+github.com/bluekeyes/templatetree v0.5.0 h1:bJ5W/D/SzB9GWzUG0G+Js8duOAwasE1vEWndxxQRoO0=
+github.com/bluekeyes/templatetree v0.5.0/go.mod h1:doLcw8f06r6e1+9R30QkqYeq6/dDwxeQAF0FHjiOrIs=
 github.com/bradleyfalzon/ghinstallation/v2 v2.8.0 h1:yUmoVv70H3J4UOqxqsee39+KlXxNEDfTbAp8c/qULKk=
 github.com/bradleyfalzon/ghinstallation/v2 v2.8.0/go.mod h1:fmPmvCiBWhJla3zDv9ZTQSZc8AbwyRnGW1yg5ep1Pcs=
 github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae h1:2Zmk+8cNvAGuY8AyvZuWpUdpQUAXwfom4ReVMe/CTIo=

--- a/server/handler/details.go
+++ b/server/handler/details.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/url"
 	"path"
@@ -35,7 +36,7 @@ import (
 type Details struct {
 	Base
 	Sessions  *scs.Manager
-	Templates templatetree.HTMLTree
+	Templates templatetree.Tree[*template.Template]
 }
 
 func (h *Details) ServeHTTP(w http.ResponseWriter, r *http.Request) error {

--- a/server/handler/index.go
+++ b/server/handler/index.go
@@ -15,6 +15,7 @@
 package handler
 
 import (
+	"html/template"
 	"net/http"
 
 	"github.com/bluekeyes/templatetree"
@@ -26,7 +27,7 @@ type Index struct {
 	Base
 
 	GithubConfig *githubapp.Config
-	Templates    templatetree.HTMLTree
+	Templates    templatetree.Tree[*template.Template]
 }
 
 func (h *Index) ServeHTTP(w http.ResponseWriter, r *http.Request) error {

--- a/vendor/github.com/bluekeyes/templatetree/.golangci.yml
+++ b/vendor/github.com/bluekeyes/templatetree/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  tests: false
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - golint
+    - govet
+    - ineffassign
+    - typecheck
+    - unconvert
+    - varcheck
+
+issues:
+  exclude-use-default: false
+
+linter-settings:
+  goimports:
+    local-prefixes: github.com/bluekeyes/templatetree

--- a/vendor/github.com/bluekeyes/templatetree/README.md
+++ b/vendor/github.com/bluekeyes/templatetree/README.md
@@ -1,11 +1,10 @@
-# templatetree [![GoDoc](https://godoc.org/github.com/bluekeyes/templatetree?status.svg)](http://godoc.org/github.com/bluekeyes/templatetree)
+# templatetree [![Go Reference](https://pkg.go.dev/badge/github.com/bluekeyes/templatetree.svg)](https://pkg.go.dev/github.com/bluekeyes/templatetree)
 
 templatetree is a standard library template loader that creates simple template
 inheritance trees. Base templates use the `block` or `template` directives to
 define sections that are overridden or provided by child templates.
 
-Functions are provided to create both `text/template` and `html/template`
-objects.
+Compatible with both `text/template` and `html/template`.
 
 ## Example
 
@@ -32,13 +31,13 @@ Given a `templates` directory with the following content:
     {{end}}
 
 
-Use `LoadHTML` to load and render the templates:
+Use `Parse` to load and render the templates:
 
 ```go
 package main
 
 import (
-	"html/template"
+	html "html/template"
 	"os"
 	"time"
 
@@ -46,13 +45,15 @@ import (
 )
 
 func main() {
-	root := template.New("root").Funcs(template.FuncMap{
-		"now": func() string {
-			return time.Now().Format(time.RFC3339)
-		},
-	})
+	factory := func(name string) templatetree.Template[*html.Template] {
+		return template.New(name).Funcs(template.FuncMap{
+			"now": func() string {
+				return time.Now().Format(time.RFC3339)
+			},
+		})
+	}
 
-	t, err := templatetree.LoadHTML("templates", "*.html.tmpl", root)
+	t, err := templatetree.Parse("templates", "*.html.tmpl", factory)
 	if err != nil {
 		panic(err)
 	}
@@ -82,9 +83,12 @@ Output:
       </body>
     </html>
 
+You can also load templates from a `fs.FS` using `templatetree.ParseFS` or
+from memory using `templatetree.ParseFiles`. See the package documentation
+for details and an example.
 
 ## Stability
 
-While the API is simple, it hasn't seen heavy use yet and may change in the
-future. I recommend vendoring this package at a specific commit if you are
-concerned about API changes.
+Beta, API changes possible. v0.4.0 redesigned and simplified the API based on
+experience with previous versions. v0.5.0 inclued another API break to use
+generics, but is functionally the same as the previous version.

--- a/vendor/github.com/bluekeyes/templatetree/doc.go
+++ b/vendor/github.com/bluekeyes/templatetree/doc.go
@@ -1,44 +1,18 @@
 // Package templatetree loads standard library templates in a way that creates
-// a template hierarchy with inheritance. Templates may extend other templates
-// by using a special comment as the first line of the template:
-//
-//     // in templates/base.tmpl
-//     base := `Header
-//     {{block "body" .}}Body{{end}}
-//     Footer`
-//
-//     // in templates/a.tmpl
-//     a := `{{/* templatetree:extends base.tmpl */}}
-//     {{define "body"}}Body A{{end}}`
-//
-//     // in templates/b.tmpl
-//     b := `{{/* templatetree:extends base.tmpl */}}
-//     {{define "body"}}Body B{{end}}`
-//
-//     t, err := templatetree.LoadText("templates", "*.tmpl", nil)
-//     // ... handle err
-//
-//     t.ExecuteTemplate(os.Stdout, "a.tmpl", nil)
-//     // => Header
-//     //    Body A
-//     //    Footer
-//
-//     t.ExecuteTemplate(os.Stdout, "b.tmpl", nil)
-//     // => Header
-//     //    Body B
-//     //    Footer
-//
-// Template trees may be arbitrarily deep and there may be multiple trees in a
-// given directory.
+// a template hierarchy with inheritance. Templates extend other templates by
+// placing a special comment as the first line of the template. Template trees
+// may be arbitrarily deep and multiple independent tree can be loaded at the
+// same time.
 //
 // The comment marking extension must be the first line of the template and
 // must exactly match the following, including whitespace:
 //
-//     {{/* templatetree:extends parent-template-name */}}
+//	{{/* templatetree:extends parent-template-name */}}
 //
-// Templates are named after their slash-separated file path relative to
-// directory that was loaded.
+// If loading from a file system, a template's name is its slash-separated file
+// path relative to the root. If parsing a map of files, the key sets the
+// template's name.
 //
-// To define functions or set other options on the templates, pass a non-nil
-// root template as the final argument to the Load* function.
+// To define functions or set other options on the templates, provide a custom
+// factory function.
 package templatetree

--- a/vendor/github.com/bluekeyes/templatetree/templatetree.go
+++ b/vendor/github.com/bluekeyes/templatetree/templatetree.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	html "html/template"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 	text "text/template"
@@ -16,159 +16,90 @@ const (
 	// CommentTagExtends is the tag used in template comments to mark a
 	// template's parent.
 	CommentTagExtends = "templatetree:extends"
-
-	// DefaultRootTemplateName is the name of the root template when none is
-	// provided by the caller.
-	DefaultRootTemplateName = "[templatetree:root]"
 )
 
-// LoadText recursively loads all text templates in dir with names matching
-// pattern, respecting inheritance. If the root template is nil, a new default
-// template is used.
-//
-// Templates are named as normalized paths relative to dir.
-func LoadText(dir, pattern string, root *text.Template) (TextTree, error) {
-	if root == nil {
-		root = text.New(DefaultRootTemplateName)
-	}
-
-	tree := make(TextTree)
-	return tree, loadAll(dir, pattern, textTemplate{root}, func(name string, t template) {
-		tree[name] = t.(textTemplate).Template
-	})
+// StdTemplate is a union of the standard library template types.
+type StdTemplate interface {
+	*text.Template | *html.Template
 }
 
-// LoadHTML recursively loads all HTML templates in dir with names matching
-// pattern, respecting inheritance. If the root template is nil, a new default
-// template is used.
-//
-// Templates are named as normalized paths relative to dir.
-func LoadHTML(dir, pattern string, root *html.Template) (HTMLTree, error) {
-	if root == nil {
-		root = html.New(DefaultRootTemplateName)
-	}
-
-	tree := make(HTMLTree)
-	return tree, loadAll(dir, pattern, htmlTemplate{root}, func(name string, t template) {
-		tree[name] = t.(htmlTemplate).Template
-	})
+// Template contains the common functions of text/template.Template and
+// html/template.Template used by this package.
+type Template[T StdTemplate] interface {
+	Name() string
+	Execute(w io.Writer, data any) error
+	ExecuteTemplate(w io.Writer, name string, data any) error
+	Parse(text string) (T, error)
 }
 
-// TextTree is a hierarchy of text templates, mapping name to template.
-type TextTree map[string]*text.Template
+// Tree is a hierarchy of templates, mapping name to template. The concrete
+// type of the values will be T.
+type Tree[T StdTemplate] map[string]Template[T]
 
 // ExecuteTemplate renders the template with the given name. See the
 // text/template package for more details.
-func (tree TextTree) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
+func (tree Tree[T]) ExecuteTemplate(wr io.Writer, name string, data any) error {
 	if tmpl, ok := tree[name]; ok {
 		return tmpl.Execute(wr, data)
 	}
 	return fmt.Errorf("templatetree: no template %q", name)
 }
 
-// HTMLTree is a hierarchy of text templates, mapping name to template.
-type HTMLTree map[string]*html.Template
+// TemplateFactory creates new empty templates.
+type TemplateFactory[T StdTemplate] func(name string) Template[T]
 
-// ExecuteTemplate renders the template with the given name. See the
-// html/template package for more details.
-func (tree HTMLTree) ExecuteTemplate(wr io.Writer, name string, data interface{}) error {
-	if tmpl, ok := tree[name]; ok {
-		return tmpl.Execute(wr, data)
+// DefaultTextFactory uses text/template.New to create templates.
+func DefaultTextFactory(name string) Template[*text.Template] {
+	return text.New(name)
+}
+
+// DefaultHTMLFactory uses html/template.New to create templates.
+func DefaultHTMLFactory(name string) Template[*html.Template] {
+	return html.New(name)
+}
+
+// Parse recursively loads all templates in dir with names matching pattern,
+// respecting inheritance. Templates are named by their paths relative to dir.
+func Parse[T StdTemplate](dir, pattern string, f TemplateFactory[T]) (Tree[T], error) {
+	return ParseFS(os.DirFS(dir), pattern, f)
+}
+
+// ParseFS recursively parses all templates in fsys with names matching
+// pattern, respecting inheritance. Templates are named by their paths in fsys.
+func ParseFS[T StdTemplate](fsys fs.FS, pattern string, f TemplateFactory[T]) (Tree[T], error) {
+	files, err := loadFiles(fsys, pattern)
+	if err != nil {
+		return nil, err
 	}
-	return fmt.Errorf("templatetree: no template %q", name)
+	return ParseFiles(files, f)
 }
 
-// adapter for text/template and html/template
-type template interface {
-	Name() string
-	Clone() (template, error)
-	Parse(string) error
-}
-
-type textTemplate struct {
-	*text.Template
-}
-
-func (t textTemplate) Clone() (template, error) {
-	nt, err := t.Template.Clone()
-	return textTemplate{nt}, err
-}
-
-func (t textTemplate) Parse(content string) error {
-	_, err := t.Template.Parse(content)
-	return err
-}
-
-type htmlTemplate struct {
-	*html.Template
-}
-
-func (t htmlTemplate) Clone() (template, error) {
-	nt, err := t.Template.Clone()
-	return htmlTemplate{nt}, err
-}
-
-func (t htmlTemplate) Parse(content string) error {
-	_, err := t.Template.Parse(content)
-	return err
-}
-
-type node struct {
-	name    string
-	path    string
-	content string
-
-	template template
-	parent   *node
-}
-
-func loadAll(dir, pattern string, root template, register func(string, template)) error {
-	nodes := make(map[string]*node)
-	walkFn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-
-		match, err := filepath.Match(pattern, filepath.Base(path))
-		if err != nil {
-			return err
-		}
-		if match {
-			name := filepath.ToSlash(strings.TrimPrefix(path, dir))
-			name = strings.TrimPrefix(name, "/")
-			nodes[name] = &node{name: name, path: path}
-		}
-		return nil
+// ParseFiles parses all templates in files, respecting inheritance. Templates
+// are named by their key in files, which maps name to content.
+func ParseFiles[T StdTemplate](files map[string]string, f TemplateFactory[T]) (Tree[T], error) {
+	if f == nil {
+		return nil, fmt.Errorf("templatetree: factory must be non-nil")
 	}
 
-	// find all the templates
-	if err := filepath.Walk(dir, walkFn); err != nil {
-		return err
+	nodes := make(map[string]*node[T])
+	for name, f := range files {
+		nodes[name] = &node[T]{name: name, content: f}
 	}
 
-	// load all content and create links
+	// create links between parents and children
 	for _, n := range nodes {
-		b, err := ioutil.ReadFile(n.path)
-		if err != nil {
-			return err
-		}
-
-		n.content = string(b)
-
 		parent := parseHeader(n.content)
 		if parent != "" {
 			if p, ok := nodes[parent]; ok {
 				n.parent = p
 			} else {
-				return fmt.Errorf("templatetree: template %q extends unknown template %s", n.name, parent)
+				return nil, fmt.Errorf("templatetree: template %q extends unknown template %s", n.name, parent)
 			}
 		}
 	}
 
 	// parse templates from the root nodes in/down
+	tree := make(Tree[T])
 	for {
 		n := findNext(nodes)
 		if n == nil {
@@ -176,21 +107,13 @@ func loadAll(dir, pattern string, root template, register func(string, template)
 		}
 		delete(nodes, n.name)
 
-		base := root
-		if n.parent != nil {
-			base = n.parent.template
-		}
-
-		t, err := base.Clone()
-		if err != nil {
-			return err
-		}
-		if err := t.Parse(n.content); err != nil {
-			return formatParseError(n, t, err)
+		t := f(n.name)
+		if err := parseInto(t, n); err != nil {
+			return nil, err
 		}
 
 		n.template = t
-		register(n.name, t)
+		tree[n.name] = t
 	}
 
 	// check for cycles
@@ -199,13 +122,29 @@ func loadAll(dir, pattern string, root template, register func(string, template)
 		for _, n := range nodes {
 			names = append(names, strconv.Quote(n.name))
 		}
-		return fmt.Errorf("templatetree: inheritance cycle in templates [%s]", strings.Join(names, ", "))
+		return nil, fmt.Errorf("templatetree: inheritance cycle in templates [%s]", strings.Join(names, ", "))
 	}
 
-	return nil
+	return tree, nil
 }
 
-func findNext(nodes map[string]*node) *node {
+type node[T StdTemplate] struct {
+	name     string
+	content  string
+	template Template[T]
+	parent   *node[T]
+}
+
+func parseInto[T StdTemplate](dst Template[T], src *node[T]) error {
+	if src.parent != nil {
+		// parents are already parsed, so we know they are valid
+		_ = parseInto(dst, src.parent)
+	}
+	_, err := dst.Parse(src.content)
+	return err
+}
+
+func findNext[T StdTemplate](nodes map[string]*node[T]) *node[T] {
 	for _, n := range nodes {
 		if n.parent == nil || n.parent.template != nil {
 			return n
@@ -229,14 +168,32 @@ func parseHeader(content string) (parent string) {
 	return
 }
 
-// The current template API doesn't provide a way to change names, so try to
-// edit the error message so the correct name appears for users. This is dirty,
-// but is strictly for usability, not correctness.
-func formatParseError(n *node, t template, err error) error {
-	msg := err.Error()
-	old := "template: " + t.Name()
-	if strings.HasPrefix(msg, old) {
-		return fmt.Errorf("template: %s%s", n.name, strings.TrimPrefix(msg, old))
+func loadFiles(fsys fs.FS, pattern string) (map[string]string, error) {
+	files := make(map[string]string)
+	walkFn := func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		match, err := path.Match(pattern, path.Base(name))
+		if err != nil {
+			return err
+		}
+		if match {
+			b, err := fs.ReadFile(fsys, name)
+			if err != nil {
+				return err
+			}
+			files[name] = string(b)
+		}
+		return nil
 	}
-	return err
+
+	if err := fs.WalkDir(fsys, ".", walkFn); err != nil {
+		return nil, err
+	}
+	return files, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,8 +14,8 @@ github.com/alexedwards/scs/stores/cookiestore
 # github.com/bluekeyes/hatpear v0.1.1
 ## explicit; go 1.11
 github.com/bluekeyes/hatpear
-# github.com/bluekeyes/templatetree v0.1.0
-## explicit; go 1.11
+# github.com/bluekeyes/templatetree v0.5.0
+## explicit; go 1.18
 github.com/bluekeyes/templatetree
 # github.com/bradleyfalzon/ghinstallation/v2 v2.8.0
 ## explicit; go 1.13


### PR DESCRIPTION
This includes some minor improvements to error messages and enables us to embed templates in the policy-bot binary in the future.