### PR TITLE
Make reviewer list consistent with other lists

### DIFF
--- a/server/templates/details_reviewers.html.tmpl
+++ b/server/templates/details_reviewers.html.tmpl
@@ -1,7 +1,7 @@
 {{/* templatetree:extends page.html.tmpl */}}
 {{define "title"}}{{.PullRequest.GetBase.GetRepo.GetFullName}}#{{.PullRequest.GetNumber}} - Reviewers | PolicyBot{{end}}
 {{define "body"}}
-<ul>
+<ul class="list-disc list-outside pl-6">
   {{- range .Reviewers}}
   <li><a href="{{ githubURL . }}">{{.}}</a></li>
   {{- else}}


### PR DESCRIPTION
Initially, I was going to make the reviewer list multi-column, but I couldn't figure out how to make it work well with both a lot of names and names that are potentially long. Stick with a simple list for now.