### PR TITLE
Fix purgecss configuration for new status behavior

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -15,9 +15,11 @@ module.exports = {
         defaultExtractor: content => {
           return content.match(/[\w-./]*\w/g) || [];
         },
-        // status classes are dynamically generated
         safelist: [
+          // status classes are dynamically generated
           "approved", "disapproved", "pending", "skipped", "error",
+          // keep all selectors that relate to hidden statuses
+          "data-next-status", "data-hide-status",
         ],
       }),
       cssnano({


### PR DESCRIPTION
Add all the attributes used for hiding skipped statuses to the purgecss safelist to avoid stripping them from the stylesheet in production builds. Because some of these values are dynamically generated, the default logic didn't detect them.