### PR TITLE
Reduce NPM update frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
Our NPM dependencies are almost all build dependencies, so it's mostly noise to get small patch updates every week.