### PR TITLE
Remove usage of ::set-output in Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       id: go_version
       run: |
         GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+        echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -64,7 +64,7 @@ jobs:
       id: go_version
       run: |
         GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+        echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       id: go_version
       run: |
         GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
-        echo "::set-output name=version::${GO_VERSION}"
+        echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go
       uses: actions/setup-go@v5


### PR DESCRIPTION
This feature is deprecated in favor of the GITHUB_OUTPUT file.