### PR TITLE
Add Option to not post failure status to github when there is no successful policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ approval_rules:
           - "^staging/.*$"
     requires:
       count: 0
+
+# Settings which affect how policy-bot acts
+settings:
+  # Set the below to true if you only want policy-bot statuses on PRs where the policy has evaluated to true
+  only_post_success_status: false
 ```
 
 #### Notes on YAML Syntax

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -37,6 +37,11 @@ type RemoteConfig struct {
 type Config struct {
 	Policy        Policy           `yaml:"policy"`
 	ApprovalRules []*approval.Rule `yaml:"approval_rules"`
+	Settings      Settings         `yaml:"settings"`
+}
+
+type Settings struct {
+	OnlyPostSuccessStatus bool `yaml:"only_post_success_status"`
 }
 
 type Policy struct {

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -195,6 +195,11 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 		return
 	}
 
+	if state != "success" && ec.Config.Config.Settings.OnlyPostSuccessStatus {
+		logger.Info().Msg("Skipping status update as it is not success and the setting is enabled to only post status updates on success")
+		return
+	}
+
 	if !ec.PullContext.IsOpen() {
 		logger.Info().Msg("Skipping status update because PR state is not open")
 		return


### PR DESCRIPTION
This should address the following issue:

https://github.com/palantir/policy-bot/issues/709