### PR TITLE
Disable logging and metrics for health checks

### DIFF
--- a/server/handler/health.go
+++ b/server/handler/health.go
@@ -28,6 +28,7 @@ type HealthCheck struct {
 
 func Health() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseapp.IgnoreAll(r)
 		baseapp.WriteJSON(w, http.StatusOK, &HealthCheck{Status: "ok", Version: version.GetVersion()})
 	})
 }


### PR DESCRIPTION
These end up adding a lot of noise to logs and are rarely useful.

Fixes #172.