### PR TITLE
Load pull request draft status from GraphQL API

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -1000,9 +1000,7 @@ type v4PullRequest struct {
 	State     string
 
 	IsCrossRepository bool
-
-	// This field is in GraphQL Preview, so don't ask for it just yet
-	IsDraft bool `graphql:""`
+	IsDraft           bool
 
 	HeadRefOID     string
 	HeadRefName    string


### PR DESCRIPTION
Back in 2019, we disabled this field because it was part of a GraphQL preview. As a result, IsDraft was always false for PRs that we loaded via the GraphQL query. For the most part, this doesn't matter, but can cause problems with reviewer requests triggered via webhooks (like status events) that do not provide complete pull request details.

This field has been out of preview for a long time now and is available in all supported versions of GitHub, so it should be safe to load.

Fixes #741.