### PR TITLE
Accept successful status checks as approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,15 +420,14 @@ requires:
   # requests for details.
   permissions: ["write"]
 
-  # Deprecated: use 'permissions: ["admin"]'
+  # "statuses" is a list of status checks that must be successful for the rule
+  # to count as approved. If set, statuses are an additional requirement beyond
+  # the approvals required by "count".
   #
-  # Allows approval by admins of the org or repository
-  # admins: true
-
-  # Deprecated: use 'permissions: ["write"]'
-  #
-  # Allows approval by users who have write on the repository
-  # write_collaborators: true
+  # For example, if "count" is 1 and "statuses" contains the "build" and "test"
+  # status checks, the rule is only approved once both the "build" and "test"
+  # status checks pass and one authorized reviewer leaves a review.
+  statuses: ["build"]
 ```
 
 ### Approval Policies

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -60,9 +60,12 @@ type ReviewRequestRule struct {
 	Mode RequestMode
 }
 
+// Requires contains the union of requirements for approval and disapproval
+// rules. Some fields may only be used by one rule type.
 type Requires struct {
-	Count  int    `yaml:"count"`
-	Actors Actors `yaml:",inline"`
+	Count    int      `yaml:"count"`
+	Actors   Actors   `yaml:",inline"`
+	Statuses []string `yaml:"statuses"`
 }
 
 type Result struct {
@@ -76,7 +79,7 @@ type Result struct {
 	Methods           *Methods
 
 	// Approvers contains the candidates that satisfied the rule.
-	Approvers []*Candidate
+	Approvers *Approvers
 
 	// Dismissals contains candidates that should be discarded because they
 	// cannot satisfy any future evaluations.
@@ -85,6 +88,11 @@ type Result struct {
 	ReviewRequestRule *ReviewRequestRule
 
 	Children []*Result
+}
+
+type Approvers struct {
+	Actors   []*Candidate
+	Statuses []string
 }
 
 type Dismissal struct {

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -76,7 +76,7 @@ func (opts *Options) GetRevokeMethods() *common.Methods {
 }
 
 // Requires is redefined instead of using common.Requires because disapproval
-// does not currently support required counts.
+// does not currently support required counts or statuses.
 type Requires struct {
 	common.Actors `yaml:",inline"`
 }

--- a/server/handler/eval_context_dismissal.go
+++ b/server/handler/eval_context_dismissal.go
@@ -69,7 +69,7 @@ func findAllDismissals(result *common.Result) []*common.Dismissal {
 func findAllApprovers(result *common.Result) map[string]bool {
 	approvers := make(map[string]bool)
 
-	if len(result.Children) == 0 && result.Error == nil {
+	if len(result.Children) == 0 && result.Error == nil && result.Approvers != nil {
 		for _, a := range result.Approvers.Actors {
 			approvers[a.User] = true
 		}

--- a/server/handler/eval_context_dismissal.go
+++ b/server/handler/eval_context_dismissal.go
@@ -70,7 +70,7 @@ func findAllApprovers(result *common.Result) map[string]bool {
 	approvers := make(map[string]bool)
 
 	if len(result.Children) == 0 && result.Error == nil {
-		for _, a := range result.Approvers {
+		for _, a := range result.Approvers.Actors {
 			approvers[a.User] = true
 		}
 	}

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -85,7 +85,14 @@
           </div>
         {{end}}
         {{if ne $s "skipped"}}{{/* only show approval details for active rules */}}
-          {{if gt .Requires.Count 0 }}{{/* only show approval details if they're required */}}
+          {{- $hasStatuses := gt (len .Requires.Statuses) 0 -}}
+          {{- $hasActors := gt .Requires.Count 0 -}}
+          {{if $hasStatuses }}
+            <div class="pt-2">
+            {{template "result-statuses-details" .}}
+            </div>
+          {{end}}
+          {{if $hasActors }}
             <div class="pt-2">
             {{template "result-approver-details" .}}
             </div>
@@ -99,7 +106,8 @@
               <div class="reviewers">{{template "spinner"}}</div>
             </div>
             {{end}}
-          {{else}}
+          {{end}}
+          {{if and (not $hasActors) (not $hasStatuses)}}
             <div class="pt-2">
               <b class="font-bold text-sm">This rule is automatically approved and requires no reviews</b>
             </div>
@@ -212,6 +220,11 @@
 {{end}}
 
 {{define "result-reviews-count"}}This rule requires at least {{.Count}} approval{{if gt .Count 1}}s{{end}}{{end}}
+
+{{define "result-statuses-details"}}
+  <b class="font-bold text-sm">This rule requires the passing status checks:</b>
+  <ul class="list-disc list-outside pl-6 py-2">{{range .Requires.Statuses}}<li class="font-mono text-sm-mono">{{.}}</li>{{end}}</ul>
+{{end}}
 
 {{define "spinner"}}
 <div class="spinner w-6 my-2" aria-label="Loading..." aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" role="progressbar">

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -68,7 +68,7 @@
 <li class="node" data-status="{{$s}}" {{if not (eq $s $nextStatus)}}data-next-status="{{$nextStatus}}"{{end}}>
   <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
     {{template "result-details" .}}
-    {{if (or (.PredicateResults) (hasActors .Requires) (hasActorsPermissions .Requires))}}
+    {{if (or (.PredicateResults) (hasActors .Requires) (hasActorsPermissions .Requires) (gt (len .Requires.Statuses) 0))}}
     <details
       class="bg-light-gray5 p-2 mt-2 text-sm"
       {{if $showReviewers}}


### PR DESCRIPTION
Many users have requested a way to write policies that conditionally require status checks, for instance by only requiring passing tests for automated dependency update pull requests. While Policy Bot has a predicate for status checks, in practice it was hard to write these types of policies using predicates, because they skips the rule when the status is missing/pending/failed, instead of leaving the rule pending.

This change makes it possible to require passing status checks as an approval condition for a rule. For conditional status check policies, this means you can write rules that remain pending until the passing status checks are present. It's also possible to combine status check approval with normal actor-based approval.

See #627