### PR TITLE
Add support for approval conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ of approval.
 Rules combine using the logical operators `and` and `or`. With no operators, a
 policy requires that all of its rules are approved to approve the pull request.
 
-### Rules
+### Rules <!-- omit in toc -->
 
 Rules define the specific circumstances in which a pull request is approved.
 Each rule has four components:
@@ -83,7 +83,7 @@ requirements to be useful.
 After evaluation, a rule can be in one of four states:
 
 * `approved` - all of the predicates and requirements are true
-* `pending` - all of the predicates are true but one or more requirements is not true
+* `pending` - all of the predicates are true but one or more requirements are not true
 * `skipped` - one or more predicates are not true
 * `error` - something went wrong while evaluating the rule
 
@@ -93,7 +93,7 @@ For the purposes of the `and` and `or` operators:
 * `pending` and `error` are equivalent to `false`
 * `skipped` completely removes the rule from the condition
 
-### Predicates vs Conditions
+### Predicates vs Required Conditions <!-- omit in toc -->
 
 When writing a rule, you can react to the state of pull request by using either
 predicates or required conditions. When would you use one over the other?
@@ -104,9 +104,9 @@ predicates or required conditions. When would you use one over the other?
   requiring extra approval for files that involve security or automatically
   approving dependency updates.
 
-* Use **conditions** when the pull request state itself is important for
-  approval. For example, conditions are useful if you want to require that a
-  pull request has certain status checks or specific labels.
+* Use **required conditions** when the pull request state itself is important
+  for approval. For example, conditions are useful if you want to require that
+  a pull request has certain status checks or specific labels.
 
 Sometimes you can achieve a desired outcome using either approach. In this
 case, we prefer predicates. Policies that use predicates may define more rules,

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -107,7 +107,7 @@ func TestRules(t *testing.T) {
 					GithubReview: &defaultGithubReview,
 				},
 			},
-			Requires: common.Requires{
+			Requires: Requires{
 				Count: 5,
 				Actors: common.Actors{
 					Users:         []string{"user4"},

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -60,11 +60,6 @@ type ReviewRequestRule struct {
 	Mode RequestMode
 }
 
-type Requires struct {
-	Count  int    `yaml:"count"`
-	Actors Actors `yaml:",inline"`
-}
-
 type Result struct {
 	Name              string
 	Description       string
@@ -72,11 +67,11 @@ type Result struct {
 	Status            EvaluationStatus
 	Error             error
 	PredicateResults  []*PredicateResult
-	Requires          Requires
 	Methods           *Methods
 
-	// Approvers contains the candidates that satisfied the rule.
-	Approvers []*Candidate
+	// Requires contains the result of evaluating the rule's
+	// requirements.
+	Requires RequiresResult
 
 	// Dismissals contains candidates that should be discarded because they
 	// cannot satisfy any future evaluations.
@@ -85,6 +80,18 @@ type Result struct {
 	ReviewRequestRule *ReviewRequestRule
 
 	Children []*Result
+}
+
+type RequiresResult struct {
+	// Count is the number of required approvals from Actors
+	// Actors is the set of actors allowed to approve
+	// Approvers contains the actual approvers found during evalutaion
+	Count     int
+	Actors    Actors
+	Approvers []*Candidate
+
+	// Conditions contains the results of all required conditions
+	Conditions []*PredicateResult
 }
 
 type Dismissal struct {

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -75,8 +75,6 @@ func (opts *Options) GetRevokeMethods() *common.Methods {
 	return m
 }
 
-// Requires is redefined instead of using common.Requires because disapproval
-// does not currently support required counts.
 type Requires struct {
 	common.Actors `yaml:",inline"`
 }
@@ -108,7 +106,10 @@ func (p *Policy) Evaluate(ctx context.Context, prctx pull.Context) (res common.R
 
 	res.Name = "disapproval"
 	res.Status = common.StatusSkipped
-	res.Requires = common.Requires{Actors: p.Requires.Actors}
+	res.Requires = common.RequiresResult{
+		Count:  1,
+		Actors: p.Requires.Actors,
+	}
 
 	var predicateResults []*common.PredicateResult
 

--- a/server/handler/details_reviewers.go
+++ b/server/handler/details_reviewers.go
@@ -19,7 +19,7 @@ import (
 	"slices"
 
 	"github.com/palantir/policy-bot/policy"
-	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/policy/approval"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/pkg/errors"
 )
@@ -152,7 +152,7 @@ func userHasReviewerPermission(user *pull.Collaborator, perms []pull.Permission)
 	return false
 }
 
-func findRuleRequires(config *policy.Config, ruleName string) *common.Requires {
+func findRuleRequires(config *policy.Config, ruleName string) *approval.Requires {
 	for _, rule := range config.ApprovalRules {
 		if rule.Name == ruleName {
 			return &rule.Requires

--- a/server/handler/eval_context_dismissal.go
+++ b/server/handler/eval_context_dismissal.go
@@ -70,7 +70,7 @@ func findAllApprovers(result *common.Result) map[string]bool {
 	approvers := make(map[string]bool)
 
 	if len(result.Children) == 0 && result.Error == nil {
-		for _, a := range result.Approvers {
+		for _, a := range result.Requires.Approvers {
 			approvers[a.User] = true
 		}
 	}

--- a/server/handler/frontend.go
+++ b/server/handler/frontend.go
@@ -102,7 +102,7 @@ func LoadTemplates(c *FilesConfig, basePath string, githubURL string) (templatet
 
 				return r
 			},
-			"hasActors": func(requires *common.Requires) bool {
+			"hasActors": func(requires common.RequiresResult) bool {
 				return len(requires.Actors.Users) > 0 || len(requires.Actors.Teams) > 0 || len(requires.Actors.Organizations) > 0
 			},
 			"getMethods": func(results *common.Result) map[string][]string {
@@ -111,7 +111,7 @@ func LoadTemplates(c *FilesConfig, basePath string, githubURL string) (templatet
 			"getActors": func(results *common.Result) map[string][]Membership {
 				return getActors(results, strings.TrimSuffix(githubURL, "/"))
 			},
-			"hasActorsPermissions": func(requires *common.Requires) bool {
+			"hasActorsPermissions": func(requires common.RequiresResult) bool {
 				return len(requires.Actors.GetPermissions()) > 0
 			},
 			"getPermissions": func(results *common.Result) []string {

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -68,7 +68,7 @@
 <li class="node" data-status="{{$s}}" {{if not (eq $s $nextStatus)}}data-next-status="{{$nextStatus}}"{{end}}>
   <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
     {{template "result-details" .}}
-    {{if (or (.PredicateResults) (hasActors .Requires) (hasActorsPermissions .Requires))}}
+    {{if (or (.PredicateResults) (hasActors .Requires) (hasActorsPermissions .Requires) (gt (len .Requires.Conditions) 0))}}
     <details
       class="bg-light-gray5 p-2 mt-2 text-sm"
       {{if $showReviewers}}
@@ -85,7 +85,14 @@
           </div>
         {{end}}
         {{if ne $s "skipped"}}{{/* only show approval details for active rules */}}
-          {{if gt .Requires.Count 0 }}{{/* only show approval details if they're required */}}
+          {{- $hasConditions := gt (len .Requires.Conditions) 0 -}}
+          {{- $hasActors := gt .Requires.Count 0 -}}
+          {{if $hasConditions }}
+            <div class="pt-2">
+            {{template "result-conditions-details" .}}
+            </div>
+          {{end}}
+          {{if $hasActors }}
             <div class="pt-2">
             {{template "result-approver-details" .}}
             </div>
@@ -99,7 +106,8 @@
               <div class="reviewers">{{template "spinner"}}</div>
             </div>
             {{end}}
-          {{else}}
+          {{end}}
+          {{if and (not $hasActors) (not $hasConditions)}}
             <div class="pt-2">
               <b class="font-bold text-sm">This rule is automatically approved and requires no reviews</b>
             </div>
@@ -212,6 +220,11 @@
 {{end}}
 
 {{define "result-reviews-count"}}This rule requires at least {{.Count}} approval{{if gt .Count 1}}s{{end}}{{end}}
+
+{{define "result-conditions-details"}}
+  {{/* TODO(bkeyes): this is a placeholder until I can refactor predicate rendering */}}
+  <b class="font-bold text-sm">This rule requires that {{len .Requires.Conditions}} condition{{if gt (len .Requires.Conditions) 1}}s are{{else}} is{{end}} met</b>
+{{end}}
 
 {{define "spinner"}}
 <div class="spinner w-6 my-2" aria-label="Loading..." aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" role="progressbar">


### PR DESCRIPTION
Many users try to use Policy Bot as a general purpose rule engine, constructing policies that enforce things about status checks, labels, and other conditions. This was poorly supported because predicates skip rules when the conditions don't match, whereas users working in this model expect the rule to apply, but remain in the pending state.

This commit introduces the concept of "conditions", which are predicates that count toward approval. All of the existing predicates tests are available, but when used as a condition they control whether the rule is pending or approved, instead of active or skipped.

Conditions can combine with regular approval requirements, but I expect most uses will either use predicates and regular approval or conditions without additional approval.

Due to limitations in how predicates work internally, the details UI shows limited information about conditions. I hope to fix this in a follow-up, but I wanted to separate the main change from the predicate refactoring.

Finally, this adds a new README section explaining how to design a policy and what all the different terms mean.

I'm open to a different name for this new feature, since it's easy to accidentally say "condition" when talking about predicates, but I couldn't think of anything else that fit better.

This is an alternative to #750, which only works for status checks. See also #627.