### PR TITLE
Fix false context matches in status processing

### DIFF
--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -41,7 +41,8 @@ func (h *Status) Handle(ctx context.Context, eventType, deliveryID string, paylo
 		return errors.Wrap(err, "failed to parse status event payload")
 	}
 
-	if strings.HasPrefix(event.GetContext(), h.PullOpts.StatusCheckContext) {
+	ownContext := h.PullOpts.StatusCheckContext
+	if event.GetContext() == ownContext || strings.HasPrefix(event.GetContext(), ownContext+":") {
 		return h.processOwn(ctx, event)
 	}
 


### PR DESCRIPTION
Policy Bot looks for its own status context to identify when people or apps might be impersonating it, but it used a simple prefix match. This meant it could falsely trigger on unrelated contexts that shared the same prefix. Change to using an exact match or a prefix match followed by a ':', which will match the contexts with a branch name.

Fixes #799.