### PR TITLE
Fix accidental use of go-github v62

### DIFF
--- a/policy/predicate/status_test.go
+++ b/policy/predicate/status_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v62/github"
+	"github.com/google/go-github/v63/github"
 	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/palantir/policy-bot/pull/pulltest"


### PR DESCRIPTION
This was introduced by a PR that was created before the upgrade to v63, but merged afterwards.