### PR TITLE
Don't look at check run results in other repositories

### DIFF
--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -42,6 +42,7 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 	}
 
 	repo := event.GetRepo()
+	repoID := repo.GetID()
 	ownerName := repo.GetOwner().GetLogin()
 	repoName := repo.GetName()
 	commitSHA := event.GetCheckRun().GetHeadSHA()
@@ -55,6 +56,19 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 		// of the event, but I can't find confirmation of that in the GitHub
 		// docs. The PR object is a minimal version that is missing the "state"
 		// field, so we can't check without loading the full object.
+
+		// The `check_run` event includes pull requests that contain the SHA
+		// which is being checked. These can be pull requests _from_ our
+		// repository _to_ another one, for example if it's been forked and
+		// there's a PR to merge changes from our repo into the fork. We don't
+		// want to try to evaluate the policy for such PRs as they're nothing to
+		// do with us.
+		prBaseRepo := pr.GetBase().GetRepo()
+		if prBaseRepo.GetID() != repoID {
+			logger.Debug().Msgf("Skipping pull request '%d' from different repository '%s'", pr.GetNumber(), prBaseRepo.GetURL())
+			continue
+		}
+
 		if err := h.Evaluate(ctx, installationID, common.TriggerStatus, pull.Locator{
 			Owner:  ownerName,
 			Repo:   repoName,


### PR DESCRIPTION
We are notified about check run completions via the `check_run` webhook event. This event contains a `pull_requests` field, which is a list of PRs that contain the SHA which just got checked:

```json
      "pull_requests": [
        {
          "url": "https://api.github.com/repos/myorg/myrepo/pulls/1337",
          "id": 333333333,
          "number": 1337,
          "head": {
            "ref": "some-branch",
            "sha": "abcdef0123456789abcdef0123456789abcdef01",
            "repo": {
              "id": 11111111,
              "url": "https://api.github.com/repos/myorg/myrepo",
              "name": "myrepo"
            }
          },
          "base": {
            "ref": "main",
            "sha": "0101010101010101010101010101010101010101",
            "repo": {
              "id": 111111111,
              "url": "https://api.github.com/repos/myorg/myrepo",
              "name": "myrepo"
            }
          }
        }
      ],
```

However (mainly but not exclusively), in the case of public repositories, this list can contain PRs in other repositories:

```json
    "pull_requests": [
      {
        "url": "https://api.github.com/repos/forkowner/myrepo/pulls/3",
        "id": 1234567890,
        "number": 3,
        "head": {
          "ref": "main",
          "sha": "6666666666666666666666666666666666666666",
          "repo": {
            "id": 111111111,
            "url": "https://api.github.com/repos/myorg/myrepo",
            "name": "myrepo"
          }
        },
        "base": {
          "ref": "main",
          "sha": "8888888888888888888888888888888888888888",
          "repo": {
            "id": 555555555,
            "url": "https://api.github.com/repos/forkowner/myrepo",
            "name": "myrepo"
          }
        }
      }
    ]
```

...this is because people can fork the repository and then create PRs _from_ our repo _into_ theirs. These PRs will contain SHAs from our repository and this causes them to appear in the `pull_requests` list of the check run, since they will share the same check run status in any repo: the check run is attached to the commit itself.

These PRs should be ignored for our purposes. We aren't evaluating a policy on the remote repo. When a `check_run` completes, we are only interested in PRs for our own repo.
