### PR TITLE
server: Allow the shared location to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ instance of the server.
 - If the file does not exist in the repository, `policy-bot` tries to load a
   shared `policy.yml` file at the root of the `.github` repository in the same
   organization. You can change this path and repository name when running your
-  own instance of the server.
+  own instance of the server, or disable this feature by setting
+  `options.shared_repository` to an empty string (`""`) in the server
+  configuration.
 
 - If a policy does not exist in the repository or in the shared organization
   repository, `policy-bot` does not post a status check on the pull request.

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -109,7 +109,9 @@ sessions:
 #
 #   # The name of an organization repository to look in for a shared policy if
 #   # a repository does not define a policy file. Can also be set by the
-#   # POLICYBOT_OPTIONS_SHARED_REPOSITORY environment variable.
+#   # POLICYBOT_OPTIONS_SHARED_REPOSITORY environment variable. Explicitly set
+#   # this or `shared_policy_path` to an empty string(`""`) to disable searching
+#   # in a shared repository.
 #   shared_repository: .github
 #
 #   # The path to the policy file in the shared organization repository.

--- a/server/server.go
+++ b/server/server.go
@@ -148,6 +148,11 @@ func New(c *Config) (*Server, error) {
 		return nil, errors.Wrap(err, "failed to initialize global cache")
 	}
 
+	sharedPolicyPaths := []string{}
+	if c.Options.SharedPolicyPath != nil {
+		sharedPolicyPaths = []string{*c.Options.SharedPolicyPath}
+	}
+
 	basePolicyHandler := handler.Base{
 		ClientCreator: cc,
 		BaseConfig:    &c.Server,
@@ -158,9 +163,7 @@ func New(c *Config) (*Server, error) {
 		ConfigFetcher: &handler.ConfigFetcher{
 			Loader: appconfig.NewLoader(
 				[]string{c.Options.PolicyPath},
-				appconfig.WithOwnerDefault(c.Options.SharedRepository, []string{
-					c.Options.SharedPolicyPath,
-				}),
+				appconfig.WithOwnerDefault(*c.Options.SharedRepository, sharedPolicyPaths),
 			),
 		},
 


### PR DESCRIPTION
The shared location can't currently be switched off. There are a couple of reasons why being able to do is desirable:

1. When Policy Bot is run for a repo which doesn't have a config, the shared location is searched for every time, since 404s aren't cached.  If we know it doesn't exist, we can skip that lookup. This saves API calls.
2. Somebody not on the Policy Bot operating team might create a `.github` repository at a later date and put a `.policy.yml` file in there. This file would then start to be used without the team knowing about it. It should be possible to prevent this.

Here we solve this by turning the shared repo and path into pointers in the struct. Then we can tell the difference between if it was explicitly set to `""` or not specified by the administrator. In the former case, we preserve the empty string, which is treated as disabling by `go-githubapp`.
