### PR TITLE
Only use the most recent check runs on a commit

### DIFF
--- a/pull/testdata/responses/check_runs_for_ref.yml
+++ b/pull/testdata/responses/check_runs_for_ref.yml
@@ -1,0 +1,28 @@
+- status: 200
+  body: |
+    {
+      "total_count": 3,
+      "check_runs": [
+        {
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2024-08-14T12:12:45Z",
+          "completed_at": "2024-08-14T12:13:14Z",
+          "name": "check-run-a"
+        },
+        {
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2024-08-14T12:10:00Z",
+          "completed_at": "2024-08-14T12:10:36Z",
+          "name": "check-run-b"
+        },
+        {
+          "status": "completed",
+          "conclusion": "failure",
+          "started_at": "2024-08-14T12:10:00Z",
+          "completed_at": "2024-08-14T12:10:21Z",
+          "name": "check-run-a"
+        }
+      ]
+    }

--- a/pull/testdata/responses/combined_status_for_ref.yml
+++ b/pull/testdata/responses/combined_status_for_ref.yml
@@ -1,0 +1,19 @@
+- status: 200
+  body: |
+    {
+      "state": "pending",
+      "statuses": [
+        {
+          "state": "pending",
+          "context": "commit-status-b",
+          "created_at": "2024-08-14T12:13:14Z",
+          "updated_at": "2024-08-14T12:13:14Z"
+        },
+        {
+          "state": "success",
+          "context": "commit-status-a",
+          "created_at": "2024-08-14T12:12:00Z",
+          "updated_at": "2024-08-14T12:12:00Z"
+        }
+      ]
+    }


### PR DESCRIPTION
This fixes an issue where we would iterate over all check runs on a commit and keep the last one. Because GitHub returns check runs in reverse chronological order, this meant we used the oldest result for each run in the event of duplicates instead of the most recent.

Fixes #821.