### PR TITLE
Set Actions Go version from go.mod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set Go version
       id: go_version
       run: |
-        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+        GO_VERSION=$(sed -E -n '/^go / s/^go ([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' < go.mod)
         echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go
@@ -61,7 +61,7 @@ jobs:
     - name: Set Go version
       id: go_version
       run: |
-        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+        GO_VERSION=$(sed -E -n '/^go / s/^go ([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' < go.mod)
         echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set Go version
       id: go_version
       run: |
-        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+        GO_VERSION=$(sed -E -n '/^go / s/^go ([0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' < go.mod)
         echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
 
     - name: Set up Go


### PR DESCRIPTION
The `.palantir/go-version` file is no longer supported, so always build with the latest patch release of the version specified in `go.mod`. This mostly matches the behavior we're adopting internally, with the main difference being that we'll never build with a newer major version of Go than what is specified in our `go.mod` file. We can't rely on the default behavior of the `setup-go` action because it always downloads the exact version in `go.mod` when a patch version is specified.