### PR TITLE
Dedupe Reviewers and TeamReviewers before submitting them to GitHub

### DIFF
--- a/server/handler/eval_context_reviewers.go
+++ b/server/handler/eval_context_reviewers.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/google/go-github/v65/github"
@@ -150,6 +151,12 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 	} else {
 		req.TeamReviewers = []string{}
 	}
+
+	// Order the reviewers and remove any duplicates
+	slices.Sort(req.Reviewers)
+	req.Reviewers = slices.Compact(req.Reviewers)
+	slices.Sort(req.TeamReviewers)
+	req.TeamReviewers = slices.Compact(req.TeamReviewers)
 
 	return req
 }

--- a/server/handler/eval_context_reviewers.go
+++ b/server/handler/eval_context_reviewers.go
@@ -152,7 +152,7 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 		req.TeamReviewers = []string{}
 	}
 
-	// Order the reviewers and remove any duplicates
+	// Order the reviewers and remove any duplicates because the Github API will error on duplicates as of Oct 2024
 	slices.Sort(req.Reviewers)
 	req.Reviewers = slices.Compact(req.Reviewers)
 	slices.Sort(req.TeamReviewers)


### PR DESCRIPTION
Fixes #855

The code takes the same deduping method as [the DetailsReviewers handler](https://github.com/palantir/policy-bot/blob/5641eeaa124026b06e9ffad47ce636862f86529b/server/handler/details_reviewers.go#L117:L119).