### PR TITLE
Add dismissed state

### DIFF
--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -88,6 +88,9 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 
 func (h *PullRequestReview) affectsApproval(reviewState pull.ReviewState, config *policy.Config) bool {
 	states := make(map[pull.ReviewState]struct{})
+	// Include dismissed state
+	states[pull.ReviewDismissed] = struct{}{}
+
 	for _, rule := range config.ApprovalRules {
 		states[rule.Options.GetMethods().GithubReviewState] = struct{}{}
 	}

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -88,7 +88,8 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 
 func (h *PullRequestReview) affectsApproval(reviewState pull.ReviewState, config *policy.Config) bool {
 	states := make(map[pull.ReviewState]struct{})
-	// Include dismissed state
+
+	// Always process events for dismissed reviews because they can revert the overall approval or disapproval to a previous state
 	states[pull.ReviewDismissed] = struct{}{}
 
 	for _, rule := range config.ApprovalRules {


### PR DESCRIPTION
Previously we skipping the check if the state was dismissed but after adding dismissed as one of the base states it will rerun the policy if we receive that event.