### PR TITLE
feat: Add support for InsecureStatusChecks in merge groups

### DIFF
--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -185,7 +185,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 
 	status := github.RepoStatus{
 		State:       &state,
-		Context:     github.String(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
+		Context:     github.Ptr(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
 		Description: &message,
 		TargetURL:   &detailsURL,
 	}
@@ -204,7 +204,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 		logger.Err(err).Msg("Failed to post repo status")
 	}
 	if ec.Options.PostInsecureStatusChecks {
-		status.Context = github.String(ec.Options.StatusCheckContext)
+		status.Context = github.Ptr(ec.Options.StatusCheckContext)
 		if err := PostStatus(ctx, ec.Client, owner, repo, sha, &status); err != nil {
 			logger.Err(err).Msg("Failed to post insecure repo status")
 		}

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -78,5 +78,12 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 		logger.Err(errors.WithStack(err)).Msg("Failed to post status check for merge group")
 	}
 
+	if h.PullOpts.PostInsecureStatusChecks {
+		status.Context = github.Ptr(h.PullOpts.StatusCheckContext)
+		if err := PostStatus(ctx, client, owner, repository, headSHA, status); err != nil {
+			logger.Err(err).Msg("Failed to post insecure repo status")
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
We have started to adopt merge groups, and we also happen to need to use the InsecureStatusChecks option because we have a significant number of release branches that are not always deterministically named.

This change just ports over the insecure posting logic to the merge group handler.