### PR TITLE
add file_exists predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ if:
     paths:
       - "^config/.*$"
 
+  # "file_exists" is satisfied if none of the files matching any regular expression
+  # in the "paths" list have been deleted in the pull request. If any matching file
+  # is removed, the predicate fails, allowing rules that depend on the file's existence
+  # to be skipped.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See the Notes on YAML Syntax section of this README for more information.
+  file_exists:
+    paths:
+      - "^\\.github/workflows/.*\\.ya?ml$"
+
   # "has_author_in" is satisfied if the user who opened the pull request is in
   # the users list or belongs to any of the listed organizations or teams. The
   # `users` field can contain a GitHub App by appending `[bot]` to the end of

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -181,6 +181,60 @@ func (pred *NoChangedFiles) Trigger() common.Trigger {
 	return common.TriggerCommit
 }
 
+type FileExists struct {
+	Paths []common.Regexp `yaml:"paths"`
+}
+
+var _ Predicate = &FileExists{}
+
+func (pred *FileExists) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	var paths []string
+	for _, r := range pred.Paths {
+		paths = append(paths, r.String())
+	}
+
+	predicateResult := common.PredicateResult{
+		Satisfied:       true,
+		ValuePhrase:     "file exists",
+		Values:          []string{},
+		ConditionPhrase: "all specified paths exist",
+		ConditionValues: paths,
+	}
+
+	changedFiles, err := prctx.ChangedFiles()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list changed files")
+	}
+
+	if len(changedFiles) == 0 {
+		predicateResult.Description = "No files were changed"
+		return &predicateResult, nil
+	}
+
+	var deletedFiles []string
+	for _, f := range changedFiles {
+		if anyMatches(pred.Paths, f.Filename) {
+			if f.Status == pull.FileDeleted {
+				deletedFiles = append(deletedFiles, f.Filename)
+			}
+		}
+	}
+
+	if len(deletedFiles) > 0 {
+		predicateResult.Satisfied = false
+		predicateResult.Values = deletedFiles
+		predicateResult.Description = fmt.Sprintf("Files matching defined patterns were deleted: %v", deletedFiles)
+		return &predicateResult, nil
+	}
+
+	predicateResult.Description = "All specified paths exist"
+	return &predicateResult, nil
+}
+
+func (pred *FileExists) Trigger() common.Trigger {
+	return common.TriggerCommit
+}
+
 type ModifiedLines struct {
 	Additions ComparisonExpr `yaml:"additions"`
 	Deletions ComparisonExpr `yaml:"deletions"`

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -364,6 +364,97 @@ func TestOnlyChangedFiles(t *testing.T) {
 	})
 }
 
+func TestFileExists(t *testing.T) {
+	p := &FileExists{
+		Paths: []common.Regexp{
+			common.NewCompiledRegexp(regexp.MustCompile("workflows/.*\\.yaml")),
+			common.NewCompiledRegexp(regexp.MustCompile("actions/.*\\.yaml")),
+		},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"file not changed",
+			[]*pull.File{},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{},
+				ConditionValues: []string{"workflows/.*\\.yaml", "actions/.*\\.yaml"},
+			},
+		},
+		{
+			"files exist and modified",
+			[]*pull.File{
+				{
+					Filename: "workflows/workflow.yaml",
+					Status:   pull.FileModified,
+				},
+				{
+					Filename: "actions/action.yaml",
+					Status:   pull.FileModified,
+				},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{},
+				ConditionValues: []string{"workflows/.*\\.yaml", "actions/.*\\.yaml"},
+			},
+		},
+		{
+			"one file deleted",
+			[]*pull.File{
+				{
+					Filename: "workflows/workflow.yaml",
+					Status:   pull.FileDeleted,
+				},
+				{
+					Filename: "actions/action.yaml",
+					Status:   pull.FileModified,
+				},
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"workflows/workflow.yaml"},
+				ConditionValues: []string{"workflows/.*\\.yaml", "actions/.*\\.yaml"},
+				Description:     "File workflows/workflow.yaml matching defined patterns was deleted",
+			},
+		},
+		{
+			"multiple files deleted",
+			[]*pull.File{
+				{
+					Filename: "workflows/workflow.yaml",
+					Status:   pull.FileDeleted,
+				},
+				{
+					Filename: "actions/action.yaml",
+					Status:   pull.FileDeleted,
+				},
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"workflows/workflow.yaml", "actions/action.yaml"},
+				ConditionValues: []string{"workflows/.*\\.yaml", "actions/.*\\.yaml"},
+				Description:     "File workflows/workflow.yaml matching defined patterns was deleted",
+			},
+		},
+		{
+			"file deleted not matching",
+			[]*pull.File{
+				{
+					Filename: "some/otherfile.yaml",
+					Status:   pull.FileDeleted,
+				},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{},
+				ConditionValues: []string{"workflows/.*\\.yaml", "actions/.*\\.yaml"},
+			},
+		},
+	})
+}
+
 func TestModifiedLines(t *testing.T) {
 	p := &ModifiedLines{
 		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 100},

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -18,6 +18,7 @@ type Predicates struct {
 	ChangedFiles     *ChangedFiles     `yaml:"changed_files"`
 	NoChangedFiles   *NoChangedFiles   `yaml:"no_changed_files"`
 	OnlyChangedFiles *OnlyChangedFiles `yaml:"only_changed_files"`
+	FileExists       *FileExists       `yaml:"file_exists"`
 
 	HasAuthorIn             *HasAuthorIn             `yaml:"has_author_in"`
 	HasContributorIn        *HasContributorIn        `yaml:"has_contributor_in"`
@@ -58,6 +59,9 @@ func (p *Predicates) Predicates() []Predicate {
 	}
 	if p.OnlyChangedFiles != nil {
 		ps = append(ps, Predicate(p.OnlyChangedFiles))
+	}
+	if p.FileExists != nil {
+		ps = append(ps, Predicate(p.FileExists))
 	}
 
 	if p.HasAuthorIn != nil {


### PR DESCRIPTION
This adds the `file_exists` predicate, which accepts a list of regex patterns used verify whether files required by a policy rule have been deleted as part of a PR. If any matching file is removed, the predicate fails, allowing rules that depend on the file's existence to be skipped.

- Added logic for `file_exists` predicate
- Updated unit tests to verify functionality
- Updated readme to document the new predicate

Closes #246