### PR TITLE
feat: add server option for strict review dismissals

### DIFF
--- a/server/handler/eval_context_dismissal.go
+++ b/server/handler/eval_context_dismissal.go
@@ -34,9 +34,11 @@ func (ec *EvalContext) dismissStaleReviewsForResult(ctx context.Context, result 
 		if d.Candidate.Type != common.ReviewCandidate {
 			continue
 		}
-		// Only dismiss reviews from users who are not currently approvers
-		if approvers[d.Candidate.User] {
-			continue
+		if !ec.Options.StrictReviewDismissal {
+			// Only dismiss reviews from users who are not currently approvers
+			if approvers[d.Candidate.User] {
+				continue
+			}
 		}
 		// Only dismiss reviews once if they're dismissed by multiple rules
 		if alreadyDismissed[d.Candidate.ReviewID] {

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -42,6 +42,11 @@ type PullEvaluationOptions struct {
 	// is otherwise private. See the README for details.
 	ExpandRequiredReviewers bool `yaml:"expand_required_reviewers"`
 
+	// StrictReviewDismissal enables sending unconditional GitHub dismissals
+	// for reviews associated with rules of invalidated approval candidates
+	// even if that same approval candidate satifies another rule.
+	StrictReviewDismissal bool `yaml:"strict_review_dismissal"`
+
 	// PostInsecureStatusChecks enables the sending of a second status using just StatusCheckContext as the context,
 	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
 	// context behaviour, and will be removed in 2.0
@@ -92,6 +97,7 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setStringPtrFromEnv("SHARED_POLICY_PATH", prefix, &p.SharedPolicyPath)
 	setStringFromEnv("STATUS_CHECK_CONTEXT", prefix, &p.StatusCheckContext)
 	setBoolFromEnv("EXPAND_REQUIRED_REVIEWERS", prefix, &p.ExpandRequiredReviewers)
+	setBoolFromEnv("STRICT_REVIEW_DISMISSAL", prefix, &p.StrictReviewDismissal)
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)
 	p.fillDefaults()
 }


### PR DESCRIPTION
This pull request introduces a new feature for strict review dismissal in the evaluation context. The most important changes include adding a new option for strict review dismissal and modifying the related logic to respect this new option.

New feature for strict review dismissal:

* [`server/handler/eval_options.go`](diffhunk://#diff-4c2f8588bb0dbf74803fffef6bbee50e7680c72899b0972fea6cf0ef80937130R45-R49): Added a new boolean field `StrictReviewDismissal` in the `PullEvaluationOptions` struct to enable unconditional GitHub dismissals for reviews associated with invalidated approval candidates.
* [`server/handler/eval_options.go`](diffhunk://#diff-4c2f8588bb0dbf74803fffef6bbee50e7680c72899b0972fea6cf0ef80937130R100): Updated the `SetValuesFromEnv` function to set the `StrictReviewDismissal` option from environment variables.

Logic modification for review dismissal:

* [`server/handler/eval_context_dismissal.go`](diffhunk://#diff-9a1aa4ae85323f98b833a9551817bf9388a01bfef333c49b28c08927f5512f2fR37-R42): Modified the `dismissStaleReviewsForResult` function to respect the new `StrictReviewDismissal` option, ensuring reviews are only dismissed if the option is enabled or the user is not currently an approver.

Closes #893 