### PR TITLE
Fix discovery of deleted files

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -301,7 +301,7 @@ func (ghc *GitHubContext) ChangedFiles() ([]*File, error) {
 			switch f.GetStatus() {
 			case "added":
 				status = FileAdded
-			case "deleted":
+			case "removed":
 				status = FileDeleted
 			case "renamed":
 				// Break renames into components: the new file is added and we

--- a/pull/testdata/responses/pull_files.yml
+++ b/pull/testdata/responses/pull_files.yml
@@ -14,7 +14,7 @@
       },
       {
         "filename": "path/bar.txt",
-        "status": "deleted",
+        "status": "removed",
         "additions": 0,
         "deletions": 21,
         "changes": 21


### PR DESCRIPTION
The loop that categorized the modified files in the pull request checked for 'deleted', but GitHub actually uses 'removed' for this status. It's likely this has always been broken because nothing in policy-bot used the deleted file status until the `file_deleted` predicate.

Note that because deleted files were still classified as "modified", this bug does not affect the `changed_files` or `only_changed_files` predicates.

Fixes #947.