### PR TITLE
Add debug logging for check run events

### DIFF
--- a/server/handler/check_run.go
+++ b/server/handler/check_run.go
@@ -50,6 +50,8 @@ func (h *CheckRun) Handle(ctx context.Context, eventType, deliveryID string, pay
 
 	ctx, logger := githubapp.PrepareRepoContext(ctx, installationID, repo)
 
+	logger.Debug().Msgf("Check run event is for '%s', found %d PRs", event.GetCheckRun().GetName(), len(event.GetCheckRun().PullRequests))
+
 	evaluationFailures := 0
 	for _, pr := range event.GetCheckRun().PullRequests {
 		// TODO(bkeyes): I'm assuming PRs in a check run are open at the time

--- a/server/handler/status.go
+++ b/server/handler/status.go
@@ -127,7 +127,7 @@ func (h *Status) processOthers(ctx context.Context, event github.StatusEvent) er
 	if err != nil {
 		return errors.Wrapf(err, "failed to list pull requests for SHA %s", commitSHA)
 	}
-	logger.Debug().Msgf("Context event is for '%s', found %d PRs", event.GetContext(), len(prs))
+	logger.Debug().Msgf("Status event is for '%s', found %d PRs", event.GetContext(), len(prs))
 
 	evaluationFailures := 0
 	for _, pr := range prs {


### PR DESCRIPTION
This mirrors the logging for status events and can help debug issues with check run processing. Without this logging, it's hard to know which check is associated with a given event.

May help with debugging the problem in #960.