### PR TITLE
Use zero value by default for comments edited time when simulating PR status

### DIFF
--- a/policy/simulated/options.go
+++ b/policy/simulated/options.go
@@ -111,10 +111,6 @@ func (r *Review) setDefaults(id, sha string) {
 		r.CreatedAt = &now
 	}
 
-	if r.LastEditedAt == nil {
-		r.LastEditedAt = &now
-	}
-
 	r.ID = id
 	r.SHA = sha
 }

--- a/policy/simulated/options.go
+++ b/policy/simulated/options.go
@@ -80,7 +80,7 @@ func (c *Comment) setDefaults() {
 	}
 
 	if c.LastEditedAt == nil {
-		c.LastEditedAt = &now
+		c.LastEditedAt = &time.Time{}
 	}
 }
 
@@ -109,6 +109,10 @@ func (r *Review) setDefaults(id, sha string) {
 	now := time.Now()
 	if r.CreatedAt == nil {
 		r.CreatedAt = &now
+	}
+
+	if r.LastEditedAt == nil {
+		r.LastEditedAt = &time.Time{}
 	}
 
 	r.ID = id

--- a/policy/simulated/options.go
+++ b/policy/simulated/options.go
@@ -72,7 +72,7 @@ type Comment struct {
 	Body         string     `json:"body"`
 }
 
-// setDefaults sets the createdAt and lastEdtedAt values to time.Now() if they are otherwise unset
+// setDefaults sets the createdAt value to time.Now(), and the lastEditedAt value to zero, if they are otherwise unset
 func (c *Comment) setDefaults() {
 	now := time.Now()
 	if c.CreatedAt == nil {

--- a/policy/simulated/options_test.go
+++ b/policy/simulated/options_test.go
@@ -82,11 +82,11 @@ func TestOptionDefaults(t *testing.T) {
 	options.setDefaults()
 	for _, comment := range options.AddComments {
 		assert.False(t, comment.CreatedAt.IsZero())
-		assert.False(t, comment.LastEditedAt.IsZero())
+		assert.True(t, comment.LastEditedAt.IsZero())
 	}
 
 	for _, review := range options.AddReviews {
 		assert.False(t, review.CreatedAt.IsZero())
-		assert.False(t, review.LastEditedAt.IsZero())
+		assert.True(t, review.LastEditedAt.IsZero())
 	}
 }


### PR DESCRIPTION
This is unnecessary and causes a difference when interacting with ignore_edited_comments options in pull requests and simulation.