### PR TITLE
feature: Add capability to hide the root url

### DIFF
--- a/server/handler/index.go
+++ b/server/handler/index.go
@@ -28,6 +28,7 @@ type Index struct {
 
 	GithubConfig *githubapp.Config
 	Templates    templatetree.Tree[*template.Template]
+	Config       *githubapp.Config
 }
 
 func (h *Index) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
@@ -36,6 +37,11 @@ func (h *Index) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 		Version    string
 		GitHubURL  string
 		PolicyPath string
+	}
+
+	if h.Config.HideRootPath {
+		http.NotFound(w, r)
+		return nil
 	}
 
 	data.AppName = h.AppName

--- a/server/server.go
+++ b/server/server.go
@@ -247,6 +247,7 @@ func New(c *Config) (*Server, error) {
 		Base:         basePolicyHandler,
 		GithubConfig: &c.Github,
 		Templates:    templates,
+		Config:       &c.Github,
 	}))
 
 	detailsHandler := handler.Details{

--- a/vendor/github.com/palantir/go-githubapp/githubapp/config.go
+++ b/vendor/github.com/palantir/go-githubapp/githubapp/config.go
@@ -34,6 +34,8 @@ type Config struct {
 		ClientID     string `yaml:"client_id" json:"clientId"`
 		ClientSecret string `yaml:"client_secret" json:"clientSecret"`
 	} `yaml:"oauth" json:"oauth"`
+
+	HideRootPath bool `yaml:"hide_root_path" json:"hideRootPath"`
 }
 
 // SetValuesFromEnv sets values in the configuration from coresponding
@@ -50,6 +52,9 @@ func (c *Config) SetValuesFromEnv(prefix string) {
 
 	setStringFromEnv("GITHUB_OAUTH_CLIENT_ID", prefix, &c.OAuth.ClientID)
 	setStringFromEnv("GITHUB_OAUTH_CLIENT_SECRET", prefix, &c.OAuth.ClientSecret)
+
+	setBoolFromEnv("POLICYBOT_HIDE_ROOT_PATH", prefix, &c.HideRootPath)
+
 }
 
 func setStringFromEnv(key, prefix string, value *string) {
@@ -63,5 +68,11 @@ func setIntFromEnv(key, prefix string, value *int64) {
 		if i, err := strconv.ParseInt(v, 10, 0); err == nil {
 			*value = i
 		}
+	}
+}
+
+func setBoolFromEnv(key, prefix string, value *bool) {
+	if _, ok := os.LookupEnv(prefix + key); ok {
+		*value = true
 	}
 }


### PR DESCRIPTION
This pull request introduces a new configuration option, `HideRootPath`, to the `Index` handler, allowing the application to conditionally hide the root path by returning a 404 response. The changes also ensure the `Config` field is properly initialized in relevant handlers.

This relates to https://github.com/palantir/policy-bot/issues/992

### New feature: Conditional hiding of the root path

* [`server/handler/index.go`](diffhunk://#diff-330d1db4aa30a4c9eb667b9b85f09adb5f10d2b15869ca1bb28d8fdcaddffb6aR31): Added a `Config` field to the `Index` struct to access configuration options.
* [`server/handler/index.go`](diffhunk://#diff-330d1db4aa30a4c9eb667b9b85f09adb5f10d2b15869ca1bb28d8fdcaddffb6aR42-R46): Updated the `ServeHTTP` method of the `Index` handler to check the `HideRootPath` configuration and return a 404 response if it is set to `true`.

### Initialization updates

* [`server/server.go`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R250): Ensured the `Config` field is initialized in the `Index` handler during server setup.