### PR TITLE
Add file filtering support to modified_lines predicate with include/exclude patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,22 @@ if:
   # "modified_lines" is satisfied if the number of lines added or deleted by
   # the pull request matches any of the listed conditions. Each expression is
   # an operator (one of '<', '>' or '='), an optional space, and a number.
+  # Optionally, use "files" to filter which files are counted:
+  # - If files is not specified, all files are counted
+  # - If only files.include is specified, only matching files are counted
+  # - If only files.exclude is specified, all files except those matching are counted
+  # - If both are specified, files must match an include pattern and NOT match any exclude pattern
   modified_lines:
     additions: "> 100"
     deletions: "> 100"
     total: "> 200"
+    files:
+      include:
+        - ".*\\.go$"
+        - ".*\\.js$"
+      exclude:
+        - ".*_test\\.go$"
+        - ".*\\.generated\\..*"
 
   # DEPRECATED: Use "has_status" below instead, which is more flexible.
   # "has_successful_status" is satisfied if the status checks that are specified

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -362,6 +362,12 @@ type ModifiedLines struct {
 	Additions ComparisonExpr `yaml:"additions,omitempty"`
 	Deletions ComparisonExpr `yaml:"deletions,omitempty"`
 	Total     ComparisonExpr `yaml:"total,omitempty"`
+	Files     *FilesConfig   `yaml:"files,omitempty"`
+}
+
+type FilesConfig struct {
+	Include []common.Regexp `yaml:"include,omitempty"`
+	Exclude []common.Regexp `yaml:"exclude,omitempty"`
 }
 
 type CompareOp uint8
@@ -469,8 +475,39 @@ func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (*c
 
 	var additions, deletions int64
 	for _, f := range files {
+		if pred.Files != nil {
+			if len(pred.Files.Exclude) > 0 && anyMatches(pred.Files.Exclude, f.Filename) {
+				continue
+			}
+			if len(pred.Files.Include) > 0 && !anyMatches(pred.Files.Include, f.Filename) {
+				continue
+			}
+		}
 		additions += int64(f.Additions)
 		deletions += int64(f.Deletions)
+	}
+
+	if pred.Files != nil {
+		if len(pred.Files.Include) > 0 || len(pred.Files.Exclude) > 0 {
+			predicateResult.ConditionsMap = make(map[string][]string)
+			if len(pred.Files.Include) > 0 {
+				predicateResult.ConditionsMap["included patterns"] = getPathStrings(pred.Files.Include)
+			}
+			if len(pred.Files.Exclude) > 0 {
+				predicateResult.ConditionsMap["excluded patterns"] = getPathStrings(pred.Files.Exclude)
+			}
+			if len(pred.Files.Include) > 0 && len(pred.Files.Exclude) > 0 {
+				predicateResult.ConditionPhrase = "meet the modification conditions for files matching include patterns but not exclude patterns"
+			} else if len(pred.Files.Include) > 0 {
+				if len(pred.Files.Include) == 1 {
+					predicateResult.ConditionPhrase = fmt.Sprintf("meet the modification conditions for files matching %s", getPathStrings(pred.Files.Include)[0])
+				} else {
+					predicateResult.ConditionPhrase = "meet the modification conditions for files matching the included patterns"
+				}
+			} else {
+				predicateResult.ConditionPhrase = "meet the modification conditions excluding specified patterns"
+			}
+		}
 	}
 
 	if !pred.Additions.IsEmpty() {

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -470,7 +470,8 @@ func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (*c
 
 	predicateResult := common.PredicateResult{
 		ValuePhrase:     "file modifications",
-		ConditionPhrase: "meet the modification conditions",
+		ConditionPhrase: "meet",
+		ConditionsMap:   make(map[string][]string),
 	}
 
 	if err != nil {
@@ -489,56 +490,60 @@ func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (*c
 		deletions += int64(f.Deletions)
 	}
 
-	if len(pred.Files.Include) > 0 || len(pred.Files.Exclude) > 0 {
-		predicateResult.ConditionsMap = make(map[string][]string)
-		if len(pred.Files.Include) > 0 {
-			predicateResult.ConditionsMap["included patterns"] = getPathStrings(pred.Files.Include)
-		}
-		if len(pred.Files.Exclude) > 0 {
-			predicateResult.ConditionsMap["excluded patterns"] = getPathStrings(pred.Files.Exclude)
-		}
-		if len(pred.Files.Include) > 0 && len(pred.Files.Exclude) > 0 {
-			predicateResult.ConditionPhrase = "meet the modification conditions for files matching include patterns but not exclude patterns"
-		} else if len(pred.Files.Include) > 0 {
-			if len(pred.Files.Include) == 1 {
-				predicateResult.ConditionPhrase = fmt.Sprintf("meet the modification conditions for files matching %s", getPathStrings(pred.Files.Include)[0])
-			} else {
-				predicateResult.ConditionPhrase = "meet the modification conditions for files matching the included patterns"
-			}
-		} else {
-			predicateResult.ConditionPhrase = "meet the modification conditions excluding specified patterns"
-		}
+	if len(pred.Files.Include) > 0 {
+		predicateResult.ConditionsMap["in files matching"] = getPathStrings(pred.Files.Include)
+	}
+	if len(pred.Files.Exclude) > 0 {
+		predicateResult.ConditionsMap["excluding files matching"] = getPathStrings(pred.Files.Exclude)
 	}
 
+	const conditionKey = "the modification conditions"
+
 	if !pred.Additions.IsEmpty() {
-		predicateResult.Values = []string{fmt.Sprintf("+%d", additions)}
-		predicateResult.ConditionValues = []string{fmt.Sprintf("added lines %s", pred.Additions.String())}
+		value := fmt.Sprintf("+%d", additions)
+		cond := fmt.Sprintf("added lines %s", pred.Additions.String())
+
 		if pred.Additions.Evaluate(additions) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
 			predicateResult.Satisfied = true
 			return &predicateResult, nil
 		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
 	}
+
 	if !pred.Deletions.IsEmpty() {
+		value := fmt.Sprintf("-%d", deletions)
+		cond := fmt.Sprintf("deleted lines %s", pred.Deletions.String())
+
 		if pred.Deletions.Evaluate(deletions) {
-			predicateResult.Values = []string{fmt.Sprintf("-%d", deletions)}
-			predicateResult.ConditionValues = []string{fmt.Sprintf("deleted lines %s", pred.Deletions.String())}
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
 			predicateResult.Satisfied = true
 			return &predicateResult, nil
 		}
-		predicateResult.Values = append(predicateResult.Values, fmt.Sprintf("-%d", deletions))
-		predicateResult.ConditionValues = append(predicateResult.ConditionValues, fmt.Sprintf("deleted lines %s", pred.Deletions.String()))
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
 	}
+
 	if !pred.Total.IsEmpty() {
+		value := fmt.Sprintf("total %d", additions+deletions)
+		cond := fmt.Sprintf("total modifications %s", pred.Total.String())
+
 		if pred.Total.Evaluate(additions + deletions) {
-			predicateResult.Values = []string{fmt.Sprintf("total %d", additions+deletions)}
-			predicateResult.ConditionValues = []string{fmt.Sprintf("total modifications %s", pred.Total.String())}
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
 			predicateResult.Satisfied = true
 			return &predicateResult, nil
 		}
-		predicateResult.Values = append(predicateResult.Values, fmt.Sprintf("total %d", additions+deletions))
-		predicateResult.ConditionValues = append(predicateResult.ConditionValues, fmt.Sprintf("total modifications %s", pred.Total.String()))
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
 	}
-	predicateResult.Satisfied = false
+
 	return &predicateResult, nil
 }
 

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -359,15 +359,19 @@ func (pred *FileNotDeleted) Trigger() common.Trigger {
 }
 
 type ModifiedLines struct {
-	Additions ComparisonExpr `yaml:"additions,omitempty"`
-	Deletions ComparisonExpr `yaml:"deletions,omitempty"`
-	Total     ComparisonExpr `yaml:"total,omitempty"`
-	Files     *FilesConfig   `yaml:"files,omitempty"`
+	Additions ComparisonExpr          `yaml:"additions,omitempty"`
+	Deletions ComparisonExpr          `yaml:"deletions,omitempty"`
+	Total     ComparisonExpr          `yaml:"total,omitempty"`
+	Files     ModifiedLinesFileFilter `yaml:"files,omitempty"`
 }
 
-type FilesConfig struct {
+type ModifiedLinesFileFilter struct {
 	Include []common.Regexp `yaml:"include,omitempty"`
 	Exclude []common.Regexp `yaml:"exclude,omitempty"`
+}
+
+func (ff ModifiedLinesFileFilter) IsZero() bool {
+	return len(ff.Include) == 0 && len(ff.Exclude) == 0
 }
 
 type CompareOp uint8
@@ -475,38 +479,34 @@ func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (*c
 
 	var additions, deletions int64
 	for _, f := range files {
-		if pred.Files != nil {
-			if len(pred.Files.Exclude) > 0 && anyMatches(pred.Files.Exclude, f.Filename) {
-				continue
-			}
-			if len(pred.Files.Include) > 0 && !anyMatches(pred.Files.Include, f.Filename) {
-				continue
-			}
+		if len(pred.Files.Exclude) > 0 && anyMatches(pred.Files.Exclude, f.Filename) {
+			continue
+		}
+		if len(pred.Files.Include) > 0 && !anyMatches(pred.Files.Include, f.Filename) {
+			continue
 		}
 		additions += int64(f.Additions)
 		deletions += int64(f.Deletions)
 	}
 
-	if pred.Files != nil {
-		if len(pred.Files.Include) > 0 || len(pred.Files.Exclude) > 0 {
-			predicateResult.ConditionsMap = make(map[string][]string)
-			if len(pred.Files.Include) > 0 {
-				predicateResult.ConditionsMap["included patterns"] = getPathStrings(pred.Files.Include)
-			}
-			if len(pred.Files.Exclude) > 0 {
-				predicateResult.ConditionsMap["excluded patterns"] = getPathStrings(pred.Files.Exclude)
-			}
-			if len(pred.Files.Include) > 0 && len(pred.Files.Exclude) > 0 {
-				predicateResult.ConditionPhrase = "meet the modification conditions for files matching include patterns but not exclude patterns"
-			} else if len(pred.Files.Include) > 0 {
-				if len(pred.Files.Include) == 1 {
-					predicateResult.ConditionPhrase = fmt.Sprintf("meet the modification conditions for files matching %s", getPathStrings(pred.Files.Include)[0])
-				} else {
-					predicateResult.ConditionPhrase = "meet the modification conditions for files matching the included patterns"
-				}
+	if len(pred.Files.Include) > 0 || len(pred.Files.Exclude) > 0 {
+		predicateResult.ConditionsMap = make(map[string][]string)
+		if len(pred.Files.Include) > 0 {
+			predicateResult.ConditionsMap["included patterns"] = getPathStrings(pred.Files.Include)
+		}
+		if len(pred.Files.Exclude) > 0 {
+			predicateResult.ConditionsMap["excluded patterns"] = getPathStrings(pred.Files.Exclude)
+		}
+		if len(pred.Files.Include) > 0 && len(pred.Files.Exclude) > 0 {
+			predicateResult.ConditionPhrase = "meet the modification conditions for files matching include patterns but not exclude patterns"
+		} else if len(pred.Files.Include) > 0 {
+			if len(pred.Files.Include) == 1 {
+				predicateResult.ConditionPhrase = fmt.Sprintf("meet the modification conditions for files matching %s", getPathStrings(pred.Files.Include)[0])
 			} else {
-				predicateResult.ConditionPhrase = "meet the modification conditions excluding specified patterns"
+				predicateResult.ConditionPhrase = "meet the modification conditions for files matching the included patterns"
 			}
+		} else {
+			predicateResult.ConditionPhrase = "meet the modification conditions excluding specified patterns"
 		}
 	}
 

--- a/policy/predicate/file.go
+++ b/policy/predicate/file.go
@@ -374,6 +374,16 @@ func (ff ModifiedLinesFileFilter) IsZero() bool {
 	return len(ff.Include) == 0 && len(ff.Exclude) == 0
 }
 
+func (ff ModifiedLinesFileFilter) MatchesFile(filename string) bool {
+	if len(ff.Exclude) > 0 && anyMatches(ff.Exclude, filename) {
+		return false
+	}
+	if len(ff.Include) > 0 && !anyMatches(ff.Include, filename) {
+		return false
+	}
+	return true
+}
+
 type CompareOp uint8
 
 const (
@@ -480,10 +490,7 @@ func (pred *ModifiedLines) Evaluate(ctx context.Context, prctx pull.Context) (*c
 
 	var additions, deletions int64
 	for _, f := range files {
-		if len(pred.Files.Exclude) > 0 && anyMatches(pred.Files.Exclude, f.Filename) {
-			continue
-		}
-		if len(pred.Files.Include) > 0 && !anyMatches(pred.Files.Include, f.Filename) {
+		if !pred.Files.MatchesFile(f.Filename) {
 			continue
 		}
 		additions += int64(f.Additions)

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -827,7 +827,7 @@ func TestModifiedLinesFiles(t *testing.T) {
 	// Test with include patterns only
 	p := &ModifiedLines{
 		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 50},
-		Files: &FilesConfig{
+		Files: ModifiedLinesFileFilter{
 			Include: []common.Regexp{
 				common.NewCompiledRegexp(regexp.MustCompile(`.*\.go`)),
 				common.NewCompiledRegexp(regexp.MustCompile(`.*\.js`)),
@@ -888,7 +888,7 @@ func TestModifiedLinesFiles(t *testing.T) {
 	// Test with total modifications and include patterns
 	p = &ModifiedLines{
 		Total: ComparisonExpr{Op: OpGreaterThan, Value: 75},
-		Files: &FilesConfig{
+		Files: ModifiedLinesFileFilter{
 			Include: []common.Regexp{
 				common.NewCompiledRegexp(regexp.MustCompile(`src/.*\.ts`)),
 			},
@@ -917,7 +917,7 @@ func TestModifiedLinesFiles(t *testing.T) {
 	// Test with exclude patterns only
 	p = &ModifiedLines{
 		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 50},
-		Files: &FilesConfig{
+		Files: ModifiedLinesFileFilter{
 			Exclude: []common.Regexp{
 				common.NewCompiledRegexp(regexp.MustCompile(`.*\.md`)),
 				common.NewCompiledRegexp(regexp.MustCompile(`.*\.txt`)),
@@ -948,7 +948,7 @@ func TestModifiedLinesFiles(t *testing.T) {
 	// Test with both include and exclude patterns (exclude takes precedence)
 	p = &ModifiedLines{
 		Total: ComparisonExpr{Op: OpGreaterThan, Value: 50},
-		Files: &FilesConfig{
+		Files: ModifiedLinesFileFilter{
 			Include: []common.Regexp{
 				common.NewCompiledRegexp(regexp.MustCompile(`src/.*`)),
 			},

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -863,8 +863,8 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: true,
 				Values:    []string{"+55"},
 				ConditionsMap: map[string][]string{
-					"in files matching":           {`.*\.go`, `.*\.js`},
 					"the modification conditions": {"added lines > 50"},
+					"in files matching":           {`.*\.go`, `.*\.js`},
 				},
 			},
 		},
@@ -879,8 +879,8 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: false,
 				Values:    []string{"+35"},
 				ConditionsMap: map[string][]string{
-					"in files matching":           {`.*\.go`, `.*\.js`},
 					"the modification conditions": {"added lines > 50"},
+					"in files matching":           {`.*\.go`, `.*\.js`},
 				},
 			},
 		},
@@ -894,8 +894,8 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: false,
 				Values:    []string{"+0"},
 				ConditionsMap: map[string][]string{
-					"in files matching":           {`.*\.go`, `.*\.js`},
 					"the modification conditions": {"added lines > 50"},
+					"in files matching":           {`.*\.go`, `.*\.js`},
 				},
 			},
 		},
@@ -923,8 +923,8 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: true,
 				Values:    []string{"total 80"},
 				ConditionsMap: map[string][]string{
-					"in files matching":           {`src/.*\.ts`},
 					"the modification conditions": {"total modifications > 75"},
+					"in files matching":           {`src/.*\.ts`},
 				},
 			},
 		},
@@ -954,8 +954,8 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: true,
 				Values:    []string{"+55"},
 				ConditionsMap: map[string][]string{
-					"excluding files matching":    {`.*\.md`, `.*\.txt`},
 					"the modification conditions": {"added lines > 50"},
+					"excluding files matching":    {`.*\.md`, `.*\.txt`},
 				},
 			},
 		},
@@ -989,9 +989,9 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: true,
 				Values:    []string{"total 70"},
 				ConditionsMap: map[string][]string{
+					"the modification conditions": {"total modifications > 50"},
 					"in files matching":           {`src/.*`},
 					"excluding files matching":    {`.*\.test\..*`, `.*_test\..*`},
-					"the modification conditions": {"total modifications > 50"},
 				},
 			},
 		},
@@ -1005,9 +1005,9 @@ func TestModifiedLinesFiles(t *testing.T) {
 				Satisfied: false,
 				Values:    []string{"total 0"},
 				ConditionsMap: map[string][]string{
+					"the modification conditions": {"total modifications > 50"},
 					"in files matching":           {`src/.*`},
 					"excluding files matching":    {`.*\.test\..*`, `.*_test\..*`},
-					"the modification conditions": {"total modifications > 50"},
 				},
 			},
 		},

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -823,6 +823,202 @@ func TestModifiedLines(t *testing.T) {
 
 }
 
+func TestModifiedLinesFiles(t *testing.T) {
+	// Test with include patterns only
+	p := &ModifiedLines{
+		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 50},
+		Files: &FilesConfig{
+			Include: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(`.*\.go`)),
+				common.NewCompiledRegexp(regexp.MustCompile(`.*\.js`)),
+			},
+		},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"filtered files meet criteria",
+			[]*pull.File{
+				{Filename: "app.go", Additions: 30},
+				{Filename: "server.go", Additions: 25},
+				{Filename: "readme.md", Additions: 100}, // Should be ignored
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"+55"},
+				ConditionValues: []string{"added lines > 50"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`.*\.go`, `.*\.js`},
+				},
+			},
+		},
+		{
+			"filtered files don't meet criteria",
+			[]*pull.File{
+				{Filename: "app.go", Additions: 20},
+				{Filename: "server.go", Additions: 15},
+				{Filename: "readme.md", Additions: 100}, // Should be ignored
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"+35"},
+				ConditionValues: []string{"added lines > 50"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`.*\.go`, `.*\.js`},
+				},
+			},
+		},
+		{
+			"no matching files",
+			[]*pull.File{
+				{Filename: "readme.md", Additions: 100},
+				{Filename: "config.xml", Additions: 50},
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"+0"},
+				ConditionValues: []string{"added lines > 50"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`.*\.go`, `.*\.js`},
+				},
+			},
+		},
+	})
+
+	// Test with total modifications and include patterns
+	p = &ModifiedLines{
+		Total: ComparisonExpr{Op: OpGreaterThan, Value: 75},
+		Files: &FilesConfig{
+			Include: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(`src/.*\.ts`)),
+			},
+		},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"typescript files with total modifications",
+			[]*pull.File{
+				{Filename: "src/app.ts", Additions: 30, Deletions: 20},
+				{Filename: "src/utils.ts", Additions: 15, Deletions: 15},
+				{Filename: "docs/readme.md", Additions: 100, Deletions: 50}, // Should be ignored
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"total 80"},
+				ConditionValues: []string{"total modifications > 75"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`src/.*\.ts`},
+				},
+			},
+		},
+	})
+
+	// Test with exclude patterns only
+	p = &ModifiedLines{
+		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 50},
+		Files: &FilesConfig{
+			Exclude: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(`.*\.md`)),
+				common.NewCompiledRegexp(regexp.MustCompile(`.*\.txt`)),
+			},
+		},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"exclude patterns filter out unwanted files",
+			[]*pull.File{
+				{Filename: "app.go", Additions: 30},
+				{Filename: "server.go", Additions: 25},
+				{Filename: "readme.md", Additions: 100}, // Should be excluded
+				{Filename: "notes.txt", Additions: 50},  // Should be excluded
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"+55"},
+				ConditionValues: []string{"added lines > 50"},
+				ConditionsMap: map[string][]string{
+					"excluded patterns": {`.*\.md`, `.*\.txt`},
+				},
+			},
+		},
+	})
+
+	// Test with both include and exclude patterns (exclude takes precedence)
+	p = &ModifiedLines{
+		Total: ComparisonExpr{Op: OpGreaterThan, Value: 50},
+		Files: &FilesConfig{
+			Include: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(`src/.*`)),
+			},
+			Exclude: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(`.*\.test\..*`)),
+				common.NewCompiledRegexp(regexp.MustCompile(`.*_test\..*`)),
+			},
+		},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"include and exclude patterns work together",
+			[]*pull.File{
+				{Filename: "src/app.go", Additions: 30, Deletions: 10},
+				{Filename: "src/app.test.go", Additions: 20, Deletions: 5},   // Should be excluded
+				{Filename: "src/utils_test.go", Additions: 15, Deletions: 5}, // Should be excluded
+				{Filename: "src/server.go", Additions: 25, Deletions: 5},
+				{Filename: "docs/readme.md", Additions: 100, Deletions: 50}, // Not in src/, should be excluded
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"total 70"},
+				ConditionValues: []string{"total modifications > 50"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`src/.*`},
+					"excluded patterns": {`.*\.test\..*`, `.*_test\..*`},
+				},
+			},
+		},
+		{
+			"conflicting patterns - exclude takes precedence",
+			[]*pull.File{
+				{Filename: "src/app.test.go", Additions: 100, Deletions: 50},  // Matches include but also exclude
+				{Filename: "src/utils_test.go", Additions: 75, Deletions: 25}, // Matches include but also exclude
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"total 0"},
+				ConditionValues: []string{"total modifications > 50"},
+				ConditionsMap: map[string][]string{
+					"included patterns": {`src/.*`},
+					"excluded patterns": {`.*\.test\..*`, `.*_test\..*`},
+				},
+			},
+		},
+	})
+
+	// Test with no Files config (all files should be counted)
+	p = &ModifiedLines{
+		Additions: ComparisonExpr{Op: OpGreaterThan, Value: 100},
+	}
+
+	runFileTests(t, p, []FileTestCase{
+		{
+			"no file config counts all files",
+			[]*pull.File{
+				{Filename: "app.go", Additions: 30},
+				{Filename: "readme.md", Additions: 50},
+				{Filename: "test.txt", Additions: 25},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"+105"},
+				ConditionValues: []string{"added lines > 100"},
+			},
+		},
+	})
+}
+
 func TestComparisonExpr(t *testing.T) {
 	tests := map[string]struct {
 		Expr   ComparisonExpr

--- a/policy/predicate/file_test.go
+++ b/policy/predicate/file_test.go
@@ -703,9 +703,11 @@ func TestModifiedLines(t *testing.T) {
 			"empty",
 			[]*pull.File{},
 			&common.PredicateResult{
-				Satisfied:       false,
-				Values:          []string{"+0", "-0"},
-				ConditionValues: []string{"added lines > 100", "deleted lines > 10"},
+				Satisfied: false,
+				Values:    []string{"+0", "-0"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"added lines > 100", "deleted lines > 10"},
+				},
 			},
 		},
 		{
@@ -716,9 +718,11 @@ func TestModifiedLines(t *testing.T) {
 				{Additions: 45},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"+110"},
-				ConditionValues: []string{"added lines > 100"},
+				Satisfied: true,
+				Values:    []string{"+110"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"added lines > 100"},
+				},
 			},
 		},
 		{
@@ -730,9 +734,11 @@ func TestModifiedLines(t *testing.T) {
 				{Deletions: 10},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"-20"},
-				ConditionValues: []string{"deleted lines > 10"},
+				Satisfied: true,
+				Values:    []string{"-20"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"deleted lines > 10"},
+				},
 			},
 		},
 	})
@@ -751,9 +757,11 @@ func TestModifiedLines(t *testing.T) {
 				{Additions: 20, Deletions: 20},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"total 120"},
-				ConditionValues: []string{"total modifications > 100"},
+				Satisfied: true,
+				Values:    []string{"total 120"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"total modifications > 100"},
+				},
 			},
 		},
 	})
@@ -771,9 +779,11 @@ func TestModifiedLines(t *testing.T) {
 				{Additions: 20, Deletions: 20},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"total 100"},
-				ConditionValues: []string{"total modifications = 100"},
+				Satisfied: true,
+				Values:    []string{"total 100"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"total modifications = 100"},
+				},
 			},
 		},
 	})
@@ -788,9 +798,11 @@ func TestModifiedLines(t *testing.T) {
 			"empty",
 			[]*pull.File{},
 			&common.PredicateResult{
-				Satisfied:       false,
-				Values:          []string{"+0", "-0"},
-				ConditionValues: []string{"added lines = 100", "deleted lines = 25"},
+				Satisfied: false,
+				Values:    []string{"+0", "-0"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"added lines = 100", "deleted lines = 25"},
+				},
 			},
 		},
 		{
@@ -800,9 +812,11 @@ func TestModifiedLines(t *testing.T) {
 				{Additions: 45},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"+100"},
-				ConditionValues: []string{"added lines = 100"},
+				Satisfied: true,
+				Values:    []string{"+100"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"added lines = 100"},
+				},
 			},
 		},
 		{
@@ -814,9 +828,11 @@ func TestModifiedLines(t *testing.T) {
 				{Deletions: 10},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"-25"},
-				ConditionValues: []string{"deleted lines = 25"},
+				Satisfied: true,
+				Values:    []string{"-25"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"deleted lines = 25"},
+				},
 			},
 		},
 	})
@@ -844,11 +860,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "readme.md", Additions: 100}, // Should be ignored
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"+55"},
-				ConditionValues: []string{"added lines > 50"},
+				Satisfied: true,
+				Values:    []string{"+55"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`.*\.go`, `.*\.js`},
+					"in files matching":           {`.*\.go`, `.*\.js`},
+					"the modification conditions": {"added lines > 50"},
 				},
 			},
 		},
@@ -860,11 +876,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "readme.md", Additions: 100}, // Should be ignored
 			},
 			&common.PredicateResult{
-				Satisfied:       false,
-				Values:          []string{"+35"},
-				ConditionValues: []string{"added lines > 50"},
+				Satisfied: false,
+				Values:    []string{"+35"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`.*\.go`, `.*\.js`},
+					"in files matching":           {`.*\.go`, `.*\.js`},
+					"the modification conditions": {"added lines > 50"},
 				},
 			},
 		},
@@ -875,11 +891,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "config.xml", Additions: 50},
 			},
 			&common.PredicateResult{
-				Satisfied:       false,
-				Values:          []string{"+0"},
-				ConditionValues: []string{"added lines > 50"},
+				Satisfied: false,
+				Values:    []string{"+0"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`.*\.go`, `.*\.js`},
+					"in files matching":           {`.*\.go`, `.*\.js`},
+					"the modification conditions": {"added lines > 50"},
 				},
 			},
 		},
@@ -904,11 +920,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "docs/readme.md", Additions: 100, Deletions: 50}, // Should be ignored
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"total 80"},
-				ConditionValues: []string{"total modifications > 75"},
+				Satisfied: true,
+				Values:    []string{"total 80"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`src/.*\.ts`},
+					"in files matching":           {`src/.*\.ts`},
+					"the modification conditions": {"total modifications > 75"},
 				},
 			},
 		},
@@ -935,11 +951,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "notes.txt", Additions: 50},  // Should be excluded
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"+55"},
-				ConditionValues: []string{"added lines > 50"},
+				Satisfied: true,
+				Values:    []string{"+55"},
 				ConditionsMap: map[string][]string{
-					"excluded patterns": {`.*\.md`, `.*\.txt`},
+					"excluding files matching":    {`.*\.md`, `.*\.txt`},
+					"the modification conditions": {"added lines > 50"},
 				},
 			},
 		},
@@ -970,12 +986,12 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "docs/readme.md", Additions: 100, Deletions: 50}, // Not in src/, should be excluded
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"total 70"},
-				ConditionValues: []string{"total modifications > 50"},
+				Satisfied: true,
+				Values:    []string{"total 70"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`src/.*`},
-					"excluded patterns": {`.*\.test\..*`, `.*_test\..*`},
+					"in files matching":           {`src/.*`},
+					"excluding files matching":    {`.*\.test\..*`, `.*_test\..*`},
+					"the modification conditions": {"total modifications > 50"},
 				},
 			},
 		},
@@ -986,12 +1002,12 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "src/utils_test.go", Additions: 75, Deletions: 25}, // Matches include but also exclude
 			},
 			&common.PredicateResult{
-				Satisfied:       false,
-				Values:          []string{"total 0"},
-				ConditionValues: []string{"total modifications > 50"},
+				Satisfied: false,
+				Values:    []string{"total 0"},
 				ConditionsMap: map[string][]string{
-					"included patterns": {`src/.*`},
-					"excluded patterns": {`.*\.test\..*`, `.*_test\..*`},
+					"in files matching":           {`src/.*`},
+					"excluding files matching":    {`.*\.test\..*`, `.*_test\..*`},
+					"the modification conditions": {"total modifications > 50"},
 				},
 			},
 		},
@@ -1011,9 +1027,11 @@ func TestModifiedLinesFiles(t *testing.T) {
 				{Filename: "test.txt", Additions: 25},
 			},
 			&common.PredicateResult{
-				Satisfied:       true,
-				Values:          []string{"+105"},
-				ConditionValues: []string{"added lines > 100"},
+				Satisfied: true,
+				Values:    []string{"+105"},
+				ConditionsMap: map[string][]string{
+					"the modification conditions": {"added lines > 100"},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
- Support three filtering modes:
  - No files config: count all files
  - Only exclude: count all files except excluded ones
  - Include (with optional exclude): count only included files, minus excluded ones
- Updated README with explanation of rules

This enables policies like:

```yaml
modified_lines:
  additions: "> 100"
  files:
    include:
      - ".*\\.go$"
      - ".*\\.js$"
    exclude:
      - ".*_test\\.go$"
      - ".*\\.generated\\..*"
```

🤖 Generated with Claude Code (https://claude.ai/code)