### PR TITLE
Add dependabot labels, disable Go updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,12 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gomod
-    directory: /
+    labels: ["no changelog", "merge when ready", "dependencies", "github_actions"]
     schedule:
       interval: weekly
 
   - package-ecosystem: npm
     directory: /
+    labels: ["no changelog", "merge when ready", "dependencies", "javascript"]
     schedule:
       interval: monthly


### PR DESCRIPTION
Add standard labels to Dependabot PRs to disable changelogs and to merge the PRs automatically once they are approved. Also remove Go dependency updates, since these are all handled by Excavator, usually before Dependabot can get to it.

