### PR TITLE
Fix evaluation triggers for comment-only reviews

### DIFF
--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -71,8 +71,7 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 		return nil
 	}
 
-	reviewState := pull.ReviewState(event.GetReview().GetState())
-	if !h.affectsApproval(reviewState, evalCtx.Config.Config) {
+	if !h.affectsApproval(event.GetReview(), evalCtx.Config.Config) {
 		logger.Debug().Msg("Skipping evaluation because this review does not impact approval")
 		return nil
 	}
@@ -86,24 +85,43 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 	return nil
 }
 
-func (h *PullRequestReview) affectsApproval(reviewState pull.ReviewState, config *policy.Config) bool {
-	states := make(map[pull.ReviewState]struct{})
+func (h *PullRequestReview) affectsApproval(review *github.PullRequestReview, config *policy.Config) bool {
+	// States contains the review states that may affect approval. Always consider dismissed
+	// reviews because they can revert the overall approval or disapproval to a previous state.
+	states := map[pull.ReviewState]bool{
+		pull.ReviewDismissed: true,
+	}
 
-	// Always process events for dismissed reviews because they can revert the overall approval or disapproval to a previous state
-	states[pull.ReviewDismissed] = struct{}{}
-
+	var methods []*common.Methods
 	for _, rule := range config.ApprovalRules {
-		states[rule.Options.GetMethods().GithubReviewState] = struct{}{}
+		m := rule.Options.GetMethods()
+		states[m.GithubReviewState] = true
+		methods = append(methods, m)
 	}
 	if disapproval := config.Policy.Disapproval; disapproval != nil {
-		states[disapproval.Options.GetDisapproveMethods().GithubReviewState] = struct{}{}
-		states[disapproval.Options.GetRevokeMethods().GithubReviewState] = struct{}{}
+		md := disapproval.Options.GetDisapproveMethods()
+		states[md.GithubReviewState] = true
+		methods = append(methods, md)
+
+		mr := disapproval.Options.GetRevokeMethods()
+		states[mr.GithubReviewState] = true
+		methods = append(methods, mr)
 	}
 
-	for state := range states {
-		if state == reviewState {
-			return true
+	reviewState := pull.ReviewState(review.GetState())
+	if states[reviewState] {
+		return true
+	}
+
+	// Reviews with the COMMENTED state are also processed as normal comments, so also consider
+	// methods that match on comments in this case.
+	if reviewState == pull.ReviewCommented {
+		for _, m := range methods {
+			if m.CommentMatches(review.GetBody()) {
+				return true
+			}
 		}
 	}
+
 	return false
 }


### PR DESCRIPTION
GitHub reviews that use the "COMMENTED" state are processed both as reviews and as regular comments. However, the handler for review events ignored this and only considered the review state when determining if the event affected approval. With certain policies, this meant that PRs would only be approved after some other event triggered an evaluation.

Copy the relevant part of the logic from the issue comment handler in to the review handler so that we can match comment-only reviews against the normal comment patterns. Also clean up the handler to avoid an unnecessary loop where a map lookup is sufficient.

Fixes #1007

