### PR TITLE
Fix GraphQL RESOURCE_LIMITS_EXCEEDED errors due to GitHub API limits #1086

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -41,8 +41,8 @@ products:
             cp -R docker/* ${CONTEXT_DIR}
             cp -R config ${CONTEXT_DIR}
           tag-templates:
-            version: "{{Repository}}palantirtechnologies/policy-bot:{{Version}}"
-            latest: "{{Repository}}palantirtechnologies/policy-bot:latest"
-            snapshot: "{{Repository}}palantirtechnologies/policy-bot:snapshot"
+            version: "{{Repository}}/tooling/policy-bot:{{Version}}"
+            latest: "{{Repository}}/tooling/policy-bot:latest"
+            snapshot: "{{Repository}}/tooling/policy-bot:snapshot-001"
     publish:
       group-id: com.palantir.policy-bot

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -43,6 +43,6 @@ products:
           tag-templates:
             version: "{{Repository}}tooling/policy-bot:{{Version}}"
             latest: "{{Repository}}tooling/policy-bot:latest"
-            snapshot: "{{Repository}}tooling/policy-bot:snapshot-001"
+            snapshot: "crinternal01.azurecr.io/tooling/policy-bot:snapshot-001"
     publish:
       group-id: com.palantir.policy-bot

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -43,6 +43,6 @@ products:
           tag-templates:
             version: "{{Repository}}tooling/policy-bot:{{Version}}"
             latest: "{{Repository}}tooling/policy-bot:latest"
-            snapshot: "crinternal01.azurecr.io/it/policy-bot:snapshot-001"
+            snapshot: "crinternal01.azurecr.io/tooling/policy-bot:snapshot-001"
     publish:
       group-id: com.palantir.policy-bot

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -43,6 +43,6 @@ products:
           tag-templates:
             version: "{{Repository}}tooling/policy-bot:{{Version}}"
             latest: "{{Repository}}tooling/policy-bot:latest"
-            snapshot: "crinternal01.azurecr.io/tooling/policy-bot:snapshot-001"
+            snapshot: "crinternal01.azurecr.io/it/policy-bot:snapshot-001"
     publish:
       group-id: com.palantir.policy-bot

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -41,8 +41,8 @@ products:
             cp -R docker/* ${CONTEXT_DIR}
             cp -R config ${CONTEXT_DIR}
           tag-templates:
-            version: "{{Repository}}/tooling/policy-bot:{{Version}}"
-            latest: "{{Repository}}/tooling/policy-bot:latest"
-            snapshot: "{{Repository}}/tooling/policy-bot:snapshot-001"
+            version: "{{Repository}}tooling/policy-bot:{{Version}}"
+            latest: "{{Repository}}tooling/policy-bot:latest"
+            snapshot: "{{Repository}}tooling/policy-bot:snapshot-001"
     publish:
       group-id: com.palantir.policy-bot

--- a/pull/github.go
+++ b/pull/github.go
@@ -490,14 +490,14 @@ func (ghc *GitHubContext) RepositoryCollaborators() ([]*Collaborator, error) {
 						Permission string
 					}
 					Nodes []v4Actor
-				} `graphql:"direct: collaborators(affiliation: DIRECT, first: 100, after: $directCursor)"`
+				} `graphql:"direct: collaborators(affiliation: DIRECT, first: 50, after: $directCursor)"`
 				AllCollaborators struct {
 					PageInfo v4PageInfo
 					Edges    []struct {
 						Permission string
 					}
 					Nodes []v4Actor
-				} `graphql:"all: collaborators(affiliation: ALL, first: 100, after: $allCursor)"`
+				} `graphql:"all: collaborators(affiliation: ALL, first: 50, after: $allCursor)"`
 			} `graphql:"repository(owner: $owner, name: $name)"`
 		}
 		qvars := map[string]interface{}{


### PR DESCRIPTION
## Before this PR
Over the past few days, we’ve encountered an issue with the policy-bot where reviewers are not being automatically assigned to pull requests (PRs) when they are created or opened for review.
Because of the following error: `failed to select reviewers: failed to list repository collaborators: failed to load repository collaborators: Resource limits for this query exceeded`

## After this PR
That people are automatically assigned by policy-bot when PRs are created

## More context
See for more information #1086 

## Possible downsides?
Possibility that GraphQL request limit is reached because the amount of calls can possibly double based on the amount of collaborators in an environment. Brought up by @bluekeyes in context of https://github.com/palantir/policy-bot/discussions/1030

