### PR TITLE
fix: add env config for force shared policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ curl: (22) The requested URL returned error: 422
 
 It can be useful to simulate how Policy Bot would evaluate a pull request if certain conditions were changed. For example: adding a review from a specific user or group, or adjusting the base branch.
 
-An API endpoint exists at `api/simulate/:org/:repo/:prNumber` to simiulate the result of a pull request. Simulations using this endpoint will NOT write the result back to the pull request status check and will instead return the result.
+An API endpoint exists at `api/simulate/:org/:repo/:prNumber` to simulate the result of a pull request. Simulations using this endpoint will NOT write the result back to the pull request status check and will instead return the result.
 
 This API requires a GitHub token be passed as a bearer token. The token must have the ability to read the pull request the simulation is being run against.
 
@@ -831,7 +831,7 @@ use a previous, non-dismissed review, if it exists, when evaluating rules.
 
 For example, if a user leaves an "approval" review and follows up with a
 "request changes" review, `policy-bot` will use the "request changes" review
-when evaluating rules. However, if the user then dimisses their "request
+when evaluating rules. However, if the user then dismisses their "request
 changes" review, `policy-bot` will instead use the initial "approval" review in
 evaluating any rules.
 
@@ -926,7 +926,7 @@ from the set.
 
 #### Invalidating Approval on Push <!-- omit in toc -->
 
-By default, `policy-bot` does not invalidate exisitng approvals when users add
+By default, `policy-bot` does not invalidate existing approvals when users add
 new commits to a pull request. You can control this behavior for each rule in a
 policy using the `invalidate_on_push` option.
 
@@ -955,7 +955,7 @@ in mid-2023 because computing it was unreliable and inaccurate (see issue
 #### Expanding Required Reviewers <!-- omit in toc -->
 
 The details view for a pull request shows the users, organizations, teams, and
-permission levels that are reqired to approve each rule. When the
+permission levels that are required to approve each rule. When the
 `options.expand_required_reviewers` server option is set, `policy-bot` expands
 these to show the list of users whose approval will satisfy each rule. This can
 make it easier for developers to figure out who they should ask for approval.

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -127,6 +127,12 @@ sessions:
 #   # Can also be set by the POLICYBOT_OPTIONS_EXPAND_REQUIRED_REVIEWERS
 #   # environment variable.
 #   expand_required_reviewers: false
+#
+#   # If true, forces the use of the shared repository policy for all repositories,
+#   # even if they define their own local policy file.
+#   # Can also be set by the POLICYBOT_OPTIONS_FORCE_SHARED_POLICY
+#   # environment variable.
+#   force_shared_policy: false
 
 # Options for locating the frontend files. By default, the server uses appropriate
 # paths for the binary distribution and Docker container. For local development,

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -103,6 +103,7 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setStringPtrFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
 	setStringPtrFromEnv("SHARED_POLICY_PATH", prefix, &p.SharedPolicyPath)
 	setStringFromEnv("STATUS_CHECK_CONTEXT", prefix, &p.StatusCheckContext)
+	setBoolFromEnv("FORCE_SHARED_POLICY", prefix, &p.ForceSharedPolicy)
 	setBoolFromEnv("EXPAND_REQUIRED_REVIEWERS", prefix, &p.ExpandRequiredReviewers)
 	setBoolFromEnv("STRICT_REVIEW_DISMISSAL", prefix, &p.StrictReviewDismissal)
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

The `ForceSharedPolicy` configuration option (introduced in #975) does not configured itself via environment variables like other configuration options. This PR brings that config value in-line with other config values in the bot.

I also fixed spelling mistakes in the README.md at the root of the repo.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `POLICYBOT_OPTIONS_FORCE_SHARED_POLICY` environment variable to configure the force shared policy option
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

None expected, the default value for the boolean will continue to be `false` as it is today.

