### PR TITLE
Use pointers for all rule options fields

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -36,47 +36,6 @@ type Rule struct {
 	Requires    Requires             `yaml:"requires,omitempty"`
 }
 
-type Options struct {
-	AllowAuthor               bool `yaml:"allow_author,omitempty"`
-	AllowContributor          bool `yaml:"allow_contributor,omitempty"`
-	AllowNonAuthorContributor bool `yaml:"allow_non_author_contributor,omitempty"`
-	InvalidateOnPush          bool `yaml:"invalidate_on_push,omitempty"`
-
-	IgnoreEditedComments bool          `yaml:"ignore_edited_comments,omitempty"`
-	IgnoreUpdateMerges   bool          `yaml:"ignore_update_merges,omitempty"`
-	IgnoreCommitsBy      common.Actors `yaml:"ignore_commits_by,omitempty"`
-
-	RequestReview RequestReview `yaml:"request_review,omitempty"`
-
-	Methods *common.Methods `yaml:"methods,omitempty"`
-}
-
-type RequestReview struct {
-	Enabled bool               `yaml:"enabled,omitempty"`
-	Mode    common.RequestMode `yaml:"mode,omitempty"`
-	Count   int                `yaml:"count,omitempty"`
-}
-
-func (opts *Options) GetMethods() *common.Methods {
-	methods := opts.Methods
-	if methods == nil {
-		methods = &common.Methods{}
-	}
-	if methods.Comments == nil {
-		methods.Comments = []string{
-			":+1:",
-			"👍",
-		}
-	}
-	if methods.GithubReview == nil {
-		defaultGithubReview := true
-		methods.GithubReview = &defaultGithubReview
-	}
-
-	methods.GithubReviewState = pull.ReviewApproved
-	return methods
-}
-
 type Requires struct {
 	Count      int                  `yaml:"count,omitempty"`
 	Actors     common.Actors        `yaml:",inline"`
@@ -168,16 +127,17 @@ func (r *Rule) Evaluate(ctx context.Context, prctx pull.Context) (res common.Res
 }
 
 func (r *Rule) getReviewRequestRule() *common.ReviewRequestRule {
-	if !r.Options.RequestReview.Enabled {
+	rr := r.Options.GetRequestReview()
+	if !rr.Enabled {
 		return nil
 	}
 
-	mode := r.Options.RequestReview.Mode
+	mode := rr.Mode
 	if mode == "" {
 		mode = common.RequestModeRandomUsers
 	}
 
-	requestedCount := r.Options.RequestReview.Count
+	requestedCount := rr.Count
 	if requestedCount == 0 {
 		requestedCount = r.Requires.Count
 	}
@@ -230,12 +190,12 @@ func (r *Rule) isApprovedByActors(ctx context.Context, prctx pull.Context, candi
 	// if contributors are allowed, the author counts as a contributor
 	author := prctx.Author()
 
-	if !r.Options.AllowAuthor && !r.Options.AllowContributor {
+	if !r.Options.IsAllowAuthor() && !r.Options.IsAllowContributor() {
 		banned[author] = true
 	}
 
 	// "contributor" is any user who added a commit to the PR
-	if !r.Options.AllowContributor && !r.Options.AllowNonAuthorContributor {
+	if !r.Options.IsAllowContributor() && !r.Options.IsAllowNonAuthorContributor() {
 		commits, err := r.filteredCommits(ctx, prctx)
 		if err != nil {
 			return false, nil, err
@@ -316,7 +276,7 @@ func (r *Rule) FilteredCandidates(ctx context.Context, prctx pull.Context) ([]*c
 	sort.Stable(common.CandidatesByCreationTime(candidates))
 
 	var editDismissals []*common.Dismissal
-	if r.Options.IgnoreEditedComments {
+	if r.Options.IsIgnoreEditedComments() {
 		candidates, editDismissals, err = r.filterEditedCandidates(ctx, prctx, candidates)
 		if err != nil {
 			return nil, nil, err
@@ -324,7 +284,7 @@ func (r *Rule) FilteredCandidates(ctx context.Context, prctx pull.Context) ([]*c
 	}
 
 	var pushDismissals []*common.Dismissal
-	if r.Options.InvalidateOnPush {
+	if r.Options.IsInvalidateOnPush() {
 		candidates, pushDismissals, err = r.filterInvalidCandidates(ctx, prctx, candidates)
 		if err != nil {
 			return nil, nil, err
@@ -341,7 +301,7 @@ func (r *Rule) FilteredCandidates(ctx context.Context, prctx pull.Context) ([]*c
 func (r *Rule) filterEditedCandidates(ctx context.Context, prctx pull.Context, candidates []*common.Candidate) ([]*common.Candidate, []*common.Dismissal, error) {
 	log := zerolog.Ctx(ctx)
 
-	if !r.Options.IgnoreEditedComments {
+	if !r.Options.IsIgnoreEditedComments() {
 		return candidates, nil, nil
 	}
 
@@ -410,8 +370,9 @@ func (r *Rule) filteredCommits(ctx context.Context, prctx pull.Context) ([]*pull
 	}
 	commits = sortCommits(commits, prctx.HeadSHA())
 
-	ignoreUpdates := r.Options.IgnoreUpdateMerges
-	ignoreCommits := !r.Options.IgnoreCommitsBy.IsZero()
+	ignoreUpdates := r.Options.IsIgnoreUpdateMerges()
+	ignoreCommitsBy := r.Options.GetIgnoreCommitsBy()
+	ignoreCommits := !ignoreCommitsBy.IsZero()
 
 	if !ignoreUpdates && !ignoreCommits {
 		return commits, nil
@@ -426,7 +387,7 @@ func (r *Rule) filteredCommits(ctx context.Context, prctx pull.Context) ([]*pull
 		}
 
 		if ignoreCommits {
-			ignore, err := isIgnoredCommit(ctx, prctx, &r.Options.IgnoreCommitsBy, c)
+			ignore, err := isIgnoredCommit(ctx, prctx, &ignoreCommitsBy, c)
 			if err != nil {
 				return nil, err
 			}

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptr[T any](val T) *T {
+	return &val
+}
+
 func TestIsApproved(t *testing.T) {
 	logger := zerolog.New(os.Stdout)
 	ctx := logger.WithContext(context.Background())
@@ -198,7 +202,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowAuthor: false,
+				AllowAuthor: ptr(false),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -214,7 +218,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowAuthor: true,
+				AllowAuthor: ptr(true),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -230,7 +234,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowContributor: false,
+				AllowContributor: ptr(false),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -246,8 +250,8 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowContributor: true,
-				AllowAuthor:      false,
+				AllowContributor: ptr(true),
+				AllowAuthor:      ptr(false),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -263,7 +267,7 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowNonAuthorContributor: true,
+				AllowNonAuthorContributor: ptr(true),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -279,8 +283,8 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowNonAuthorContributor: true,
-				AllowAuthor:               true,
+				AllowNonAuthorContributor: ptr(true),
+				AllowAuthor:               ptr(true),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -296,8 +300,8 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
 			Options: Options{
-				AllowNonAuthorContributor: true,
-				AllowContributor:          true,
+				AllowNonAuthorContributor: ptr(true),
+				AllowContributor:          ptr(true),
 			},
 			Requires: Requires{
 				Count: 1,
@@ -393,7 +397,7 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
-		r.Options.InvalidateOnPush = true
+		r.Options.InvalidateOnPush = ptr(true)
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
 	})
 
@@ -421,7 +425,7 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertApproved(t, prctx, r, "Approved by review-approver")
 
-		r.Options.InvalidateOnPush = true
+		r.Options.InvalidateOnPush = ptr(true)
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 1 approval from disqualified users")
 	})
 
@@ -450,12 +454,12 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 			Options: Options{
-				InvalidateOnPush: true,
+				InvalidateOnPush: ptr(true),
 			},
 		}
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
 
-		r.Options.IgnoreUpdateMerges = true
+		r.Options.IgnoreUpdateMerges = ptr(true)
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 	})
 
@@ -487,7 +491,7 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 8 approvals from disqualified users")
 
-		r.Options.IgnoreUpdateMerges = true
+		r.Options.IgnoreUpdateMerges = ptr(true)
 		assertApproved(t, prctx, r, "Approved by merge-committer")
 	})
 
@@ -510,7 +514,7 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 7 approvals from disqualified users")
 
-		r.Options.IgnoreCommitsBy = common.Actors{
+		r.Options.IgnoreCommitsBy = &common.Actors{
 			Users: []string{"comment-approver"},
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
@@ -527,7 +531,7 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 			Options: Options{
-				IgnoreCommitsBy: common.Actors{
+				IgnoreCommitsBy: &common.Actors{
 					Users: []string{"contributor-author"},
 				},
 			},
@@ -559,8 +563,8 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
-		r.Options.InvalidateOnPush = true
-		r.Options.IgnoreCommitsBy = common.Actors{
+		r.Options.InvalidateOnPush = ptr(true)
+		r.Options.IgnoreCommitsBy = &common.Actors{
 			Users: []string{"mhaypenny"},
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
@@ -603,10 +607,10 @@ func TestIsApproved(t *testing.T) {
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
-		r.Options.InvalidateOnPush = true
+		r.Options.InvalidateOnPush = ptr(true)
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
 
-		r.Options.IgnoreCommitsBy = common.Actors{
+		r.Options.IgnoreCommitsBy = &common.Actors{
 			Users: []string{"mhaypenny"},
 		}
 		assertApproved(t, prctx, r, "Approved by comment-approver")
@@ -626,7 +630,7 @@ func TestIsApproved(t *testing.T) {
 
 		assertApproved(t, prctx, r, "Approved by review-comment-editor")
 
-		r.Options.IgnoreEditedComments = true
+		r.Options.IgnoreEditedComments = ptr(true)
 
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
 	})
@@ -645,7 +649,7 @@ func TestIsApproved(t *testing.T) {
 
 		assertApproved(t, prctx, r, "Approved by comment-editor")
 
-		r.Options.IgnoreEditedComments = true
+		r.Options.IgnoreEditedComments = ptr(true)
 
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
 	})
@@ -666,13 +670,13 @@ func TestIsApproved(t *testing.T) {
 						common.NewCompiledRegexp(regexp.MustCompile("/no-platform")),
 					},
 				},
-				IgnoreEditedComments: false,
+				IgnoreEditedComments: ptr(false),
 			},
 		}
 
 		assertApproved(t, prctx, r, "Approved by body-editor")
 
-		r.Options.IgnoreEditedComments = true
+		r.Options.IgnoreEditedComments = ptr(true)
 
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 5 approvals from disqualified users")
 	})
@@ -817,7 +821,7 @@ func TestTrigger(t *testing.T) {
 						common.NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
 					},
 				},
-				IgnoreEditedComments: false,
+				IgnoreEditedComments: ptr(false),
 			},
 			Requires: Requires{
 				Count: 1,

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -106,8 +106,8 @@ func TestRules(t *testing.T) {
 				},
 			},
 			Options: Options{
-				AllowAuthor:      true,
-				AllowContributor: true,
+				AllowAuthor:      ptr(true),
+				AllowContributor: ptr(true),
 				// InvalidateOnPush: true,
 				Methods: &common.Methods{
 					Comments:     comments,

--- a/policy/approval/options.go
+++ b/policy/approval/options.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+)
+
+type Options struct {
+	AllowAuthor               *bool `yaml:"allow_author,omitempty"`
+	AllowContributor          *bool `yaml:"allow_contributor,omitempty"`
+	AllowNonAuthorContributor *bool `yaml:"allow_non_author_contributor,omitempty"`
+	InvalidateOnPush          *bool `yaml:"invalidate_on_push,omitempty"`
+
+	IgnoreEditedComments *bool          `yaml:"ignore_edited_comments,omitempty"`
+	IgnoreUpdateMerges   *bool          `yaml:"ignore_update_merges,omitempty"`
+	IgnoreCommitsBy      *common.Actors `yaml:"ignore_commits_by,omitempty"`
+
+	RequestReview *RequestReview `yaml:"request_review,omitempty"`
+
+	Methods *common.Methods `yaml:"methods,omitempty"`
+}
+
+type RequestReview struct {
+	Enabled bool               `yaml:"enabled,omitempty"`
+	Mode    common.RequestMode `yaml:"mode,omitempty"`
+	Count   int                `yaml:"count,omitempty"`
+}
+
+func (opts *Options) IsAllowAuthor() bool {
+	if opts.AllowAuthor == nil {
+		return false
+	}
+	return *opts.AllowAuthor
+}
+
+func (opts *Options) IsAllowContributor() bool {
+	if opts.AllowContributor == nil {
+		return false
+	}
+	return *opts.AllowContributor
+}
+
+func (opts *Options) IsAllowNonAuthorContributor() bool {
+	if opts.AllowNonAuthorContributor == nil {
+		return false
+	}
+	return *opts.AllowNonAuthorContributor
+}
+
+func (opts *Options) IsInvalidateOnPush() bool {
+	if opts.InvalidateOnPush == nil {
+		return false
+	}
+	return *opts.InvalidateOnPush
+}
+
+func (opts *Options) IsIgnoreEditedComments() bool {
+	if opts.IgnoreEditedComments == nil {
+		return false
+	}
+	return *opts.IgnoreEditedComments
+}
+
+func (opts *Options) IsIgnoreUpdateMerges() bool {
+	if opts.IgnoreUpdateMerges == nil {
+		return false
+	}
+	return *opts.IgnoreUpdateMerges
+}
+
+func (opts *Options) GetIgnoreCommitsBy() common.Actors {
+	if opts.IgnoreCommitsBy == nil {
+		return common.Actors{}
+	}
+	return *opts.IgnoreCommitsBy
+}
+
+func (opts *Options) GetRequestReview() RequestReview {
+	if opts.RequestReview == nil {
+		return RequestReview{}
+	}
+	return *opts.RequestReview
+}
+
+func (opts *Options) GetMethods() *common.Methods {
+	methods := opts.Methods
+	if methods == nil {
+		methods = &common.Methods{}
+	}
+	if methods.Comments == nil {
+		methods.Comments = []string{
+			":+1:",
+			"👍",
+		}
+	}
+	if methods.GithubReview == nil {
+		defaultGithubReview := true
+		methods.GithubReview = &defaultGithubReview
+	}
+
+	methods.GithubReviewState = pull.ReviewApproved
+	return methods
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -52,7 +52,7 @@ func ParsePolicy(c *Config, opts *GlobalOptions) (common.Evaluator, error) {
 	rulesByName := make(map[string]*approval.Rule)
 	for _, r := range c.ApprovalRules {
 		if opts != nil && opts.IgnoreEditedComments != nil {
-			r.Options.IgnoreEditedComments = *opts.IgnoreEditedComments
+			r.Options.IgnoreEditedComments = opts.IgnoreEditedComments
 		}
 
 		rulesByName[r.Name] = r

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -62,7 +62,7 @@ func TestParsePolicy(t *testing.T) {
 		}
 
 		_, err := ParsePolicy(c, &GlobalOptions{
-			IgnoreEditedComments: boolPtr(true),
+			IgnoreEditedComments: ptr(true),
 		})
 		assert.NoError(t, err)
 	})
@@ -136,7 +136,7 @@ func TestParsePolicy(t *testing.T) {
 		rule := &approval.Rule{
 			Name: "test-rule",
 			Options: approval.Options{
-				IgnoreEditedComments: false,
+				IgnoreEditedComments: ptr(false),
 			},
 		}
 
@@ -150,10 +150,10 @@ func TestParsePolicy(t *testing.T) {
 		}
 
 		_, err := ParsePolicy(c, &GlobalOptions{
-			IgnoreEditedComments: boolPtr(true),
+			IgnoreEditedComments: ptr(true),
 		})
 		assert.NoError(t, err)
-		assert.True(t, rule.Options.IgnoreEditedComments)
+		assert.True(t, rule.Options.IsIgnoreEditedComments())
 	})
 
 	t.Run("errorWhenRuleNotFound", func(t *testing.T) {
@@ -447,6 +447,6 @@ func castToResult(e common.Evaluator) *common.Result {
 	return (*common.Result)(e.(*StaticEvaluator))
 }
 
-func boolPtr(b bool) *bool {
-	return &b
+func ptr[T any](val T) *T {
+	return &val
 }


### PR DESCRIPTION
Allow distinguishing between options that are unset, set to a non-zero value, and set to a zero value. This is required to add default option support for #41.

