### PR TITLE
Add accessor methods for common.Methods fields

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -47,13 +47,13 @@ func (r *Rule) Trigger() common.Trigger {
 
 	if r.Requires.Count > 0 {
 		m := r.Options.GetMethods()
-		if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+		if len(m.GetComments()) > 0 || len(m.GetCommentPatterns()) > 0 {
 			t |= common.TriggerComment
 		}
-		if len(m.BodyPatterns) > 0 {
+		if len(m.GetBodyPatterns()) > 0 {
 			t |= common.TriggerPullRequest
 		}
-		if m.GithubReview != nil && *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+		if m.IsGithubReview() || len(m.GetGithubReviewCommentPatterns()) > 0 {
 			t |= common.TriggerReview
 		}
 	}

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -30,9 +30,32 @@ type Methods struct {
 	BodyPatterns                []Regexp `yaml:"body_patterns,omitempty"`
 
 	// If GithubReview is true, GithubReviewState is the state a review must
-	// have to be considered a candidated. It is currently excluded from
-	// serialized forms and should be set by the application.
-	GithubReviewState pull.ReviewState `yaml:"-" json:"-"`
+	// have to be considered a candidate. It is set after parsing based on the
+	// context in which Methods is used, rather than by the YAML configuration.
+	GithubReviewState pull.ReviewState `yaml:"-"`
+}
+
+func (m *Methods) GetComments() []string {
+	return m.Comments
+}
+
+func (m *Methods) GetCommentPatterns() []Regexp {
+	return m.CommentPatterns
+}
+
+func (m *Methods) IsGithubReview() bool {
+	if m.GithubReview == nil {
+		return false
+	}
+	return *m.GithubReview
+}
+
+func (m *Methods) GetGithubReviewCommentPatterns() []Regexp {
+	return m.GithubReviewCommentPatterns
+}
+
+func (m *Methods) GetBodyPatterns() []Regexp {
+	return m.BodyPatterns
 }
 
 type CandidateType string
@@ -65,7 +88,7 @@ func (cs CandidatesByCreationTime) Less(i, j int) bool {
 func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candidate, error) {
 	var candidates []*Candidate
 
-	if len(m.Comments) > 0 || len(m.CommentPatterns) > 0 {
+	if len(m.GetComments()) > 0 || len(m.GetCommentPatterns()) > 0 {
 		comments, err := prctx.Comments()
 		if err != nil {
 			return nil, err
@@ -83,7 +106,7 @@ func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candid
 		}
 	}
 
-	if len(m.BodyPatterns) > 0 {
+	if len(m.GetBodyPatterns()) > 0 {
 		prBody, err := prctx.Body()
 		if err != nil {
 			return nil, err
@@ -97,7 +120,7 @@ func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candid
 		}
 	}
 
-	if m.GithubReview != nil && *m.GithubReview || len(m.GithubReviewCommentPatterns) > 0 {
+	if m.IsGithubReview() || len(m.GetGithubReviewCommentPatterns()) > 0 {
 		reviews, err := prctx.Reviews()
 		if err != nil {
 			return nil, err
@@ -105,8 +128,8 @@ func (m *Methods) Candidates(ctx context.Context, prctx pull.Context) ([]*Candid
 
 		for _, r := range reviews {
 			if r.State == m.GithubReviewState {
-				if len(m.GithubReviewCommentPatterns) > 0 {
-					if m.githubReviewCommentMatches(r.Body) {
+				if len(m.GetGithubReviewCommentPatterns()) > 0 {
+					if m.GithubReviewCommentMatches(r.Body) {
 						candidates = append(candidates, &Candidate{
 							Type:         ReviewCandidate,
 							ReviewID:     r.ID,
@@ -149,12 +172,12 @@ func deduplicateCandidates(all []*Candidate) []*Candidate {
 }
 
 func (m *Methods) CommentMatches(commentBody string) bool {
-	for _, comment := range m.Comments {
+	for _, comment := range m.GetComments() {
 		if strings.Contains(commentBody, comment) {
 			return true
 		}
 	}
-	for _, pattern := range m.CommentPatterns {
+	for _, pattern := range m.GetCommentPatterns() {
 		if pattern.Matches(commentBody) {
 			return true
 		}
@@ -162,8 +185,8 @@ func (m *Methods) CommentMatches(commentBody string) bool {
 	return false
 }
 
-func (m *Methods) githubReviewCommentMatches(commentBody string) bool {
-	for _, pattern := range m.GithubReviewCommentPatterns {
+func (m *Methods) GithubReviewCommentMatches(commentBody string) bool {
+	for _, pattern := range m.GetGithubReviewCommentPatterns() {
 		if pattern.Matches(commentBody) {
 			return true
 		}
@@ -172,7 +195,7 @@ func (m *Methods) githubReviewCommentMatches(commentBody string) bool {
 }
 
 func (m *Methods) BodyMatches(prBody string) bool {
-	for _, pattern := range m.BodyPatterns {
+	for _, pattern := range m.GetBodyPatterns() {
 		if pattern.Matches(prBody) {
 			return true
 		}

--- a/policy/disapproval/disapprove.go
+++ b/policy/disapproval/disapprove.go
@@ -92,12 +92,18 @@ func (p *Policy) Trigger() common.Trigger {
 
 	if !p.Requires.IsZero() {
 		dm := p.Options.GetDisapproveMethods()
-		rm := p.Options.GetRevokeMethods()
-
-		if len(dm.Comments) > 0 || len(rm.Comments) > 0 {
+		if len(dm.GetComments()) > 0 || len(dm.GetCommentPatterns()) > 0 {
 			t |= common.TriggerComment
 		}
-		if dm.GithubReview != nil && *dm.GithubReview || rm.GithubReview != nil && *rm.GithubReview {
+		if dm.IsGithubReview() || len(dm.GetGithubReviewCommentPatterns()) > 0 {
+			t |= common.TriggerReview
+		}
+
+		rm := p.Options.GetRevokeMethods()
+		if len(rm.GetComments()) > 0 || len(rm.GetCommentPatterns()) > 0 {
+			t |= common.TriggerComment
+		}
+		if rm.IsGithubReview() || len(rm.GetGithubReviewCommentPatterns()) > 0 {
 			t |= common.TriggerReview
 		}
 	}

--- a/server/handler/frontend.go
+++ b/server/handler/frontend.go
@@ -173,19 +173,19 @@ func getMethods(result *common.Result) map[string][]string {
 	)
 
 	patternInfo := make(map[string][]string)
-	for _, comment := range result.Methods.Comments {
+	for _, comment := range result.Methods.GetComments() {
 		patternInfo[commentKey] = append(patternInfo[commentKey], comment)
 	}
-	for _, commentPattern := range result.Methods.CommentPatterns {
+	for _, commentPattern := range result.Methods.GetCommentPatterns() {
 		patternInfo[commentPatternKey] = append(patternInfo[commentPatternKey], commentPattern.String())
 	}
-	for _, bodyPattern := range result.Methods.BodyPatterns {
+	for _, bodyPattern := range result.Methods.GetBodyPatterns() {
 		patternInfo[bodyPatternKey] = append(patternInfo[bodyPatternKey], bodyPattern.String())
 	}
-	if result.Methods.GithubReview != nil && *result.Methods.GithubReview {
+	if result.Methods.IsGithubReview() || len(result.Methods.GetGithubReviewCommentPatterns()) > 0 {
 		reviewPatternKey := reviewKey + fmt.Sprintf(" %s matching patterns", result.Methods.GithubReviewState)
-		if len(result.Methods.GithubReviewCommentPatterns) > 0 {
-			for _, githubReviewCommentPattern := range result.Methods.GithubReviewCommentPatterns {
+		if len(result.Methods.GetGithubReviewCommentPatterns()) > 0 {
+			for _, githubReviewCommentPattern := range result.Methods.GetGithubReviewCommentPatterns() {
 				patternInfo[reviewPatternKey] = append(patternInfo[reviewPatternKey], githubReviewCommentPattern.String())
 			}
 		} else {


### PR DESCRIPTION
Most of these can already be nil, removing the need to add pointers to distinguish between unset, set to non-zero, and set to zero values. However, the accessors are still useful to allow getting default values in a future PR. It also helps in the one case of a boolean pointer where we had to check for nil each time.

Required as part of adding default support for #41.

