### PR TITLE
Add internal support for default options

### DIFF
--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -35,6 +35,10 @@ func ptr[T any](val T) *T {
 	return &val
 }
 
+var defaultOptions = Options{
+	Methods: DefaultMethods(),
+}
+
 func TestIsApproved(t *testing.T) {
 	logger := zerolog.New(os.Stdout)
 	ctx := logger.WithContext(context.Background())
@@ -184,13 +188,20 @@ func TestIsApproved(t *testing.T) {
 		// checking that we don't make an unnecessary call to the GitHub API.
 		prctx.CommentsError = errors.New("Comments() was called")
 
-		r := &Rule{}
+		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
+		}
 		assertApproved(t, prctx, r, "No approval required")
 	})
 
 	t.Run("singleApprovalRequired", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 			},
@@ -203,6 +214,7 @@ func TestIsApproved(t *testing.T) {
 		r := &Rule{
 			Options: Options{
 				AllowAuthor: ptr(false),
+				Defaults:    &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -219,6 +231,7 @@ func TestIsApproved(t *testing.T) {
 		r := &Rule{
 			Options: Options{
 				AllowAuthor: ptr(true),
+				Defaults:    &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -235,6 +248,7 @@ func TestIsApproved(t *testing.T) {
 		r := &Rule{
 			Options: Options{
 				AllowContributor: ptr(false),
+				Defaults:         &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -252,6 +266,7 @@ func TestIsApproved(t *testing.T) {
 			Options: Options{
 				AllowContributor: ptr(true),
 				AllowAuthor:      ptr(false),
+				Defaults:         &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -268,6 +283,7 @@ func TestIsApproved(t *testing.T) {
 		r := &Rule{
 			Options: Options{
 				AllowNonAuthorContributor: ptr(true),
+				Defaults:                  &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -285,6 +301,7 @@ func TestIsApproved(t *testing.T) {
 			Options: Options{
 				AllowNonAuthorContributor: ptr(true),
 				AllowAuthor:               ptr(true),
+				Defaults:                  &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -302,6 +319,7 @@ func TestIsApproved(t *testing.T) {
 			Options: Options{
 				AllowNonAuthorContributor: ptr(true),
 				AllowContributor:          ptr(true),
+				Defaults:                  &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -316,6 +334,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("specificUserApproves", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -326,6 +347,9 @@ func TestIsApproved(t *testing.T) {
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r = &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -339,6 +363,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("specificOrgApproves", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -349,6 +376,9 @@ func TestIsApproved(t *testing.T) {
 		assertApproved(t, prctx, r, "Approved by comment-approver")
 
 		r = &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -362,6 +392,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("specificOrgsOrUserApproves", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 2,
 				Actors: common.Actors{
@@ -388,6 +421,9 @@ func TestIsApproved(t *testing.T) {
 		}
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -416,6 +452,9 @@ func TestIsApproved(t *testing.T) {
 		}
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -447,14 +486,15 @@ func TestIsApproved(t *testing.T) {
 		})
 
 		r := &Rule{
+			Options: Options{
+				InvalidateOnPush: ptr(true),
+				Defaults:         &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
 					Users: []string{"comment-approver"},
 				},
-			},
-			Options: Options{
-				InvalidateOnPush: ptr(true),
 			},
 		}
 		assertPending(t, prctx, r, "0/1 required approvals. Ignored 6 approvals from disqualified users")
@@ -482,6 +522,9 @@ func TestIsApproved(t *testing.T) {
 		})
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -505,6 +548,9 @@ func TestIsApproved(t *testing.T) {
 		})
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -524,14 +570,15 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 
 		r := &Rule{
+			Options: Options{
+				IgnoreCommitsBy: &common.Actors{
+					Users: []string{"contributor-author"},
+				},
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
-					Users: []string{"contributor-author"},
-				},
-			},
-			Options: Options{
-				IgnoreCommitsBy: &common.Actors{
 					Users: []string{"contributor-author"},
 				},
 			},
@@ -554,6 +601,9 @@ func TestIsApproved(t *testing.T) {
 		}
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -598,6 +648,9 @@ func TestIsApproved(t *testing.T) {
 		}
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -620,6 +673,9 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -639,6 +695,9 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -658,12 +717,6 @@ func TestIsApproved(t *testing.T) {
 		prctx := basePullContext()
 
 		r := &Rule{
-			Requires: Requires{
-				Count: 1,
-				Actors: common.Actors{
-					Users: []string{"body-editor"},
-				},
-			},
 			Options: Options{
 				Methods: &common.Methods{
 					BodyPatterns: []common.Regexp{
@@ -671,6 +724,13 @@ func TestIsApproved(t *testing.T) {
 					},
 				},
 				IgnoreEditedComments: ptr(false),
+				Defaults:             &defaultOptions,
+			},
+			Requires: Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Users: []string{"body-editor"},
+				},
 			},
 		}
 
@@ -684,6 +744,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("conditionsRequiredStatusPending", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Conditions: predicate.Predicates{
 					HasStatus: &predicate.HasStatus{Statuses: []string{"deploy"}},
@@ -696,6 +759,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("conditionsRequiredStatusSuccess", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Conditions: predicate.Predicates{
 					HasStatus: &predicate.HasStatus{Statuses: []string{"build"}},
@@ -708,6 +774,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("conditionsRequiredStatusAndMissingApproval", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Conditions: predicate.Predicates{
@@ -721,6 +790,9 @@ func TestIsApproved(t *testing.T) {
 	t.Run("conditionsRequiredStatusAndOrgApproval", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Count: 1,
 				Actors: common.Actors{
@@ -737,7 +809,11 @@ func TestIsApproved(t *testing.T) {
 
 func TestTrigger(t *testing.T) {
 	t.Run("triggerCommitOnRules", func(t *testing.T) {
-		r := &Rule{}
+		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
+		}
 
 		assert.True(t, r.Trigger().Matches(common.TriggerCommit), "expected %s to match %", r.Trigger(), common.TriggerCommit)
 	})
@@ -750,6 +826,7 @@ func TestTrigger(t *testing.T) {
 						"lgtm",
 					},
 				},
+				Defaults: &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -768,6 +845,7 @@ func TestTrigger(t *testing.T) {
 						common.NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
 					},
 				},
+				Defaults: &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -785,6 +863,7 @@ func TestTrigger(t *testing.T) {
 				Methods: &common.Methods{
 					GithubReview: &defaultGithubReview,
 				},
+				Defaults: &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -803,6 +882,7 @@ func TestTrigger(t *testing.T) {
 						common.NewCompiledRegexp(regexp.MustCompile("(?i)nice")),
 					},
 				},
+				Defaults: &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -822,6 +902,7 @@ func TestTrigger(t *testing.T) {
 					},
 				},
 				IgnoreEditedComments: ptr(false),
+				Defaults:             &defaultOptions,
 			},
 			Requires: Requires{
 				Count: 1,
@@ -833,6 +914,9 @@ func TestTrigger(t *testing.T) {
 
 	t.Run("triggerStatusesForStatuses", func(t *testing.T) {
 		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
 			Requires: Requires{
 				Conditions: predicate.Predicates{
 					HasStatus: predicate.NewHasStatus([]string{"status1"}, []string{"skipped", "success"}),

--- a/policy/approval/evaluate_test.go
+++ b/policy/approval/evaluate_test.go
@@ -54,7 +54,7 @@ func TestRules(t *testing.T) {
     # invalidate_on_push: true
     methods:
       comments: ["+1"]
-      github_review: true
+      github_review: false
   requires:
     users: ["user4"]
     teams: ["team3", "team4"]
@@ -65,12 +65,6 @@ func TestRules(t *testing.T) {
 	var rules []*Rule
 	require.NoError(t, yaml.UnmarshalStrict([]byte(ruleText), &rules))
 
-	defaultGithubReview := true
-	defaultComments := []string{
-		":+1:",
-		"👍",
-	}
-	comments := []string{"+1"}
 	expected := []*Rule{
 		{
 			Name: "rule1",
@@ -108,10 +102,9 @@ func TestRules(t *testing.T) {
 			Options: Options{
 				AllowAuthor:      ptr(true),
 				AllowContributor: ptr(true),
-				// InvalidateOnPush: true,
 				Methods: &common.Methods{
-					Comments:     comments,
-					GithubReview: &defaultGithubReview,
+					Comments:     []string{"+1"},
+					GithubReview: ptr(false),
 				},
 			},
 			Requires: Requires{
@@ -126,64 +119,6 @@ func TestRules(t *testing.T) {
 	}
 
 	require.True(t, reflect.DeepEqual(expected, rules))
-
-	optionsText := `
-allow_author: true
-allow_contributor: true
-invalidate_on_push: true
-methods:
-  comments: ["+1"]
-`
-	expectedMethods := &common.Methods{
-		Comments:     comments,
-		GithubReview: &defaultGithubReview,
-	}
-	var options *Options
-	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &options))
-
-	methods := options.GetMethods()
-
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
-	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
-
-	optionsText = `
-allow_author: true
-allow_contributor: true
-invalidate_on_push: true
-methods:
-  github_review: false
-`
-	falseGithubReview := false
-	expectedMethods = &common.Methods{
-		Comments:     defaultComments,
-		GithubReview: &falseGithubReview,
-	}
-
-	var optionsTwo *Options
-	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &optionsTwo))
-
-	methods = optionsTwo.GetMethods()
-
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
-	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
-
-	optionsText = `
-allow_author: true
-allow_contributor: true
-invalidate_on_push: true
-`
-	expectedMethods = &common.Methods{
-		Comments:     defaultComments,
-		GithubReview: &defaultGithubReview,
-	}
-	var optionsThree *Options
-	require.NoError(t, yaml.UnmarshalStrict([]byte(optionsText), &optionsThree))
-
-	methods = optionsThree.GetMethods()
-
-	require.True(t, reflect.DeepEqual(expectedMethods.Comments, methods.Comments))
-	require.True(t, reflect.DeepEqual(*expectedMethods.GithubReview, *methods.GithubReview))
-
 }
 
 type mockRequirement struct {

--- a/policy/approval/options.go
+++ b/policy/approval/options.go
@@ -19,6 +19,17 @@ import (
 	"github.com/palantir/policy-bot/pull"
 )
 
+func DefaultMethods() *common.Methods {
+	review := true
+	return &common.Methods{
+		Comments: []string{
+			":+1:",
+			"👍",
+		},
+		GithubReview: &review,
+	}
+}
+
 type Options struct {
 	AllowAuthor               *bool `yaml:"allow_author,omitempty"`
 	AllowContributor          *bool `yaml:"allow_contributor,omitempty"`
@@ -32,6 +43,12 @@ type Options struct {
 	RequestReview *RequestReview `yaml:"request_review,omitempty"`
 
 	Methods *common.Methods `yaml:"methods,omitempty"`
+
+	// Defaults contains default options values for this rule, set by the
+	// policy or the server. The field is populated after parsing the YAML
+	// configuration. If nil, unset fields default to the zero value of their
+	// element type, unless otherwise noted.
+	Defaults *Options `yaml:"-"`
 }
 
 type RequestReview struct {
@@ -40,78 +57,96 @@ type RequestReview struct {
 	Count   int                `yaml:"count,omitempty"`
 }
 
-func (opts *Options) IsAllowAuthor() bool {
+func (opts Options) IsAllowAuthor() bool {
 	if opts.AllowAuthor == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsAllowAuthor()
+		}
 		return false
 	}
 	return *opts.AllowAuthor
 }
 
-func (opts *Options) IsAllowContributor() bool {
+func (opts Options) IsAllowContributor() bool {
 	if opts.AllowContributor == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsAllowContributor()
+		}
 		return false
 	}
 	return *opts.AllowContributor
 }
 
-func (opts *Options) IsAllowNonAuthorContributor() bool {
+func (opts Options) IsAllowNonAuthorContributor() bool {
 	if opts.AllowNonAuthorContributor == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsAllowNonAuthorContributor()
+		}
 		return false
 	}
 	return *opts.AllowNonAuthorContributor
 }
 
-func (opts *Options) IsInvalidateOnPush() bool {
+func (opts Options) IsInvalidateOnPush() bool {
 	if opts.InvalidateOnPush == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsInvalidateOnPush()
+		}
 		return false
 	}
 	return *opts.InvalidateOnPush
 }
 
-func (opts *Options) IsIgnoreEditedComments() bool {
+func (opts Options) IsIgnoreEditedComments() bool {
 	if opts.IgnoreEditedComments == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsIgnoreEditedComments()
+		}
 		return false
 	}
 	return *opts.IgnoreEditedComments
 }
 
-func (opts *Options) IsIgnoreUpdateMerges() bool {
+func (opts Options) IsIgnoreUpdateMerges() bool {
 	if opts.IgnoreUpdateMerges == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.IsIgnoreUpdateMerges()
+		}
 		return false
 	}
 	return *opts.IgnoreUpdateMerges
 }
 
-func (opts *Options) GetIgnoreCommitsBy() common.Actors {
+func (opts Options) GetIgnoreCommitsBy() common.Actors {
 	if opts.IgnoreCommitsBy == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.GetIgnoreCommitsBy()
+		}
 		return common.Actors{}
 	}
 	return *opts.IgnoreCommitsBy
 }
 
-func (opts *Options) GetRequestReview() RequestReview {
+func (opts Options) GetRequestReview() RequestReview {
 	if opts.RequestReview == nil {
+		if opts.Defaults != nil {
+			return opts.Defaults.GetRequestReview()
+		}
 		return RequestReview{}
 	}
 	return *opts.RequestReview
 }
 
-func (opts *Options) GetMethods() *common.Methods {
-	methods := opts.Methods
-	if methods == nil {
-		methods = &common.Methods{}
+func (opts Options) GetMethods() *common.Methods {
+	var m common.Methods
+	if opts.Methods != nil {
+		m = *opts.Methods // make a copy since we might modify 'm.Defaults'
 	}
-	if methods.Comments == nil {
-		methods.Comments = []string{
-			":+1:",
-			"👍",
-		}
-	}
-	if methods.GithubReview == nil {
-		defaultGithubReview := true
-		methods.GithubReview = &defaultGithubReview
+	if opts.Defaults != nil {
+		m.Defaults = opts.Defaults.GetMethods()
 	}
 
-	methods.GithubReviewState = pull.ReviewApproved
-	return methods
+	// Approvals always use `pull.ReviewApproved` as the state
+	m.GithubReviewState = pull.ReviewApproved
+	return &m
 }

--- a/policy/approval/options_test.go
+++ b/policy/approval/options_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approval
+
+import (
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsFields(t *testing.T) {
+	fields := map[string]struct {
+		Seed         Options
+		Get          func(Options) any
+		UnsetValue   any
+		SetValue     any
+		DefaultValue any // use SetValue if nil
+	}{
+		"AllowAuthor": {
+			Seed:       Options{AllowAuthor: ptr(true)},
+			Get:        func(o Options) any { return o.IsAllowAuthor() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"AllowContributor": {
+			Seed:       Options{AllowContributor: ptr(true)},
+			Get:        func(o Options) any { return o.IsAllowContributor() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"AllowNonAuthorContributor": {
+			Seed:       Options{AllowNonAuthorContributor: ptr(true)},
+			Get:        func(o Options) any { return o.IsAllowNonAuthorContributor() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"InvalidateOnPush": {
+			Seed:       Options{InvalidateOnPush: ptr(true)},
+			Get:        func(o Options) any { return o.IsInvalidateOnPush() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"IgnoreEditedComments": {
+			Seed:       Options{IgnoreEditedComments: ptr(true)},
+			Get:        func(o Options) any { return o.IsIgnoreEditedComments() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"IgnoreUpdateMerges": {
+			Seed:       Options{IgnoreUpdateMerges: ptr(true)},
+			Get:        func(o Options) any { return o.IsIgnoreUpdateMerges() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"IgnoreCommitsBy": {
+			Seed: Options{
+				IgnoreCommitsBy: &common.Actors{
+					Users: []string{"mhaypenny"},
+				},
+			},
+			Get:        func(o Options) any { return o.GetIgnoreCommitsBy() },
+			UnsetValue: common.Actors{},
+			SetValue: common.Actors{
+				Users: []string{"mhaypenny"},
+			},
+		},
+		"RequestReview": {
+			Seed: Options{
+				RequestReview: &RequestReview{
+					Enabled: true,
+					Mode:    common.RequestModeTeams,
+				},
+			},
+			Get:        func(o Options) any { return o.GetRequestReview() },
+			UnsetValue: RequestReview{},
+			SetValue: RequestReview{
+				Enabled: true,
+				Mode:    common.RequestModeTeams,
+			},
+		},
+		"Methods": {
+			Seed: Options{
+				Methods: &common.Methods{
+					Comments:     []string{"+1"},
+					GithubReview: ptr(true),
+				},
+			},
+			Get: func(o Options) any { return o.GetMethods() },
+			UnsetValue: &common.Methods{
+				GithubReviewState: pull.ReviewApproved,
+			},
+			SetValue: &common.Methods{
+				Comments:          []string{"+1"},
+				GithubReview:      ptr(true),
+				GithubReviewState: pull.ReviewApproved,
+			},
+			DefaultValue: &common.Methods{
+				GithubReviewState: pull.ReviewApproved,
+				Defaults: &common.Methods{
+					Comments:          []string{"+1"},
+					GithubReview:      ptr(true),
+					GithubReviewState: pull.ReviewApproved,
+				},
+			},
+		},
+	}
+
+	for field, spec := range fields {
+		t.Run(field, func(t *testing.T) {
+			v := spec.Get(Options{})
+			assert.Equal(t, spec.UnsetValue, v, "incorrect unset value")
+
+			v = spec.Get(spec.Seed)
+			assert.Equal(t, spec.SetValue, v, "incorrect set value")
+
+			v = spec.Get(Options{Defaults: &spec.Seed})
+			if spec.DefaultValue != nil {
+				assert.Equal(t, spec.DefaultValue, v, "incorrect default value")
+			} else {
+				assert.Equal(t, spec.SetValue, v, "incorrect default value")
+			}
+		})
+	}
+}

--- a/policy/common/methods.go
+++ b/policy/common/methods.go
@@ -33,28 +33,61 @@ type Methods struct {
 	// have to be considered a candidate. It is set after parsing based on the
 	// context in which Methods is used, rather than by the YAML configuration.
 	GithubReviewState pull.ReviewState `yaml:"-"`
+
+	// Defaults contains default method values for this rule, set by the policy
+	// or the server. The field is populated after parsing the YAML
+	// configuration. If nil, unset fields default to the zero value of their
+	// element type, unless otherwise noted.
+	Defaults *Methods `yaml:"-"`
 }
 
 func (m *Methods) GetComments() []string {
+	if m.Comments == nil {
+		if m.Defaults != nil {
+			return m.Defaults.GetComments()
+		}
+		return nil
+	}
 	return m.Comments
 }
 
 func (m *Methods) GetCommentPatterns() []Regexp {
+	if m.CommentPatterns == nil {
+		if m.Defaults != nil {
+			return m.Defaults.GetCommentPatterns()
+		}
+		return nil
+	}
 	return m.CommentPatterns
 }
 
 func (m *Methods) IsGithubReview() bool {
 	if m.GithubReview == nil {
+		if m.Defaults != nil {
+			return m.Defaults.IsGithubReview()
+		}
 		return false
 	}
 	return *m.GithubReview
 }
 
 func (m *Methods) GetGithubReviewCommentPatterns() []Regexp {
+	if m.GithubReviewCommentPatterns == nil {
+		if m.Defaults != nil {
+			return m.Defaults.GetGithubReviewCommentPatterns()
+		}
+		return nil
+	}
 	return m.GithubReviewCommentPatterns
 }
 
 func (m *Methods) GetBodyPatterns() []Regexp {
+	if m.BodyPatterns == nil {
+		if m.Defaults != nil {
+			return m.Defaults.GetBodyPatterns()
+		}
+		return nil
+	}
 	return m.BodyPatterns
 }
 

--- a/policy/common/methods_test.go
+++ b/policy/common/methods_test.go
@@ -200,3 +200,67 @@ func TestCandidatesByCreationTime(t *testing.T) {
 		assert.Equalf(t, u, cs[i].User, "candidate at position %d is incorrect", i)
 	}
 }
+
+func TestMethodsFields(t *testing.T) {
+	pattern := NewCompiledRegexp(regexp.MustCompile("^(?i:LGTM)$"))
+
+	fields := map[string]struct {
+		Seed         Methods
+		Get          func(Methods) any
+		UnsetValue   any
+		SetValue     any
+		DefaultValue any // use SetValue if nil
+	}{
+		"Comments": {
+			Seed:       Methods{Comments: []string{"+1"}},
+			Get:        func(m Methods) any { return m.GetComments() },
+			UnsetValue: []string(nil),
+			SetValue:   []string{"+1"},
+		},
+		"CommentPatterns": {
+			Seed:       Methods{CommentPatterns: []Regexp{pattern}},
+			Get:        func(m Methods) any { return m.GetCommentPatterns() },
+			UnsetValue: []Regexp(nil),
+			SetValue:   []Regexp{pattern},
+		},
+		"GithubReview": {
+			Seed:       Methods{GithubReview: ptr(true)},
+			Get:        func(m Methods) any { return m.IsGithubReview() },
+			UnsetValue: false,
+			SetValue:   true,
+		},
+		"GithubReviewCommentPatterns": {
+			Seed:       Methods{GithubReviewCommentPatterns: []Regexp{pattern}},
+			Get:        func(m Methods) any { return m.GetGithubReviewCommentPatterns() },
+			UnsetValue: []Regexp(nil),
+			SetValue:   []Regexp{pattern},
+		},
+		"BodyPatterns": {
+			Seed:       Methods{BodyPatterns: []Regexp{pattern}},
+			Get:        func(m Methods) any { return m.GetBodyPatterns() },
+			UnsetValue: []Regexp(nil),
+			SetValue:   []Regexp{pattern},
+		},
+	}
+
+	for field, spec := range fields {
+		t.Run(field, func(t *testing.T) {
+			v := spec.Get(Methods{})
+			assert.Equal(t, spec.UnsetValue, v, "incorrect unset value")
+
+			v = spec.Get(spec.Seed)
+			assert.Equal(t, spec.SetValue, v, "incorrect set value")
+
+			v = spec.Get(Methods{Defaults: &spec.Seed})
+			if spec.DefaultValue != nil {
+				assert.Equal(t, spec.DefaultValue, v, "incorrect default value")
+			} else {
+				assert.Equal(t, spec.SetValue, v, "incorrect default value")
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -49,10 +49,20 @@ type GlobalOptions struct {
 }
 
 func ParsePolicy(c *Config, opts *GlobalOptions) (common.Evaluator, error) {
+	defaultApprovalOptions := approval.Options{
+		Methods: approval.DefaultMethods(),
+	}
+
 	rulesByName := make(map[string]*approval.Rule)
 	for _, r := range c.ApprovalRules {
-		if opts != nil && opts.IgnoreEditedComments != nil {
-			r.Options.IgnoreEditedComments = opts.IgnoreEditedComments
+		// Set server-level rule defaults
+		r.Options.Defaults = &defaultApprovalOptions
+
+		// Override rule options controlled by the server
+		if opts != nil {
+			if opts.IgnoreEditedComments != nil {
+				r.Options.IgnoreEditedComments = opts.IgnoreEditedComments
+			}
 		}
 
 		rulesByName[r.Name] = r


### PR DESCRIPTION
This is not exposed to users yet, but provides a cleaner way to set default options that are not the zero value, like the standard approval methods. A future commit will connect these to user-visible defaults in policies and in the server as part of #41.
