### PR TITLE
Add support for policy and server default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ instance of the server.
   This means it is safe to enable `policy-bot` on all repositories in an
   organization.
 
+Server administrators can also set the `force_shared_policy` option to disable
+loading policies from local repositories, requiring that all repositories use a
+policy supplied in a shared organization repository.
+
 ### policy.yml Specification
 
 The overall policy is expressed by:
@@ -611,6 +615,81 @@ requires:
       statuses:
         - "build"
         - "vulnerability scan"
+```
+
+#### Default Options
+
+Policies and server administrators can define new default values for approval
+rule options. This makes it easier to set common options accross all rules.
+Policy Bot tries values in the following order until it finds a set value:
+
+1. Explicit rule options
+2. Policy-level default options
+3. Configurable server-level default options
+4. Hardcoded server-level default options
+
+To define policy-level defaults, add the `approval_defaults` section at the top
+level of the policy file:
+
+```yaml
+approval_defaults:
+  # "options" can contain any property available as a rule-level option
+  options:
+    invalidate_on_push: true
+    methods:
+      comments: []
+      comment_patterns: ["^LGTM$"]
+
+approval_rules:
+  # This rule is invalided by new commits and uses the "LGTM" comment to
+  # indicate approval
+  - name: devtools approval
+    requires:
+      count: 1
+      teams: ["palantir/devtools"]
+
+  # This rule is also invalided by new commits, but uses the ":+1:" comment to
+  # indicate approval
+  - name: special approval comments
+    options:
+      methods:
+        comment_patterns: ["^:+1:$"]
+    requires:
+      count: 1
+      teams: ["palantir/plus-oners"]
+```
+
+Option values are not merged. For example, defining the `ignore_commits_by` or
+`methods.comment_patterns` options in a rule completely replaces any default
+values for these options.
+
+The only exception to this is the `methods` property, which supports limited
+merging. This matches the legacy behavior for how rule values combined with the
+hardcoded server defaults. For example:
+
+```yaml
+# server defaults
+options:
+  methods:
+    comments: ["==APPROVED=="]
+
+# policy defaults
+options:
+  methods:
+    comment_patterns: ["^LGTM$"]
+    github_review: false
+
+# rule overrides
+options:
+  methods:
+    comment_patterns: ["^:+1:$"]
+
+# combined value used during evaluation
+options:
+  methods:
+    comments: ["==APPROVED=="]
+    comment_patterns: ["^:+1:$"]
+    github_review: false
 ```
 
 ### Approval Policies

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ requires:
 #### Default Options
 
 Policies and server administrators can define new default values for approval
-rule options. This makes it easier to set common options accross all rules.
+rule options. This makes it easier to set common options across all rules.
 Policy Bot tries values in the following order until it finds a set value:
 
 1. Explicit rule options
@@ -641,15 +641,15 @@ approval_defaults:
       comment_patterns: ["^LGTM$"]
 
 approval_rules:
-  # This rule is invalided by new commits and uses the "LGTM" comment to
-  # indicate approval
+  # Existing approvals for this rule are invalided by new commits and it uses
+  # the "LGTM" comment to indicate approval
   - name: devtools approval
     requires:
       count: 1
       teams: ["palantir/devtools"]
 
-  # This rule is also invalided by new commits, but uses the ":+1:" comment to
-  # indicate approval
+  # Existing approvals for this rule are also invalided by new commits, but it
+  # uses the ":+1:" comment to indicate approval
   - name: special approval comments
     options:
       methods:

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -133,6 +133,23 @@ sessions:
 #   # Can also be set by the POLICYBOT_OPTIONS_FORCE_SHARED_POLICY
 #   # environment variable.
 #   force_shared_policy: false
+#
+#   # Default options to use for all appoval rules processed by the server.
+#   # Policies can override these values with their own defaults or in individual
+#   # rules. This is equivalent to the "approval_defaults" option in a policy and
+#   # accepts all of the same values.
+#   #
+#   # Options can be set by environment variables by coverting the path to the
+#   # YAML key to uppercase and replacing dots with underscores. For example,
+#   # to set the 'invalidate_on_push' option, set the
+#   # POLICYBOT_OPTIONS_APPROVAL_DEFAULTS_OPTIONS_INVALIDATE_ON_PUSH variable.
+#   #
+#   # To set list values, set the environment variable to a comma-separated
+#   # list of elements. List elements that contain commas are not supported in
+#   # environment variables; use the YAML configuration in this case.
+#   approval_defaults:
+#     options:
+#       invalidate_on_push: true
 
 # Options for locating the frontend files. By default, the server uses appropriate
 # paths for the binary distribution and Docker container. For local development,

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -42,6 +42,10 @@ type Requires struct {
 	Conditions predicate.Predicates `yaml:"conditions,omitempty"`
 }
 
+type Defaults struct {
+	Options *Options `yaml:"options,omitempty"`
+}
+
 func (r *Rule) Trigger() common.Trigger {
 	t := common.TriggerCommit
 

--- a/policy/common/regexp.go
+++ b/policy/common/regexp.go
@@ -76,3 +76,8 @@ func (r *Regexp) UnmarshalJSON(data []byte) (err error) {
 	*r, err = NewRegexp(pattern)
 	return err
 }
+
+func (r *Regexp) UnmarshalText(text []byte) (err error) {
+	*r, err = NewRegexp(string(text))
+	return err
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -35,8 +35,9 @@ type RemoteConfig struct {
 }
 
 type Config struct {
-	Policy        Policy           `yaml:"policy,omitempty"`
-	ApprovalRules []*approval.Rule `yaml:"approval_rules,omitempty"`
+	Policy           Policy             `yaml:"policy,omitempty"`
+	ApprovalDefaults *approval.Defaults `yaml:"approval_defaults,omitempty"`
+	ApprovalRules    []*approval.Rule   `yaml:"approval_rules,omitempty"`
 }
 
 type Policy struct {
@@ -44,19 +45,41 @@ type Policy struct {
 	Disapproval *disapproval.Policy `yaml:"disapproval,omitempty"`
 }
 
+// GlobalOptions defines server-level properties that affect policy parsing, like default or override values.
 type GlobalOptions struct {
-	IgnoreEditedComments *bool `yaml:"ignore_edited_comments,omitempty"` // If true, edited comments will not trigger the policy evaluation.
+	// IgnoreEditedComments, if non-nil, overrides the value of this option in
+	// all rules. If true, editing a comment will invalidate the comment for
+	// approval in all policies.
+	IgnoreEditedComments *bool
+
+	// ApprovalDefaults defines server-level default values for policies. For
+	// instance, this can change the default approval strings for all policies.
+	ApprovalDefaults *approval.Defaults
 }
 
 func ParsePolicy(c *Config, opts *GlobalOptions) (common.Evaluator, error) {
-	defaultApprovalOptions := approval.Options{
+	// Build the options hierarchy in reverse order. When reading an option,
+	// values are tried in the following order:
+	//
+	// 1. Rule
+	// 2. Policy default
+	// 3. Configurable server default
+	// 4. Hardcoded server default
+	//
+	defaultApprovalOptions := &approval.Options{
 		Methods: approval.DefaultMethods(),
+	}
+	if opts != nil && opts.ApprovalDefaults != nil {
+		defaultApprovalOptions = setDefaultOptions(defaultApprovalOptions, opts.ApprovalDefaults.Options)
+	}
+	if c.ApprovalDefaults != nil {
+		defaultApprovalOptions = setDefaultOptions(defaultApprovalOptions, c.ApprovalDefaults.Options)
 	}
 
 	rulesByName := make(map[string]*approval.Rule)
 	for _, r := range c.ApprovalRules {
-		// Set server-level rule defaults
-		r.Options.Defaults = &defaultApprovalOptions
+		// Set policy and server rule defaults
+		r.Options.Defaults = defaultApprovalOptions
 
 		// Override rule options controlled by the server
 		if opts != nil {
@@ -82,6 +105,14 @@ func ParsePolicy(c *Config, opts *GlobalOptions) (common.Evaluator, error) {
 		approval:    evalApproval,
 		disapproval: evalDisapproval,
 	}, nil
+}
+
+func setDefaultOptions(existing *approval.Options, next *approval.Options) *approval.Options {
+	if next != nil {
+		next.Defaults = existing
+		return next
+	}
+	return existing
 }
 
 type evaluator struct {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -156,6 +156,134 @@ func TestParsePolicy(t *testing.T) {
 		assert.True(t, rule.Options.IsIgnoreEditedComments())
 	})
 
+	t.Run("withPolicyApprovalDefaults", func(t *testing.T) {
+		rule1 := &approval.Rule{
+			Name: "rule1",
+			Options: approval.Options{
+				AllowAuthor: ptr(true),
+			},
+		}
+		rule2 := &approval.Rule{
+			Name: "rule2",
+			Options: approval.Options{
+				InvalidateOnPush: ptr(false),
+			},
+		}
+
+		c := &Config{
+			Policy: Policy{
+				Approval: approval.Policy{
+					"rule1", "rule2",
+				},
+			},
+			ApprovalRules: []*approval.Rule{rule1, rule2},
+			ApprovalDefaults: &approval.Defaults{
+				Options: &approval.Options{
+					InvalidateOnPush:     ptr(true),
+					IgnoreEditedComments: ptr(true),
+				},
+			},
+		}
+
+		_, err := ParsePolicy(c, nil)
+		assert.NoError(t, err)
+
+		assert.True(t, rule1.Options.IsAllowAuthor())
+		assert.True(t, rule1.Options.IsInvalidateOnPush())
+		assert.True(t, rule1.Options.IsIgnoreEditedComments())
+
+		assert.False(t, rule2.Options.IsInvalidateOnPush())
+		assert.True(t, rule2.Options.IsIgnoreEditedComments())
+	})
+
+	t.Run("withServerApprovalDefaults", func(t *testing.T) {
+		rule1 := &approval.Rule{
+			Name: "rule1",
+			Options: approval.Options{
+				AllowAuthor: ptr(true),
+			},
+		}
+		rule2 := &approval.Rule{
+			Name: "rule2",
+			Options: approval.Options{
+				InvalidateOnPush: ptr(false),
+			},
+		}
+
+		c := &Config{
+			Policy: Policy{
+				Approval: approval.Policy{
+					"rule1", "rule2",
+				},
+			},
+			ApprovalRules: []*approval.Rule{rule1, rule2},
+		}
+
+		_, err := ParsePolicy(c, &GlobalOptions{
+			ApprovalDefaults: &approval.Defaults{
+				Options: &approval.Options{
+					InvalidateOnPush:     ptr(true),
+					IgnoreEditedComments: ptr(true),
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.True(t, rule1.Options.IsAllowAuthor())
+		assert.True(t, rule1.Options.IsInvalidateOnPush())
+		assert.True(t, rule1.Options.IsIgnoreEditedComments())
+
+		assert.False(t, rule2.Options.IsInvalidateOnPush())
+		assert.True(t, rule2.Options.IsIgnoreEditedComments())
+	})
+
+	t.Run("withServerAndPolicyApprovalDefaults", func(t *testing.T) {
+		rule1 := &approval.Rule{
+			Name: "rule1",
+			Options: approval.Options{
+				AllowAuthor: ptr(true),
+			},
+		}
+		rule2 := &approval.Rule{
+			Name: "rule2",
+			Options: approval.Options{
+				InvalidateOnPush: ptr(false),
+			},
+		}
+
+		c := &Config{
+			Policy: Policy{
+				Approval: approval.Policy{
+					"rule1", "rule2",
+				},
+			},
+			ApprovalRules: []*approval.Rule{rule1, rule2},
+			ApprovalDefaults: &approval.Defaults{
+				Options: &approval.Options{
+					Methods: &common.Methods{
+						Comments: []string{"ship it"},
+					},
+				},
+			},
+		}
+
+		_, err := ParsePolicy(c, &GlobalOptions{
+			ApprovalDefaults: &approval.Defaults{
+				Options: &approval.Options{
+					InvalidateOnPush: ptr(true),
+				},
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.True(t, rule1.Options.IsAllowAuthor())
+		assert.True(t, rule1.Options.IsInvalidateOnPush())
+		assert.Equal(t, []string{"ship it"}, rule1.Options.GetMethods().GetComments())
+
+		assert.False(t, rule2.Options.IsInvalidateOnPush())
+		assert.Equal(t, []string{"ship it"}, rule2.Options.GetMethods().GetComments())
+	})
+
 	t.Run("errorWhenRuleNotFound", func(t *testing.T) {
 		c := &Config{
 			Policy: Policy{

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -97,6 +97,7 @@ func (ec *EvalContext) ParseConfig(ctx context.Context, trigger common.Trigger) 
 
 	opts := &policy.GlobalOptions{
 		IgnoreEditedComments: ec.Options.IgnoreEditedComments,
+		ApprovalDefaults:     ec.Options.ApprovalDefaults,
 	}
 
 	evaluator, err := policy.ParsePolicy(fc.Config, opts)

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -17,6 +17,8 @@ package handler
 import (
 	"os"
 	"strconv"
+
+	"github.com/palantir/policy-bot/policy/approval"
 )
 
 const (
@@ -58,6 +60,12 @@ type PullEvaluationOptions struct {
 	// IgnoreEditedComments enables ignoring comments that have been edited when evaluating approval rules.
 	// This provides a server-side option to ignore edited comments across all rules.
 	IgnoreEditedComments *bool `yaml:"ignore_edited_comments"`
+
+	// ApprovalDefaults defines default values for all approval rules evaluated
+	// by the server. Use this to change things like the default approval
+	// comments or `invalidate_on_push` behavior globally. Policies may
+	// override these default by providing their own values.
+	ApprovalDefaults *approval.Defaults `yaml:"approval_defaults"`
 
 	// This field is unused but is left to avoid breaking configuration files.
 	// This value is now loaded from the GitHub API.

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -120,7 +120,7 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)
 	setBoolPtrFromEnv("IGNORE_EDITED_COMMENTS", prefix, &p.IgnoreEditedComments)
 
-	p.setApprovalDefaultsFromEnv(prefix + "_APPROVAL_DEFAULTS")
+	p.setApprovalDefaultsFromEnv(prefix + "APPROVAL_DEFAULTS_")
 
 	p.fillDefaults()
 }

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -15,10 +15,13 @@
 package handler
 
 import (
+	"encoding"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/palantir/policy-bot/policy/approval"
+	"github.com/palantir/policy-bot/policy/common"
 )
 
 const (
@@ -116,20 +119,157 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setBoolFromEnv("STRICT_REVIEW_DISMISSAL", prefix, &p.StrictReviewDismissal)
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)
 	setBoolPtrFromEnv("IGNORE_EDITED_COMMENTS", prefix, &p.IgnoreEditedComments)
+
+	p.setApprovalDefaultsFromEnv(prefix + "_APPROVAL_DEFAULTS")
+
 	p.fillDefaults()
 }
 
-func setStringFromEnv(key, prefix string, value *string) bool {
+func (p *PullEvaluationOptions) setApprovalDefaultsFromEnv(prefix string) {
+	var d *approval.Defaults
+	if p.ApprovalDefaults != nil {
+		d = p.ApprovalDefaults
+	} else {
+		d = &approval.Defaults{}
+	}
+
+	var opts *approval.Options
+	if d.Options != nil {
+		opts = d.Options
+	} else {
+		opts = &approval.Options{}
+	}
+
+	hasOpts := isAny(
+		setBoolPtrFromEnv("OPTIONS_ALLOW_AUTHOR", prefix, &opts.AllowAuthor),
+		setBoolPtrFromEnv("OPTIONS_ALLOW_CONTRIBUTOR", prefix, &opts.AllowContributor),
+		setBoolPtrFromEnv("OPTIONS_ALLOW_NON_AUTHOR_CONTRIBUTOR", prefix, &opts.AllowNonAuthorContributor),
+		setBoolPtrFromEnv("OPTIONS_INVALIDATE_ON_PUSH", prefix, &opts.InvalidateOnPush),
+		setBoolPtrFromEnv("OPTIONS_IGNORE_EDITED_COMMENTS", prefix, &opts.IgnoreEditedComments),
+		setBoolPtrFromEnv("OPTIONS_IGNORE_UPDATE_MERGES", prefix, &opts.IgnoreUpdateMerges),
+	)
+
+	var commitsBy *common.Actors
+	if opts.IgnoreCommitsBy != nil {
+		commitsBy = opts.IgnoreCommitsBy
+	} else {
+		commitsBy = &common.Actors{}
+	}
+
+	if isAny(
+		setStringListFromEnv("OPTIONS_IGNORE_COMMITS_BY_USERS", prefix, &commitsBy.Users),
+		setStringListFromEnv("OPTIONS_IGNORE_COMMITS_BY_TEAMS", prefix, &commitsBy.Teams),
+		setStringListFromEnv("OPTIONS_IGNORE_COMMITS_BY_ORGANIZATIONS", prefix, &commitsBy.Organizations),
+		setListFromEnv("OPTIONS_IGNORE_COMMITS_BY_PERMISSIONS", prefix, &commitsBy.Permissions),
+	) {
+		hasOpts = true
+		if opts.IgnoreCommitsBy != commitsBy {
+			opts.IgnoreCommitsBy = commitsBy
+		}
+	}
+
+	var rr *approval.RequestReview
+	if opts.RequestReview != nil {
+		rr = opts.RequestReview
+	} else {
+		rr = &approval.RequestReview{}
+	}
+
+	if isAny(
+		setBoolFromEnv("OPTIONS_REQUEST_REVIEW_ENABLED", prefix, &rr.Enabled),
+		setStringFromEnv("OPTIONS_REQUEST_REVIEW_MODE", prefix, &rr.Mode),
+		setIntFromEnv("OPTIONS_REQUEST_REVIEW_COUNT", prefix, &rr.Count),
+	) {
+		hasOpts = true
+		if opts.RequestReview != rr {
+			opts.RequestReview = rr
+		}
+	}
+
+	var methods *common.Methods
+	if opts.Methods != nil {
+		methods = opts.Methods
+	} else {
+		methods = &common.Methods{}
+	}
+
+	if isAny(
+		setStringListFromEnv("OPTIONS_METHODS_COMMENTS", prefix, &methods.Comments),
+		setListFromEnv("OPTIONS_METHODS_COMMENT_PATTERNS", prefix, &methods.CommentPatterns),
+		setBoolPtrFromEnv("OPTIONS_METHODS_GITHUB_REVIEW", prefix, &methods.GithubReview),
+		setListFromEnv("OPTIONS_METHODS_GITHUB_REVIEW_COMMENT_PATTERNS", prefix, &methods.GithubReviewCommentPatterns),
+		setListFromEnv("OPTIONS_METHODS_BODY_PATTERNS", prefix, &methods.BodyPatterns),
+	) {
+		hasOpts = true
+		if opts.Methods != methods {
+			opts.Methods = methods
+		}
+	}
+
+	// Store new objects if we created them and set any properties
+	if hasOpts {
+		if d.Options != opts {
+			d.Options = opts
+		}
+		if p.ApprovalDefaults != d {
+			p.ApprovalDefaults = d
+		}
+	}
+}
+
+func isAny(bs ...bool) bool {
+	for _, b := range bs {
+		if b {
+			return true
+		}
+	}
+	return false
+}
+
+func setStringFromEnv[T ~string](key, prefix string, value *T) bool {
 	if v, ok := os.LookupEnv(prefix + key); ok {
-		*value = v
+		*value = T(v)
 		return true
 	}
 	return false
 }
 
-func setStringPtrFromEnv(key, prefix string, value **string) bool {
+func setStringPtrFromEnv[T ~string](key, prefix string, value **T) bool {
 	if v, ok := os.LookupEnv(prefix + key); ok {
-		*value = &v
+		vt := T(v)
+		*value = &vt
+		return true
+	}
+	return false
+}
+
+func setStringListFromEnv[T ~string](key, prefix string, value *[]T) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		var items []T
+		for _, item := range strings.Split(v, ",") {
+			items = append(items, T(item))
+		}
+		*value = items
+		return true
+	}
+	return false
+}
+
+type textUnmarshallerPtr[T any] interface {
+	*T
+	encoding.TextUnmarshaler
+}
+
+func setListFromEnv[T any, PT textUnmarshallerPtr[T]](key, prefix string, value *[]T) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		var items []T
+		for _, item := range strings.Split(v, ",") {
+			var t T
+			if err := PT(&t).UnmarshalText([]byte(item)); err == nil {
+				items = append(items, t)
+			}
+		}
+		*value = items
 		return true
 	}
 	return false
@@ -149,6 +289,16 @@ func setBoolPtrFromEnv(key, prefix string, value **bool) bool {
 	if v, ok := os.LookupEnv(prefix + key); ok {
 		if b, err := strconv.ParseBool(v); err == nil {
 			*value = &b
+			return true
+		}
+	}
+	return false
+}
+
+func setIntFromEnv(key, prefix string, value *int) bool {
+	if v, ok := os.LookupEnv(prefix + key); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			*value = i
 			return true
 		}
 	}

--- a/server/handler/eval_options_test.go
+++ b/server/handler/eval_options_test.go
@@ -1,0 +1,327 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/approval"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullEvaluationOptions_SetValuesFromEnv(t *testing.T) {
+	tests := map[string]struct {
+		Env         map[string]string
+		SetExpected func(*PullEvaluationOptions)
+	}{
+		"PolicyPath": {
+			Env: map[string]string{"PEO_POLICY_PATH": "test/policy.yml"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.PolicyPath = "test/policy.yml"
+			},
+		},
+		"SharedRepository": {
+			Env: map[string]string{"PEO_SHARED_REPOSITORY": "settings"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.SharedRepository = ptr("settings")
+			},
+		},
+		"SharedPolicyPath": {
+			Env: map[string]string{"PEO_SHARED_POLICY_PATH": "configs/policy-bot/policy.yml"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.SharedPolicyPath = ptr("configs/policy-bot/policy.yml")
+			},
+		},
+		"StatusCheckContext": {
+			Env: map[string]string{"PEO_STATUS_CHECK_CONTEXT": "custom-policy-bot"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.StatusCheckContext = "custom-policy-bot"
+			},
+		},
+		"ForceSharedPolicy": {
+			Env: map[string]string{"PEO_FORCE_SHARED_POLICY": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ForceSharedPolicy = true
+			},
+		},
+		"ExpandRequiredReviewers": {
+			Env: map[string]string{"PEO_EXPAND_REQUIRED_REVIEWERS": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ExpandRequiredReviewers = true
+			},
+		},
+		"StrictReviewDismissal": {
+			Env: map[string]string{"PEO_STRICT_REVIEW_DISMISSAL": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.StrictReviewDismissal = true
+			},
+		},
+		"PostInsecureStatusChecks": {
+			Env: map[string]string{"PEO_POST_INSECURE_STATUS_CHECKS": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.PostInsecureStatusChecks = true
+			},
+		},
+		"IgnoreEditedComments": {
+			Env: map[string]string{"PEO_IGNORE_EDITED_COMMENTS": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.IgnoreEditedComments = ptr(true)
+			},
+		},
+		"ApprovalDefaults.Options.AllowAuthor": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_ALLOW_AUTHOR": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						AllowAuthor: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.AllowContributor": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_ALLOW_CONTRIBUTOR": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						AllowContributor: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.AllowNonAuthorContributor": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_ALLOW_NON_AUTHOR_CONTRIBUTOR": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						AllowNonAuthorContributor: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.InvalidateOnPush": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_INVALIDATE_ON_PUSH": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						InvalidateOnPush: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreEditedComments": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_EDITED_COMMENTS": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreEditedComments: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreUpdateMerges": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_UPDATE_MERGES": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreUpdateMerges: ptr(true),
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreCommitsBy.Users": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_COMMITS_BY_USERS": "bot-user,ci-user"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreCommitsBy: &common.Actors{
+							Users: []string{"bot-user", "ci-user"},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreCommitsBy.Teams": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_COMMITS_BY_TEAMS": "org/bots,org/ci"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreCommitsBy: &common.Actors{
+							Teams: []string{"org/bots", "org/ci"},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreCommitsBy.Organizations": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_COMMITS_BY_ORGANIZATIONS": "bot-org,automation-org"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreCommitsBy: &common.Actors{
+							Organizations: []string{"bot-org", "automation-org"},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.IgnoreCommitsBy.Permissions": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_IGNORE_COMMITS_BY_PERMISSIONS": "admin,write"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						IgnoreCommitsBy: &common.Actors{
+							Permissions: []pull.Permission{pull.PermissionAdmin, pull.PermissionWrite},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.RequestReview.Enabled": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_REQUEST_REVIEW_ENABLED": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						RequestReview: &approval.RequestReview{
+							Enabled: true,
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.RequestReview.Mode": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_REQUEST_REVIEW_MODE": "random"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						RequestReview: &approval.RequestReview{
+							Mode: "random",
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.RequestReview.Count": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_REQUEST_REVIEW_COUNT": "3"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						RequestReview: &approval.RequestReview{
+							Count: 3,
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.Methods.Comments": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_METHODS_COMMENTS": "LGTM,approved"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						Methods: &common.Methods{
+							Comments: []string{"LGTM", "approved"},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.Methods.CommentPatterns": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_METHODS_COMMENT_PATTERNS": "^looks good,^approved by"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						Methods: &common.Methods{
+							CommentPatterns: []common.Regexp{
+								common.NewCompiledRegexp(regexp.MustCompile("^looks good")),
+								common.NewCompiledRegexp(regexp.MustCompile("^approved by")),
+							},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.Methods.GithubReview": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_METHODS_GITHUB_REVIEW": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						Methods: &common.Methods{
+							GithubReview: ptr(true),
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.Methods.GithubReviewCommentPatterns": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_METHODS_GITHUB_REVIEW_COMMENT_PATTERNS": "^approved,^LGTM"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						Methods: &common.Methods{
+							GithubReviewCommentPatterns: []common.Regexp{
+								common.NewCompiledRegexp(regexp.MustCompile("^approved")),
+								common.NewCompiledRegexp(regexp.MustCompile("^LGTM")),
+							},
+						},
+					},
+				}
+			},
+		},
+		"ApprovalDefaults.Options.Methods.BodyPatterns": {
+			Env: map[string]string{"PEO_APPROVAL_DEFAULTS_OPTIONS_METHODS_BODY_PATTERNS": "(?m)^Approved-By:,(?m)^Signed-Off-By:"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.ApprovalDefaults = &approval.Defaults{
+					Options: &approval.Options{
+						Methods: &common.Methods{
+							BodyPatterns: []common.Regexp{
+								common.NewCompiledRegexp(regexp.MustCompile("(?m)^Approved-By:")),
+								common.NewCompiledRegexp(regexp.MustCompile("(?m)^Signed-Off-By:")),
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range test.Env {
+				t.Setenv(k, v)
+			}
+
+			opts := PullEvaluationOptions{}
+			opts.SetValuesFromEnv("PEO_")
+
+			// Explicitly set defaults to avoid calling `fillDefaults` on both
+			// the input and the output and hiding potential bugs
+			expected := PullEvaluationOptions{
+				PolicyPath:         DefaultPolicyPath,
+				SharedRepository:   ptr(DefaultSharedRepository),
+				SharedPolicyPath:   ptr(DefaultSharedPolicyPath),
+				StatusCheckContext: DefaultStatusCheckContext,
+			}
+			test.SetExpected(&expected)
+
+			assert.Equal(t, expected, opts, "incorrect options set from environment")
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -126,6 +126,7 @@ func (h *Simulate) getSimulatedResult(ctx context.Context, installation githubap
 
 	opts := &policy.GlobalOptions{
 		IgnoreEditedComments: h.PullOpts.IgnoreEditedComments,
+		ApprovalDefaults:     h.PullOpts.ApprovalDefaults,
 	}
 
 	evaluator, err := policy.ParsePolicy(config.Config, opts)


### PR DESCRIPTION
Polices and server administrators can now define default values for rule options that apply to all rules in the policy or all rules globally, respectively. Rules can still override default values as needed.

This will make it much easier to do things like make sure all rules are invalidated by pushes or use custom comments for approval.

Closes #41.

