### PR TITLE
feat(go-predicate): customize

### DIFF
--- a/config/policy-examples/new-predicates.yml
+++ b/config/policy-examples/new-predicates.yml
@@ -1,0 +1,76 @@
+# Example policy demonstrating the three new predicates:
+# - changed_files_count: Count changed files with filters
+# - commit_count: Count total commits in a PR
+# - commit_messages: Match commit message patterns
+
+policy:
+  approval:
+    - name: Small changes auto-approve
+      description: PRs with fewer than 20 files are automatically approved
+      requires:
+        count: 0  # Auto-approve
+      if:
+        changed_files_count:
+          total: "< 20"
+
+    - name: Large changes with exception label
+      description: PRs with 20+ files but have exception label are approved
+      requires:
+        count: 0  # Auto-approve with label
+      if:
+        has_labels:
+          labels:
+            - "exception"
+        changed_files_count:
+          total: ">= 20"
+
+    - name: Large changes without exception need approval
+      description: PRs with 20+ files without exception label need admin approval
+      requires:
+        count: 1
+        admins: true
+      if:
+        changed_files_count:
+          total: ">= 20"
+
+    - name: Keep PRs small - auto approve
+      description: PRs with 10 or fewer commits are automatically approved
+      requires:
+        count: 0  # Auto-approve
+      if:
+        commit_count:
+          total: "<= 10"
+
+    - name: General approval not requiring JIRA
+      description: Standard PRs don't need JIRA tickets in commits
+      requires:
+        count: 1
+        admins: true
+
+    - name: Check for breaking changes
+      description: PRs with breaking changes need special review
+      requires:
+        count: 2
+        teams:
+          - "org/breaking-change-reviewers"
+      if:
+        commit_messages:
+          mode: any
+          scope: body
+          matches:
+            - "(?i)breaking change"
+
+    - name: Documentation changes need fewer reviews
+      description: Documentation-only changes need just one approval
+      requires:
+        count: 1
+        admins: true
+      if:
+        changed_files_count:
+          total: "< 100"
+          files:
+            include:
+              - "^docs/.*"
+            exclude:
+              - "^src/.*"
+              - "^test/.*"

--- a/policy/predicate/changed_files_count.go
+++ b/policy/predicate/changed_files_count.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type ChangedFilesCount struct {
+	Total    ComparisonExpr              `yaml:"total,omitempty"`
+	Added    ComparisonExpr              `yaml:"added,omitempty"`
+	Modified ComparisonExpr              `yaml:"modified,omitempty"`
+	Deleted  ComparisonExpr              `yaml:"deleted,omitempty"`
+	Files    ChangedFilesCountFileFilter `yaml:"files,omitempty"`
+}
+
+type ChangedFilesCountFileFilter struct {
+	Include []common.Regexp `yaml:"include,omitempty"`
+	Exclude []common.Regexp `yaml:"exclude,omitempty"`
+}
+
+func (ff ChangedFilesCountFileFilter) IsZero() bool {
+	return len(ff.Include) == 0 && len(ff.Exclude) == 0
+}
+
+func (ff ChangedFilesCountFileFilter) MatchesFile(filename string) bool {
+	if len(ff.Exclude) > 0 && anyMatches(ff.Exclude, filename) {
+		return false
+	}
+	if len(ff.Include) > 0 && !anyMatches(ff.Include, filename) {
+		return false
+	}
+	return true
+}
+
+var _ Predicate = &ChangedFilesCount{}
+
+func (pred *ChangedFilesCount) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "changed files",
+		ConditionPhrase: "meet",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	files, err := prctx.ChangedFiles()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list changed files")
+	}
+
+	// Count files by status
+	var totalCount, addedCount, modifiedCount, deletedCount int64
+	for _, f := range files {
+		if !pred.Files.MatchesFile(f.Filename) {
+			continue
+		}
+
+		totalCount++
+		switch f.Status {
+		case pull.FileAdded:
+			addedCount++
+		case pull.FileModified:
+			modifiedCount++
+		case pull.FileDeleted:
+			deletedCount++
+		}
+	}
+
+	// Add file filter information if specified
+	if len(pred.Files.Include) > 0 {
+		predicateResult.ConditionsMap["in files matching"] = getPathStrings(pred.Files.Include)
+	}
+	if len(pred.Files.Exclude) > 0 {
+		predicateResult.ConditionsMap["excluding files matching"] = getPathStrings(pred.Files.Exclude)
+	}
+
+	const conditionKey = "the file count conditions"
+
+	// Check total condition
+	if !pred.Total.IsEmpty() {
+		value := fmt.Sprintf("total %d", totalCount)
+		cond := fmt.Sprintf("total files %s", pred.Total.String())
+
+		if pred.Total.Evaluate(totalCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check added condition
+	if !pred.Added.IsEmpty() {
+		value := fmt.Sprintf("added %d", addedCount)
+		cond := fmt.Sprintf("added files %s", pred.Added.String())
+
+		if pred.Added.Evaluate(addedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check modified condition
+	if !pred.Modified.IsEmpty() {
+		value := fmt.Sprintf("modified %d", modifiedCount)
+		cond := fmt.Sprintf("modified files %s", pred.Modified.String())
+
+		if pred.Modified.Evaluate(modifiedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check deleted condition
+	if !pred.Deleted.IsEmpty() {
+		value := fmt.Sprintf("deleted %d", deletedCount)
+		cond := fmt.Sprintf("deleted files %s", pred.Deleted.String())
+
+		if pred.Deleted.Evaluate(deletedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred *ChangedFilesCount) Trigger() common.Trigger {
+	return common.TriggerCommit
+}

--- a/policy/predicate/changed_files_count_test.go
+++ b/policy/predicate/changed_files_count_test.go
@@ -1,0 +1,254 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChangedFilesCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("totalCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileDeleted},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 files should be < 5")
+			assert.Contains(t, result.Values, "total 3")
+		}
+	})
+
+	t.Run("addedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Added: ComparisonExpr{Op: OpLessThan, Value: 3},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileAdded},
+				{Filename: "file3.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 added files should be < 3")
+			assert.Contains(t, result.Values, "added 2")
+		}
+	})
+
+	t.Run("modifiedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Modified: ComparisonExpr{Op: OpEquals, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileModified},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileAdded},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 modified files should = 2")
+			assert.Contains(t, result.Values, "modified 2")
+		}
+	})
+
+	t.Run("deletedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Deleted: ComparisonExpr{Op: OpGreaterThan, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileDeleted},
+				{Filename: "file2.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "1 deleted file should be > 0")
+			assert.Contains(t, result.Values, "deleted 1")
+		}
+	})
+
+	t.Run("withIncludeFilter", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 3},
+			Files: ChangedFilesCountFileFilter{
+				Include: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile("^src/.*")),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "src/file1.go", Status: pull.FileAdded},
+				{Filename: "src/file2.go", Status: pull.FileModified},
+				{Filename: "docs/readme.md", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 files in src/ should be < 3")
+			assert.Contains(t, result.Values, "total 2")
+		}
+	})
+
+	t.Run("withExcludeFilter", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 2},
+			Files: ChangedFilesCountFileFilter{
+				Exclude: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile(`.*\.md$`)),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "readme.md", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 non-md files should = 2")
+			assert.Contains(t, result.Values, "total 2")
+		}
+	})
+
+	t.Run("withIncludeAndExclude", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Added: ComparisonExpr{Op: OpEquals, Value: 1},
+			Files: ChangedFilesCountFileFilter{
+				Include: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile("^src/.*")),
+				},
+				Exclude: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile(`.*_test\.go$`)),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "src/file1.go", Status: pull.FileAdded},
+				{Filename: "src/file1_test.go", Status: pull.FileAdded},
+				{Filename: "docs/readme.md", Status: pull.FileAdded},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "1 added file in src/ (excluding tests) should = 1")
+			assert.Contains(t, result.Values, "added 1")
+		}
+	})
+
+	t.Run("multipleConditionsFirstSatisfied", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total:    ComparisonExpr{Op: OpLessThan, Value: 5},
+			Added:    ComparisonExpr{Op: OpGreaterThan, Value: 10},
+			Modified: ComparisonExpr{Op: OpEquals, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "total condition satisfied first")
+			assert.Contains(t, result.Values, "total 3")
+		}
+	})
+
+	t.Run("noneConditionsSatisfied", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpGreaterThan, Value: 10},
+			Added: ComparisonExpr{Op: OpGreaterThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no conditions should be satisfied")
+			assert.Contains(t, result.Values, "total 2")
+			assert.Contains(t, result.Values, "added 1")
+		}
+	})
+
+	t.Run("zeroFiles", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "0 files should = 0")
+			assert.Contains(t, result.Values, "total 0")
+		}
+	})
+}
+
+func TestChangedFilesCountTrigger(t *testing.T) {
+	p := &ChangedFilesCount{
+		Total: ComparisonExpr{Op: OpLessThan, Value: 20},
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/commit_count.go
+++ b/policy/predicate/commit_count.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type CommitCount struct {
+	Total ComparisonExpr `yaml:"total,omitempty"`
+}
+
+var _ Predicate = &CommitCount{}
+
+func (pred *CommitCount) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "commits",
+		ConditionPhrase: "meet",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	commits, err := prctx.Commits()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list commits")
+	}
+
+	count := int64(len(commits))
+
+	if !pred.Total.IsEmpty() {
+		value := fmt.Sprintf("%d", count)
+		cond := fmt.Sprintf("total commits %s", pred.Total.String())
+
+		predicateResult.Values = []string{value}
+		predicateResult.ConditionsMap["the commit count condition"] = []string{cond}
+
+		if pred.Total.Evaluate(count) {
+			predicateResult.Satisfied = true
+			predicateResult.Description = fmt.Sprintf("PR has %d commits", count)
+		} else {
+			predicateResult.Satisfied = false
+			predicateResult.Description = fmt.Sprintf("PR has %d commits, which does not meet the condition", count)
+		}
+
+		return &predicateResult, nil
+	}
+
+	// If no conditions are specified, default to unsatisfied
+	predicateResult.Satisfied = false
+	predicateResult.Description = "No commit count conditions specified"
+	return &predicateResult, nil
+}
+
+func (pred *CommitCount) Trigger() common.Trigger {
+	return common.TriggerCommit
+}

--- a/policy/predicate/commit_count_test.go
+++ b/policy/predicate/commit_count_test.go
@@ -1,0 +1,148 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("lessThan", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should be < 5")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("greaterThan", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpGreaterThan, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should be > 2")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("equals", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 3},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should = 3")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("notSatisfied", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "3 commits should not be < 2")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("zeroCommits", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "0 commits should = 0")
+			assert.Equal(t, []string{"0"}, result.Values)
+		}
+	})
+
+	t.Run("noConditions", func(t *testing.T) {
+		p := &CommitCount{}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "should be unsatisfied when no conditions specified")
+		}
+	})
+}
+
+func TestCommitCountTrigger(t *testing.T) {
+	p := &CommitCount{
+		Total: ComparisonExpr{Op: OpLessThan, Value: 10},
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/commit_messages.go
+++ b/policy/predicate/commit_messages.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type CommitMessages struct {
+	Mode       string          `yaml:"mode,omitempty"`
+	Scope      string          `yaml:"scope,omitempty"`
+	Matches    []common.Regexp `yaml:"matches,omitempty"`
+	NotMatches []common.Regexp `yaml:"not_matches,omitempty"`
+}
+
+var _ Predicate = &CommitMessages{}
+
+func (pred *CommitMessages) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	commits, err := prctx.Commits()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list commits")
+	}
+
+	// Default mode is "all"
+	mode := pred.Mode
+	if mode == "" {
+		mode = "all"
+	}
+
+	// Default scope is "subject"
+	scope := pred.Scope
+	if scope == "" {
+		scope = "subject"
+	}
+
+	// Validate mode
+	if mode != "all" && mode != "any" {
+		return nil, errors.Errorf("invalid mode %q: must be 'all' or 'any'", mode)
+	}
+
+	// Validate scope
+	if scope != "subject" && scope != "body" && scope != "full" {
+		return nil, errors.Errorf("invalid scope %q: must be 'subject', 'body', or 'full'", scope)
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "commit messages",
+		ConditionPhrase: "match",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	// Add pattern information
+	if len(pred.Matches) > 0 {
+		predicateResult.ConditionsMap["matches patterns"] = getPatternStrings(pred.Matches)
+	}
+	if len(pred.NotMatches) > 0 {
+		predicateResult.ConditionsMap["does not match patterns"] = getPatternStrings(pred.NotMatches)
+	}
+
+	// Add mode and scope information
+	predicateResult.ConditionsMap["evaluation mode"] = []string{mode}
+	predicateResult.ConditionsMap["message scope"] = []string{scope}
+
+	if len(commits) == 0 {
+		predicateResult.Satisfied = false
+		predicateResult.Description = "No commits found in pull request"
+		return &predicateResult, nil
+	}
+
+	// Collect commit messages
+	commitMessages := make([]string, 0, len(commits))
+	for _, c := range commits {
+		msg := pred.getCommitMessage(c, scope)
+		shaShort := c.SHA
+		if len(shaShort) > 7 {
+			shaShort = shaShort[:7]
+		}
+		commitMessages = append(commitMessages, fmt.Sprintf("%s: %s", shaShort, msg))
+	}
+	predicateResult.Values = commitMessages
+
+	// Evaluate based on mode
+	if mode == "all" {
+		// All commits must satisfy the conditions
+		for _, c := range commits {
+			msg := pred.getCommitMessage(c, scope)
+			if !pred.messageMatches(msg) {
+				shaShort := c.SHA
+				if len(shaShort) > 7 {
+					shaShort = shaShort[:7]
+				}
+				predicateResult.Satisfied = false
+				predicateResult.Description = fmt.Sprintf("Commit %s does not match the required patterns", shaShort)
+				return &predicateResult, nil
+			}
+		}
+		predicateResult.Satisfied = true
+		predicateResult.Description = fmt.Sprintf("All %d commits match the required patterns", len(commits))
+		return &predicateResult, nil
+	}
+
+	// mode == "any": At least one commit must satisfy the conditions
+	for _, c := range commits {
+		msg := pred.getCommitMessage(c, scope)
+		if pred.messageMatches(msg) {
+			shaShort := c.SHA
+			if len(shaShort) > 7 {
+				shaShort = shaShort[:7]
+			}
+			predicateResult.Satisfied = true
+			predicateResult.Description = fmt.Sprintf("Commit %s matches the required patterns", shaShort)
+			return &predicateResult, nil
+		}
+	}
+	predicateResult.Satisfied = false
+	predicateResult.Description = "No commits match the required patterns"
+	return &predicateResult, nil
+}
+
+func (pred *CommitMessages) getCommitMessage(c *pull.Commit, scope string) string {
+	switch scope {
+	case "subject":
+		return c.MessageHeadline
+	case "body":
+		return c.MessageBody
+	case "full":
+		if c.MessageBody == "" {
+			return c.MessageHeadline
+		}
+		return c.MessageHeadline + "\n\n" + c.MessageBody
+	default:
+		return c.MessageHeadline
+	}
+}
+
+func (pred *CommitMessages) messageMatches(msg string) bool {
+	// If there are Matches patterns, at least one must match
+	if len(pred.Matches) > 0 {
+		if !anyMatches(pred.Matches, msg) {
+			return false
+		}
+	}
+
+	// If there are NotMatches patterns, none must match
+	if len(pred.NotMatches) > 0 {
+		if anyMatches(pred.NotMatches, msg) {
+			return false
+		}
+	}
+
+	// If we have patterns and passed all checks, it's a match
+	// If we have no patterns at all, consider it a match (vacuous truth)
+	return true
+}
+
+func (pred *CommitMessages) Trigger() common.Trigger {
+	return common.TriggerCommit
+}
+
+func getPatternStrings(patterns []common.Regexp) []string {
+	var strs []string
+	for _, r := range patterns {
+		strs = append(strs, r.String())
+	}
+	return strs
+}

--- a/policy/predicate/commit_messages_test.go
+++ b/policy/predicate/commit_messages_test.go
@@ -1,0 +1,372 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitMessages(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allModeSubjectMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "JIRA-123: Add feature"},
+				{SHA: "def456", MessageHeadline: "JIRA-456: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "all commits should match pattern")
+			assert.Contains(t, result.Description, "All 2 commits")
+		}
+	})
+
+	t.Run("allModeOneDoesNotMatch", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "JIRA-123: Add feature"},
+				{SHA: "def456", MessageHeadline: "Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "one commit does not match")
+			assert.Contains(t, result.Description, "def456")
+		}
+	})
+
+	t.Run("anyModeOneMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Fix typo"},
+				{SHA: "def456", MessageHeadline: "JIRA-456: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "at least one commit matches")
+			assert.Contains(t, result.Description, "def456")
+		}
+	})
+
+	t.Run("anyModeNoneMatch", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Fix typo"},
+				{SHA: "def456", MessageHeadline: "Update docs"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no commits match")
+			assert.Contains(t, result.Description, "No commits match")
+		}
+	})
+
+	t.Run("notMatchesPattern", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP|fixup")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Add feature"},
+				{SHA: "def456", MessageHeadline: "Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "no commits contain WIP or fixup")
+		}
+	})
+
+	t.Run("notMatchesFails", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP|fixup")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Add feature"},
+				{SHA: "def456", MessageHeadline: "WIP: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "one commit contains WIP")
+		}
+	})
+
+	t.Run("matchesAndNotMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^[A-Z]+")),
+			},
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "FEAT: Add feature"},
+				{SHA: "def456", MessageHeadline: "FIX: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "all start with uppercase and none have WIP")
+		}
+	})
+
+	t.Run("bodyScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "body",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("(?i)breaking change")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{
+					SHA:             "abc123",
+					MessageHeadline: "Update API",
+					MessageBody:     "This is a breaking change to the API",
+				},
+				{
+					SHA:             "def456",
+					MessageHeadline: "Fix bug",
+					MessageBody:     "Minor bug fix",
+				},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "one commit body mentions breaking change")
+		}
+	})
+
+	t.Run("fullScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "full",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("important")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{
+					SHA:             "abc123",
+					MessageHeadline: "Update feature",
+					MessageBody:     "This is an important update",
+				},
+				{
+					SHA:             "def456",
+					MessageHeadline: "Important fix",
+					MessageBody:     "",
+				},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "commits contain 'important' in subject or body")
+		}
+	})
+
+	t.Run("defaultMode", func(t *testing.T) {
+		p := &CommitMessages{
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^feat:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "feat: add feature"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "default mode should be 'all'")
+		}
+	})
+
+	t.Run("defaultScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode: "all",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^feat:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "feat: add feature", MessageBody: "details"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "default scope should be 'subject'")
+		}
+	})
+
+	t.Run("noCommits", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(".*")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no commits should fail")
+			assert.Contains(t, result.Description, "No commits found")
+		}
+	})
+
+	t.Run("invalidMode", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "invalid",
+			Scope: "subject",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "test"},
+			},
+		}
+
+		_, err := p.Evaluate(ctx, prctx)
+		assert.Error(t, err, "invalid mode should return error")
+		assert.Contains(t, err.Error(), "invalid mode")
+	})
+
+	t.Run("invalidScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "invalid",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "test"},
+			},
+		}
+
+		_, err := p.Evaluate(ctx, prctx)
+		assert.Error(t, err, "invalid scope should return error")
+		assert.Contains(t, err.Error(), "invalid scope")
+	})
+
+	t.Run("noPatterns", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "any message"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "no patterns should always pass")
+		}
+	})
+}
+
+func TestCommitMessagesTrigger(t *testing.T) {
+	p := &CommitMessages{
+		Mode:  "all",
+		Scope: "subject",
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -33,6 +33,10 @@ type Predicates struct {
 
 	ModifiedLines *ModifiedLines `yaml:"modified_lines,omitempty"`
 
+	ChangedFilesCount *ChangedFilesCount `yaml:"changed_files_count,omitempty"`
+	CommitCount       *CommitCount       `yaml:"commit_count,omitempty"`
+	CommitMessages    *CommitMessages    `yaml:"commit_messages,omitempty"`
+
 	HasStatus *HasStatus `yaml:"has_status,omitempty"`
 	// `has_successful_status` is a deprecated field that is kept for backwards
 	// compatibility.  `has_status` replaces it, and can accept any conclusion
@@ -102,6 +106,18 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.ModifiedLines != nil {
 		ps = append(ps, Predicate(p.ModifiedLines))
+	}
+
+	if p.ChangedFilesCount != nil {
+		ps = append(ps, Predicate(p.ChangedFilesCount))
+	}
+
+	if p.CommitCount != nil {
+		ps = append(ps, Predicate(p.CommitCount))
+	}
+
+	if p.CommitMessages != nil {
+		ps = append(ps, Predicate(p.CommitMessages))
 	}
 
 	if p.HasStatus != nil {

--- a/pull/context.go
+++ b/pull/context.go
@@ -161,6 +161,12 @@ type Commit struct {
 	// committer is not a real user.
 	Committer string
 
+	// MessageHeadline is the first line of the commit message (subject).
+	MessageHeadline string
+
+	// MessageBody is the commit message body (everything after the subject).
+	MessageBody string
+
 	// Signature is the signature and details that was extracted from the commit.
 	// It is nil if the commit has no signature
 	Signature *Signature

--- a/pull/github.go
+++ b/pull/github.go
@@ -1211,6 +1211,8 @@ type v4Commit struct {
 	Author          v4GitActor
 	Committer       v4GitActor
 	CommittedViaWeb bool
+	MessageHeadline string
+	MessageBody     string
 	Parents         struct {
 		Nodes []struct {
 			OID string
@@ -1236,6 +1238,8 @@ func (c *v4Commit) ToCommit() *Commit {
 		CommittedViaWeb: c.CommittedViaWeb,
 		Author:          c.Author.User.GetV3Login(),
 		Committer:       c.Committer.User.GetV3Login(),
+		MessageHeadline: c.MessageHeadline,
+		MessageBody:     c.MessageBody,
 		Signature:       signature,
 	}
 }


### PR DESCRIPTION
## Before this PR
Policy-bot lacked predicates to enforce policies based on:
- Number of changed files in a PR (total, added, modified, deleted)
- Number of commits in a PR
- Commit message patterns and conventions

This made it difficult to implement common policies like:
- Auto-approving small PRs
- Requiring additional review for large changes
- Enforcing commit message conventions (e.g., JIRA ticket references)
- Detecting breaking changes mentioned in commit messages

Referenced issue: https://github.com/palantir/policy-bot/issues/1062

## After this PR
Adds three new built-in predicates to enable more granular PR policies:

### 1. `changed_files_count` - Count changed files with advanced filtering
```yaml
changed_files_count:
  total: "< 20"      # Total changed files
  added: "<= 5"      # Newly added files
  modified: "> 0"    # Modified files
  deleted: "< 2"     # Deleted files
  files:
    include:
      - "^src/.*"    # Only count files matching patterns
    exclude:
      - "^docs/.*"   # Exclude files matching patterns
```

### 2. `commit_count` - Count total commits in a PR
```yaml
commit_count:
  total: "<= 10"     # Limit number of commits
```

### 3. `commit_messages` - Match commit message patterns
```yaml
commit_messages:
  mode: all          # "all" (every commit) or "any" (at least one)
  scope: subject     # "subject", "body", or "full"
  matches:
    - "^JIRA-[0-9]+:"  # Required patterns
  not_matches:
    - "(?i)WIP|fixup"  # Forbidden patterns
```

**Implementation Details:**
- All predicates follow existing code patterns and architecture
- Added `MessageHeadline` and `MessageBody` fields to `Commit` struct for `commit_messages` predicate
- Updated GraphQL queries to fetch commit message data
- Comprehensive test coverage for all three predicates
- All tests pass: `./godelw verify` ✅
- Example policy configuration provided in new-predicates.yml

**Example Use Cases:**
- Auto-approve PRs with < 20 files
- Auto-approve PRs with ≤ 10 commits
- Require admin approval for large PRs (≥ 20 files) unless they have an "exception" label
- Enforce JIRA ticket references in commit messages
- Flag PRs with breaking changes mentioned in commit bodies
- Different approval requirements for documentation vs code changes

==COMMIT_MSG==
feat: Add changed_files_count, commit_count, and commit_messages predicates

Implements three new predicates requested in issue #1062:
- changed_files_count: Count changed files with filtering by status and path patterns
- commit_count: Count total commits in a PR with comparison operators
- commit_messages: Match commit message patterns with configurable mode and scope

Also adds MessageHeadline and MessageBody fields to Commit struct to support
commit message pattern matching.

All predicates include comprehensive tests and follow existing code patterns.
==COMMIT_MSG==

## Possible downsides?

**Breaking Changes:**
- None. The new predicates are opt-in and don't affect existing policies.

**GraphQL Query Changes:**
- Added `messageHeadline` and `messageBody` fields to commit queries. This increases the data fetched per commit but is necessary for the `commit_messages` predicate functionality.

**Performance Considerations:**
- File filtering in `changed_files_count` iterates through all changed files, which should have minimal impact for typical PRs (< 1000 files).
- Commit message matching in `commit_messages` iterates through all commits, efficient for typical PRs (< 100 commits).

**API Compatibility:**
- The `Commit` struct now includes two new fields (`MessageHeadline`, `MessageBody`). This is backward compatible as Go's zero values (empty strings) are safe defaults.