### PR TITLE
feat: add commit_count predicate

### DIFF
--- a/policy/predicate/commit_count.go
+++ b/policy/predicate/commit_count.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type CommitCount struct {
+	Total ComparisonExpr `yaml:"total,omitempty"`
+}
+
+var _ Predicate = &CommitCount{}
+
+func (pred *CommitCount) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "commits",
+		ConditionPhrase: "meet",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	commits, err := prctx.Commits()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list commits")
+	}
+
+	count := int64(len(commits))
+
+	if !pred.Total.IsEmpty() {
+		value := fmt.Sprintf("%d", count)
+		cond := fmt.Sprintf("total commits %s", pred.Total.String())
+
+		predicateResult.Values = []string{value}
+		predicateResult.ConditionsMap["the commit count condition"] = []string{cond}
+
+		if pred.Total.Evaluate(count) {
+			predicateResult.Satisfied = true
+			predicateResult.Description = fmt.Sprintf("PR has %d commits", count)
+		} else {
+			predicateResult.Satisfied = false
+			predicateResult.Description = fmt.Sprintf("PR has %d commits, which does not meet the condition", count)
+		}
+
+		return &predicateResult, nil
+	}
+
+	// If no conditions are specified, default to unsatisfied
+	predicateResult.Satisfied = false
+	predicateResult.Description = "No commit count conditions specified"
+	return &predicateResult, nil
+}
+
+func (pred *CommitCount) Trigger() common.Trigger {
+	return common.TriggerCommit
+}

--- a/policy/predicate/commit_count_test.go
+++ b/policy/predicate/commit_count_test.go
@@ -1,0 +1,148 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("lessThan", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should be < 5")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("greaterThan", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpGreaterThan, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should be > 2")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("equals", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 3},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 commits should = 3")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("notSatisfied", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+				{SHA: "def456"},
+				{SHA: "ghi789"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "3 commits should not be < 2")
+			assert.Equal(t, []string{"3"}, result.Values)
+		}
+	})
+
+	t.Run("zeroCommits", func(t *testing.T) {
+		p := &CommitCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "0 commits should = 0")
+			assert.Equal(t, []string{"0"}, result.Values)
+		}
+	})
+
+	t.Run("noConditions", func(t *testing.T) {
+		p := &CommitCount{}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "should be unsatisfied when no conditions specified")
+		}
+	})
+}
+
+func TestCommitCountTrigger(t *testing.T) {
+	p := &CommitCount{
+		Total: ComparisonExpr{Op: OpLessThan, Value: 10},
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -33,6 +33,8 @@ type Predicates struct {
 
 	ModifiedLines *ModifiedLines `yaml:"modified_lines,omitempty"`
 
+	CommitCount *CommitCount `yaml:"commit_count,omitempty"`
+
 	HasStatus *HasStatus `yaml:"has_status,omitempty"`
 	// `has_successful_status` is a deprecated field that is kept for backwards
 	// compatibility.  `has_status` replaces it, and can accept any conclusion
@@ -102,6 +104,10 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.ModifiedLines != nil {
 		ps = append(ps, Predicate(p.ModifiedLines))
+	}
+
+	if p.CommitCount != nil {
+		ps = append(ps, Predicate(p.CommitCount))
 	}
 
 	if p.HasStatus != nil {


### PR DESCRIPTION
Add predicate to count total commits in a PR with comparison operators (<, >, =). Implements part of GitHub issue #1062.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

