### PR TITLE
feat: add changed_files_count predicate

### DIFF
--- a/policy/predicate/changed_files_count.go
+++ b/policy/predicate/changed_files_count.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type ChangedFilesCount struct {
+	Total    ComparisonExpr              `yaml:"total,omitempty"`
+	Added    ComparisonExpr              `yaml:"added,omitempty"`
+	Modified ComparisonExpr              `yaml:"modified,omitempty"`
+	Deleted  ComparisonExpr              `yaml:"deleted,omitempty"`
+	Files    ChangedFilesCountFileFilter `yaml:"files,omitempty"`
+}
+
+type ChangedFilesCountFileFilter struct {
+	Include []common.Regexp `yaml:"include,omitempty"`
+	Exclude []common.Regexp `yaml:"exclude,omitempty"`
+}
+
+func (ff ChangedFilesCountFileFilter) IsZero() bool {
+	return len(ff.Include) == 0 && len(ff.Exclude) == 0
+}
+
+func (ff ChangedFilesCountFileFilter) MatchesFile(filename string) bool {
+	if len(ff.Exclude) > 0 && anyMatches(ff.Exclude, filename) {
+		return false
+	}
+	if len(ff.Include) > 0 && !anyMatches(ff.Include, filename) {
+		return false
+	}
+	return true
+}
+
+var _ Predicate = &ChangedFilesCount{}
+
+func (pred *ChangedFilesCount) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "changed files",
+		ConditionPhrase: "meet",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	files, err := prctx.ChangedFiles()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list changed files")
+	}
+
+	// Count files by status
+	var totalCount, addedCount, modifiedCount, deletedCount int64
+	for _, f := range files {
+		if !pred.Files.MatchesFile(f.Filename) {
+			continue
+		}
+
+		totalCount++
+		switch f.Status {
+		case pull.FileAdded:
+			addedCount++
+		case pull.FileModified:
+			modifiedCount++
+		case pull.FileDeleted:
+			deletedCount++
+		}
+	}
+
+	// Add file filter information if specified
+	if len(pred.Files.Include) > 0 {
+		predicateResult.ConditionsMap["in files matching"] = getPathStrings(pred.Files.Include)
+	}
+	if len(pred.Files.Exclude) > 0 {
+		predicateResult.ConditionsMap["excluding files matching"] = getPathStrings(pred.Files.Exclude)
+	}
+
+	const conditionKey = "the file count conditions"
+
+	// Check total condition
+	if !pred.Total.IsEmpty() {
+		value := fmt.Sprintf("total %d", totalCount)
+		cond := fmt.Sprintf("total files %s", pred.Total.String())
+
+		if pred.Total.Evaluate(totalCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check added condition
+	if !pred.Added.IsEmpty() {
+		value := fmt.Sprintf("added %d", addedCount)
+		cond := fmt.Sprintf("added files %s", pred.Added.String())
+
+		if pred.Added.Evaluate(addedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check modified condition
+	if !pred.Modified.IsEmpty() {
+		value := fmt.Sprintf("modified %d", modifiedCount)
+		cond := fmt.Sprintf("modified files %s", pred.Modified.String())
+
+		if pred.Modified.Evaluate(modifiedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	// Check deleted condition
+	if !pred.Deleted.IsEmpty() {
+		value := fmt.Sprintf("deleted %d", deletedCount)
+		cond := fmt.Sprintf("deleted files %s", pred.Deleted.String())
+
+		if pred.Deleted.Evaluate(deletedCount) {
+			predicateResult.Values = []string{value}
+			predicateResult.ConditionsMap[conditionKey] = []string{cond}
+			predicateResult.Satisfied = true
+			return &predicateResult, nil
+		}
+
+		predicateResult.Values = append(predicateResult.Values, value)
+		predicateResult.ConditionsMap[conditionKey] = append(predicateResult.ConditionsMap[conditionKey], cond)
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred *ChangedFilesCount) Trigger() common.Trigger {
+	return common.TriggerCommit
+}

--- a/policy/predicate/changed_files_count_test.go
+++ b/policy/predicate/changed_files_count_test.go
@@ -1,0 +1,254 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChangedFilesCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("totalCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileDeleted},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "3 files should be < 5")
+			assert.Contains(t, result.Values, "total 3")
+		}
+	})
+
+	t.Run("addedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Added: ComparisonExpr{Op: OpLessThan, Value: 3},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileAdded},
+				{Filename: "file3.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 added files should be < 3")
+			assert.Contains(t, result.Values, "added 2")
+		}
+	})
+
+	t.Run("modifiedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Modified: ComparisonExpr{Op: OpEquals, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileModified},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileAdded},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 modified files should = 2")
+			assert.Contains(t, result.Values, "modified 2")
+		}
+	})
+
+	t.Run("deletedCount", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Deleted: ComparisonExpr{Op: OpGreaterThan, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileDeleted},
+				{Filename: "file2.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "1 deleted file should be > 0")
+			assert.Contains(t, result.Values, "deleted 1")
+		}
+	})
+
+	t.Run("withIncludeFilter", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpLessThan, Value: 3},
+			Files: ChangedFilesCountFileFilter{
+				Include: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile("^src/.*")),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "src/file1.go", Status: pull.FileAdded},
+				{Filename: "src/file2.go", Status: pull.FileModified},
+				{Filename: "docs/readme.md", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 files in src/ should be < 3")
+			assert.Contains(t, result.Values, "total 2")
+		}
+	})
+
+	t.Run("withExcludeFilter", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 2},
+			Files: ChangedFilesCountFileFilter{
+				Exclude: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile(`.*\.md$`)),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "readme.md", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "2 non-md files should = 2")
+			assert.Contains(t, result.Values, "total 2")
+		}
+	})
+
+	t.Run("withIncludeAndExclude", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Added: ComparisonExpr{Op: OpEquals, Value: 1},
+			Files: ChangedFilesCountFileFilter{
+				Include: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile("^src/.*")),
+				},
+				Exclude: []common.Regexp{
+					common.NewCompiledRegexp(regexp.MustCompile(`.*_test\.go$`)),
+				},
+			},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "src/file1.go", Status: pull.FileAdded},
+				{Filename: "src/file1_test.go", Status: pull.FileAdded},
+				{Filename: "docs/readme.md", Status: pull.FileAdded},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "1 added file in src/ (excluding tests) should = 1")
+			assert.Contains(t, result.Values, "added 1")
+		}
+	})
+
+	t.Run("multipleConditionsFirstSatisfied", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total:    ComparisonExpr{Op: OpLessThan, Value: 5},
+			Added:    ComparisonExpr{Op: OpGreaterThan, Value: 10},
+			Modified: ComparisonExpr{Op: OpEquals, Value: 2},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+				{Filename: "file3.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "total condition satisfied first")
+			assert.Contains(t, result.Values, "total 3")
+		}
+	})
+
+	t.Run("noneConditionsSatisfied", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpGreaterThan, Value: 10},
+			Added: ComparisonExpr{Op: OpGreaterThan, Value: 5},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{
+				{Filename: "file1.go", Status: pull.FileAdded},
+				{Filename: "file2.go", Status: pull.FileModified},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no conditions should be satisfied")
+			assert.Contains(t, result.Values, "total 2")
+			assert.Contains(t, result.Values, "added 1")
+		}
+	})
+
+	t.Run("zeroFiles", func(t *testing.T) {
+		p := &ChangedFilesCount{
+			Total: ComparisonExpr{Op: OpEquals, Value: 0},
+		}
+
+		prctx := &pulltest.Context{
+			ChangedFilesValue: []*pull.File{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "0 files should = 0")
+			assert.Contains(t, result.Values, "total 0")
+		}
+	})
+}
+
+func TestChangedFilesCountTrigger(t *testing.T) {
+	p := &ChangedFilesCount{
+		Total: ComparisonExpr{Op: OpLessThan, Value: 20},
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -33,6 +33,8 @@ type Predicates struct {
 
 	ModifiedLines *ModifiedLines `yaml:"modified_lines,omitempty"`
 
+	ChangedFilesCount *ChangedFilesCount `yaml:"changed_files_count,omitempty"`
+
 	HasStatus *HasStatus `yaml:"has_status,omitempty"`
 	// `has_successful_status` is a deprecated field that is kept for backwards
 	// compatibility.  `has_status` replaces it, and can accept any conclusion
@@ -102,6 +104,10 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.ModifiedLines != nil {
 		ps = append(ps, Predicate(p.ModifiedLines))
+	}
+
+	if p.ChangedFilesCount != nil {
+		ps = append(ps, Predicate(p.ChangedFilesCount))
 	}
 
 	if p.HasStatus != nil {


### PR DESCRIPTION
Add predicate to count changed files by status (total/added/modified/deleted) with path filtering. Implements part of GitHub issue #1062.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

