### PR TITLE
feat: add commit_messages predicate

### DIFF
--- a/policy/predicate/commit_messages.go
+++ b/policy/predicate/commit_messages.go
@@ -1,0 +1,183 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type CommitMessages struct {
+	Mode       string          `yaml:"mode,omitempty"`
+	Scope      string          `yaml:"scope,omitempty"`
+	Matches    []common.Regexp `yaml:"matches,omitempty"`
+	NotMatches []common.Regexp `yaml:"not_matches,omitempty"`
+}
+
+var _ Predicate = &CommitMessages{}
+
+func (pred *CommitMessages) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	commits, err := prctx.Commits()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list commits")
+	}
+
+	// Default mode is "all"
+	mode := pred.Mode
+	if mode == "" {
+		mode = "all"
+	}
+
+	// Default scope is "subject"
+	scope := pred.Scope
+	if scope == "" {
+		scope = "subject"
+	}
+
+	// Validate mode
+	if mode != "all" && mode != "any" {
+		return nil, errors.Errorf("invalid mode %q: must be 'all' or 'any'", mode)
+	}
+
+	// Validate scope
+	if scope != "subject" && scope != "body" && scope != "full" {
+		return nil, errors.Errorf("invalid scope %q: must be 'subject', 'body', or 'full'", scope)
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "commit messages",
+		ConditionPhrase: "match",
+		ConditionsMap:   make(map[string][]string),
+	}
+
+	// Add pattern information
+	if len(pred.Matches) > 0 {
+		predicateResult.ConditionsMap["matches patterns"] = getPatternStrings(pred.Matches)
+	}
+	if len(pred.NotMatches) > 0 {
+		predicateResult.ConditionsMap["does not match patterns"] = getPatternStrings(pred.NotMatches)
+	}
+
+	// Add mode and scope information
+	predicateResult.ConditionsMap["evaluation mode"] = []string{mode}
+	predicateResult.ConditionsMap["message scope"] = []string{scope}
+
+	if len(commits) == 0 {
+		predicateResult.Satisfied = false
+		predicateResult.Description = "No commits found in pull request"
+		return &predicateResult, nil
+	}
+
+	// Collect commit messages
+	commitMessages := make([]string, 0, len(commits))
+	for _, c := range commits {
+		msg := pred.getCommitMessage(c, scope)
+		shaShort := c.SHA
+		if len(shaShort) > 7 {
+			shaShort = shaShort[:7]
+		}
+		commitMessages = append(commitMessages, fmt.Sprintf("%s: %s", shaShort, msg))
+	}
+	predicateResult.Values = commitMessages
+
+	// Evaluate based on mode
+	if mode == "all" {
+		// All commits must satisfy the conditions
+		for _, c := range commits {
+			msg := pred.getCommitMessage(c, scope)
+			if !pred.messageMatches(msg) {
+				shaShort := c.SHA
+				if len(shaShort) > 7 {
+					shaShort = shaShort[:7]
+				}
+				predicateResult.Satisfied = false
+				predicateResult.Description = fmt.Sprintf("Commit %s does not match the required patterns", shaShort)
+				return &predicateResult, nil
+			}
+		}
+		predicateResult.Satisfied = true
+		predicateResult.Description = fmt.Sprintf("All %d commits match the required patterns", len(commits))
+		return &predicateResult, nil
+	}
+
+	// mode == "any": At least one commit must satisfy the conditions
+	for _, c := range commits {
+		msg := pred.getCommitMessage(c, scope)
+		if pred.messageMatches(msg) {
+			shaShort := c.SHA
+			if len(shaShort) > 7 {
+				shaShort = shaShort[:7]
+			}
+			predicateResult.Satisfied = true
+			predicateResult.Description = fmt.Sprintf("Commit %s matches the required patterns", shaShort)
+			return &predicateResult, nil
+		}
+	}
+	predicateResult.Satisfied = false
+	predicateResult.Description = "No commits match the required patterns"
+	return &predicateResult, nil
+}
+
+func (pred *CommitMessages) getCommitMessage(c *pull.Commit, scope string) string {
+	switch scope {
+	case "subject":
+		return c.MessageHeadline
+	case "body":
+		return c.MessageBody
+	case "full":
+		if c.MessageBody == "" {
+			return c.MessageHeadline
+		}
+		return c.MessageHeadline + "\n\n" + c.MessageBody
+	default:
+		return c.MessageHeadline
+	}
+}
+
+func (pred *CommitMessages) messageMatches(msg string) bool {
+	// If there are Matches patterns, at least one must match
+	if len(pred.Matches) > 0 {
+		if !anyMatches(pred.Matches, msg) {
+			return false
+		}
+	}
+
+	// If there are NotMatches patterns, none must match
+	if len(pred.NotMatches) > 0 {
+		if anyMatches(pred.NotMatches, msg) {
+			return false
+		}
+	}
+
+	// If we have patterns and passed all checks, it's a match
+	// If we have no patterns at all, consider it a match (vacuous truth)
+	return true
+}
+
+func (pred *CommitMessages) Trigger() common.Trigger {
+	return common.TriggerCommit
+}
+
+func getPatternStrings(patterns []common.Regexp) []string {
+	var strs []string
+	for _, r := range patterns {
+		strs = append(strs, r.String())
+	}
+	return strs
+}

--- a/policy/predicate/commit_messages_test.go
+++ b/policy/predicate/commit_messages_test.go
@@ -1,0 +1,372 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitMessages(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allModeSubjectMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "JIRA-123: Add feature"},
+				{SHA: "def456", MessageHeadline: "JIRA-456: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "all commits should match pattern")
+			assert.Contains(t, result.Description, "All 2 commits")
+		}
+	})
+
+	t.Run("allModeOneDoesNotMatch", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "JIRA-123: Add feature"},
+				{SHA: "def456", MessageHeadline: "Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "one commit does not match")
+			assert.Contains(t, result.Description, "def456")
+		}
+	})
+
+	t.Run("anyModeOneMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Fix typo"},
+				{SHA: "def456", MessageHeadline: "JIRA-456: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "at least one commit matches")
+			assert.Contains(t, result.Description, "def456")
+		}
+	})
+
+	t.Run("anyModeNoneMatch", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^JIRA-[0-9]+:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Fix typo"},
+				{SHA: "def456", MessageHeadline: "Update docs"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no commits match")
+			assert.Contains(t, result.Description, "No commits match")
+		}
+	})
+
+	t.Run("notMatchesPattern", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP|fixup")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Add feature"},
+				{SHA: "def456", MessageHeadline: "Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "no commits contain WIP or fixup")
+		}
+	})
+
+	t.Run("notMatchesFails", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP|fixup")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "Add feature"},
+				{SHA: "def456", MessageHeadline: "WIP: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "one commit contains WIP")
+		}
+	})
+
+	t.Run("matchesAndNotMatches", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^[A-Z]+")),
+			},
+			NotMatches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("WIP")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "FEAT: Add feature"},
+				{SHA: "def456", MessageHeadline: "FIX: Fix bug"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "all start with uppercase and none have WIP")
+		}
+	})
+
+	t.Run("bodyScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "body",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("(?i)breaking change")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{
+					SHA:             "abc123",
+					MessageHeadline: "Update API",
+					MessageBody:     "This is a breaking change to the API",
+				},
+				{
+					SHA:             "def456",
+					MessageHeadline: "Fix bug",
+					MessageBody:     "Minor bug fix",
+				},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "one commit body mentions breaking change")
+		}
+	})
+
+	t.Run("fullScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "any",
+			Scope: "full",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("important")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{
+					SHA:             "abc123",
+					MessageHeadline: "Update feature",
+					MessageBody:     "This is an important update",
+				},
+				{
+					SHA:             "def456",
+					MessageHeadline: "Important fix",
+					MessageBody:     "",
+				},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "commits contain 'important' in subject or body")
+		}
+	})
+
+	t.Run("defaultMode", func(t *testing.T) {
+		p := &CommitMessages{
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^feat:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "feat: add feature"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "default mode should be 'all'")
+		}
+	})
+
+	t.Run("defaultScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode: "all",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile("^feat:")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "feat: add feature", MessageBody: "details"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "default scope should be 'subject'")
+		}
+	})
+
+	t.Run("noCommits", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+			Matches: []common.Regexp{
+				common.NewCompiledRegexp(regexp.MustCompile(".*")),
+			},
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.False(t, result.Satisfied, "no commits should fail")
+			assert.Contains(t, result.Description, "No commits found")
+		}
+	})
+
+	t.Run("invalidMode", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "invalid",
+			Scope: "subject",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "test"},
+			},
+		}
+
+		_, err := p.Evaluate(ctx, prctx)
+		assert.Error(t, err, "invalid mode should return error")
+		assert.Contains(t, err.Error(), "invalid mode")
+	})
+
+	t.Run("invalidScope", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "invalid",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "test"},
+			},
+		}
+
+		_, err := p.Evaluate(ctx, prctx)
+		assert.Error(t, err, "invalid scope should return error")
+		assert.Contains(t, err.Error(), "invalid scope")
+	})
+
+	t.Run("noPatterns", func(t *testing.T) {
+		p := &CommitMessages{
+			Mode:  "all",
+			Scope: "subject",
+		}
+
+		prctx := &pulltest.Context{
+			CommitsValue: []*pull.Commit{
+				{SHA: "abc123", MessageHeadline: "any message"},
+			},
+		}
+
+		result, err := p.Evaluate(ctx, prctx)
+		if assert.NoError(t, err) {
+			assert.True(t, result.Satisfied, "no patterns should always pass")
+		}
+	})
+}
+
+func TestCommitMessagesTrigger(t *testing.T) {
+	p := &CommitMessages{
+		Mode:  "all",
+		Scope: "subject",
+	}
+
+	assert.Equal(t, common.TriggerCommit, p.Trigger())
+}

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -33,6 +33,8 @@ type Predicates struct {
 
 	ModifiedLines *ModifiedLines `yaml:"modified_lines,omitempty"`
 
+	CommitMessages *CommitMessages `yaml:"commit_messages,omitempty"`
+
 	HasStatus *HasStatus `yaml:"has_status,omitempty"`
 	// `has_successful_status` is a deprecated field that is kept for backwards
 	// compatibility.  `has_status` replaces it, and can accept any conclusion
@@ -102,6 +104,10 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.ModifiedLines != nil {
 		ps = append(ps, Predicate(p.ModifiedLines))
+	}
+
+	if p.CommitMessages != nil {
+		ps = append(ps, Predicate(p.CommitMessages))
 	}
 
 	if p.HasStatus != nil {

--- a/pull/context.go
+++ b/pull/context.go
@@ -161,6 +161,12 @@ type Commit struct {
 	// committer is not a real user.
 	Committer string
 
+	// MessageHeadline is the first line of the commit message (subject).
+	MessageHeadline string
+
+	// MessageBody is the commit message body (everything after the subject).
+	MessageBody string
+
 	// Signature is the signature and details that was extracted from the commit.
 	// It is nil if the commit has no signature
 	Signature *Signature

--- a/pull/github.go
+++ b/pull/github.go
@@ -1211,6 +1211,8 @@ type v4Commit struct {
 	Author          v4GitActor
 	Committer       v4GitActor
 	CommittedViaWeb bool
+	MessageHeadline string
+	MessageBody     string
 	Parents         struct {
 		Nodes []struct {
 			OID string
@@ -1236,6 +1238,8 @@ func (c *v4Commit) ToCommit() *Commit {
 		CommittedViaWeb: c.CommittedViaWeb,
 		Author:          c.Author.User.GetV3Login(),
 		Committer:       c.Committer.User.GetV3Login(),
+		MessageHeadline: c.MessageHeadline,
+		MessageBody:     c.MessageBody,
 		Signature:       signature,
 	}
 }


### PR DESCRIPTION
Add predicate to match commit message patterns with configurable mode (all/any) and scope (subject/body/full). Requires updates to pull.Commit struct to include MessageHeadline and MessageBody fields. Implements part of GitHub issue #1062.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

