### PR TITLE
Optimize Actors.IsActor check

### DIFF
--- a/policy/common/actor.go
+++ b/policy/common/actor.go
@@ -99,18 +99,22 @@ func (a *Actors) IsActor(ctx context.Context, prctx pull.Context, user string) (
 		}
 	}
 
-	userPerm, err := prctx.CollaboratorPermission(user)
-	if err != nil {
-		return false, err
-	}
-	if userPerm == pull.PermissionNone {
-		return false, nil
-	}
+	permissions := a.GetPermissions()
+	if len(permissions) > 0 {
+		userPerm, err := prctx.CollaboratorPermission(user)
+		if err != nil {
+			return false, err
+		}
+		if userPerm == pull.PermissionNone {
+			return false, nil
+		}
 
-	for _, p := range a.GetPermissions() {
-		if userPerm >= p {
-			return true, nil
+		for _, p := range permissions {
+			if userPerm >= p {
+				return true, nil
+			}
 		}
 	}
+
 	return false, nil
 }


### PR DESCRIPTION
Related to https://github.com/palantir/policy-bot/discussions/1030.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

In `Actors.IsActor`, `GitHubContext.CollaboratorPermission` is called unnecessarily, which consumes extra rate limits.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

In `Actors.IsActor`, `GitHubContext.CollaboratorPermission` is only called when needed.

As the table below shows, the behavior should be the same as before, except for the unnecessary API call eliminated where `Permissions` is not used.

| | `userPerm != pull.PermissionNone` | `userPerm == pull.PermissionNone` |
| -- | -- | -- |
| `len(permissions) > 0` | API called, check is performed | returns false, nil |
| `len(permissions) == 0` | no API calls, no check performed, returns false, nil | returns false, nil |

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Whether the call to `CollaboratorPermission` has any "side effects" needs to be carefully considered, especially in the case where the user does not have permission in the repository.

The actual implementation of `CollaboratorPermission` (not the test one) is here:

https://github.com/palantir/policy-bot/blob/a4ac11af89ee0d7326b0998072bdf2f6bf98cf1f/pull/github.go#L648-L698

To breakdown the implementation:

* L649-654 returns the cached result where it is already cached.
* L656-674 builds the query and the variables.
* L676-694 loops through all collaborators to check the user's permission. In particular,
    * (L680-682) It fetches a page of collaborators that match the name of the queried user.
        * When the collaborator does not exist in the repository, GitHub API returns empty result but does not err.
    * (L683-690) if the user exists as a collaborator, then the permission is parsed. This only errs if there is an invalid permission.
    * (L691-693) If there is no next page, break the loop.
* L696 writes to the cache.
* L697 returns the permission.

Therefore, we believe that removing the call to `CollaboratorPermission` when `GetPermissions()` is empty, should not have any downsides.

We would like the review to double check this assumption, in addition to all the usual reviews.