### PR TITLE
Simplify the validate subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,12 @@ curl: (22) The requested URL returned error: 422
 {"message":"failed to parse approval policy: failed to parse subpolicies for 'and': policy references undefined rule 'the devtools team has approved', allowed values: [the devtools team has]","version":"1.12.5"}
 ```
 
+The `policy-bot` binary also includes a `validate` subcomand that can validate local policy files without running a server instance:
+
+```sh
+policy-bot validate -p path/to/policy.yml
+```
+
 #### Simulation API
 
 It can be useful to simulate how Policy Bot would evaluate a pull request if certain conditions were changed. For example: adding a review from a specific user or group, or adjusting the base branch.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io/fs"
 	"os"
 
 	"github.com/palantir/policy-bot/server"
@@ -36,19 +36,10 @@ var ServerCmd = &cobra.Command{
 }
 
 func readServerConfig(cfgFile string) (*server.Config, error) {
-	fi, err := os.Stat(cfgFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed fetching server config file: %s", cfgFile)
+	bytes, err := os.ReadFile(cfgFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, errors.Errorf("server config file does not exist: %s", cfgFile)
 	}
-	if os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "server config file does not exist: %s", cfgFile)
-	}
-	if !fi.Mode().IsRegular() {
-		return nil, errors.New("server config file is not a regular file: " + cfgFile)
-	}
-
-	var bytes []byte
-	bytes, err = ioutil.ReadFile(cfgFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed reading server config file: %s", cfgFile)
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io/fs"
 	"os"
 
 	"github.com/palantir/policy-bot/policy"
@@ -24,44 +24,27 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var policyBotPolicy struct {
+var validateCmdConfig struct {
 	Path string
 }
 
-var PolicyBotValidationCmd = &cobra.Command{
+var ValidationCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Runs validation of policy-bot policy.",
-	Long:  "Runs valdation of a policy-bot policy yaml file.",
+	Short: "Validates the syntax and structure of a policy file.",
+	Long:  "Validates the YAML syntax and logical structure of a local policy file. It does not support remote policy references.",
 
-	RunE: policyBotValidationCmd,
+	RunE: validationCmd,
 }
 
-func readPolicyBotPolicy(cfgFile string) ([]byte, error) {
-	fi, err := os.Stat(cfgFile)
-	if os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "policy file does not exist: %s", cfgFile)
+func validationCmd(cmd *cobra.Command, args []string) error {
+	policyData, err := os.ReadFile(validateCmdConfig.Path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return errors.Errorf("policy file does not exist: %s", validateCmdConfig.Path)
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed fetching policy file: %s", cfgFile)
-	}
-	if !fi.Mode().IsRegular() {
-		return nil, errors.New("policy file is not a regular file: " + cfgFile)
+		return errors.Wrapf(err, "failed to read policy file: %s", validateCmdConfig.Path)
 	}
 
-	var bytes []byte
-	bytes, err = ioutil.ReadFile(cfgFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed reading policy file: %s", cfgFile)
-	}
-
-	return bytes, nil
-}
-
-func policyBotValidationCmd(cmd *cobra.Command, args []string) error {
-	policyData, err := readPolicyBotPolicy(policyBotPolicy.Path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read policy file")
-	}
 	var policyConfig policy.Config
 	if err := yaml.UnmarshalStrict(policyData, &policyConfig); err != nil {
 		return errors.Wrapf(err, "failed to parse policy from yaml file")
@@ -73,7 +56,7 @@ func policyBotValidationCmd(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	RootCmd.AddCommand(PolicyBotValidationCmd)
+	RootCmd.AddCommand(ValidationCmd)
 
-	PolicyBotValidationCmd.Flags().StringVarP(&policyBotPolicy.Path, "policy", "p", ".policy.yml", "policy file for policy-bot")
+	ValidationCmd.Flags().StringVarP(&validateCmdConfig.Path, "policy", "p", ".policy.yml", "path to the policy file to validate")
 }


### PR DESCRIPTION
## Before this PR
The `server` and `validate` commands perform unnecessary checks when reading files. The `validate` command implementation also has some verbose/inconsistent variable names and messages.

## After this PR
Simplify the validate subcomand and remove unnecessary checks when loading files.

## Possible downsides?
None

