### PR TITLE
improvement: parallelize calls to load pr reviewers

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-github/v79/github"
@@ -594,18 +595,38 @@ func (ghc *GitHubContext) RepositoryCollaborators() ([]*Collaborator, error) {
 			return nil, err
 		}
 
-		teamMembership := make(map[string][]string)
-		for team := range teamPerms {
-			// List full membership instead of testing each collaborator under
-			// the assumption that (teams * members) is much less than the
-			// total number of collaborators, which include those from the org
-			members, err := ghc.TeamMembers(ghc.owner + "/" + team)
-			if err != nil {
-				return nil, err
-			}
+		// Fetch team memberships in parallel. List full membership instead of
+		// testing each collaborator under the assumption that (teams * members)
+		// is much less than the total number of collaborators.
+		type teamResult struct {
+			team    string
+			members []string
+			err     error
+		}
+		resultCh := make(chan teamResult, len(teamPerms))
+		sem := make(chan struct{}, 20)
 
-			for _, member := range members {
-				teamMembership[member] = append(teamMembership[member], team)
+		var wg sync.WaitGroup
+		for team := range teamPerms {
+			wg.Add(1)
+			go func(team string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				members, err := ghc.TeamMembers(ghc.owner + "/" + team)
+				resultCh <- teamResult{team: team, members: members, err: err}
+			}(team)
+		}
+		wg.Wait()
+		close(resultCh)
+
+		teamMembership := make(map[string][]string)
+		for result := range resultCh {
+			if result.err != nil {
+				return nil, result.err
+			}
+			for _, member := range result.members {
+				teamMembership[member] = append(teamMembership[member], result.team)
 			}
 		}
 

--- a/pull/github_membership.go
+++ b/pull/github_membership.go
@@ -17,6 +17,7 @@ package pull
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/google/go-github/v79/github"
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ type GitHubMembershipContext struct {
 	ctx    context.Context
 	client *github.Client
 
+	mu          sync.Mutex
 	membership  map[string]bool
 	orgMembers  map[string][]string
 	teamMembers map[string][]string
@@ -61,7 +63,9 @@ func (mc *GitHubMembershipContext) IsTeamMember(team, user string) (bool, error)
 		return false, err
 	}
 
+	mc.mu.Lock()
 	isMember, ok := mc.membership[key]
+	mc.mu.Unlock()
 	if ok {
 		return isMember, nil
 	}
@@ -72,7 +76,9 @@ func (mc *GitHubMembershipContext) IsTeamMember(team, user string) (bool, error)
 	}
 
 	isMember = membership != nil && membership.GetState() == "active"
+	mc.mu.Lock()
 	mc.membership[key] = isMember
+	mc.mu.Unlock()
 
 	return isMember, nil
 }
@@ -80,7 +86,9 @@ func (mc *GitHubMembershipContext) IsTeamMember(team, user string) (bool, error)
 func (mc *GitHubMembershipContext) IsOrgMember(org, user string) (bool, error) {
 	key := membershipKey(org, user)
 
+	mc.mu.Lock()
 	isMember, ok := mc.membership[key]
+	mc.mu.Unlock()
 	if ok {
 		return isMember, nil
 	}
@@ -90,69 +98,87 @@ func (mc *GitHubMembershipContext) IsOrgMember(org, user string) (bool, error) {
 		return false, errors.Wrap(err, "failed to get organization membership")
 	}
 
+	mc.mu.Lock()
 	mc.membership[key] = isMember
+	mc.mu.Unlock()
 	return isMember, nil
 }
 
 func (mc *GitHubMembershipContext) OrganizationMembers(org string) ([]string, error) {
+	mc.mu.Lock()
 	members, ok := mc.orgMembers[org]
-	if !ok {
-		opt := &github.ListMembersOptions{
-			ListOptions: github.ListOptions{
-				PerPage: 100,
-			},
-		}
-
-		for {
-			users, resp, err := mc.client.Organizations.ListMembers(mc.ctx, org, opt)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to list members of org %s page %d", org, opt.Page)
-			}
-			for _, u := range users {
-				members = append(members, u.GetLogin())
-				// And cache these values for later lookups
-				mc.membership[membershipKey(org, u.GetLogin())] = true
-			}
-			if resp.NextPage == 0 {
-				break
-			}
-			opt.Page = resp.NextPage
-		}
-		mc.orgMembers[org] = members
+	mc.mu.Unlock()
+	if ok {
+		return members, nil
 	}
+
+	opt := &github.ListMembersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	for {
+		users, resp, err := mc.client.Organizations.ListMembers(mc.ctx, org, opt)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list members of org %s page %d", org, opt.Page)
+		}
+		for _, u := range users {
+			members = append(members, u.GetLogin())
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	mc.mu.Lock()
+	mc.orgMembers[org] = members
+	for _, m := range members {
+		mc.membership[membershipKey(org, m)] = true
+	}
+	mc.mu.Unlock()
 	return members, nil
 }
 
 func (mc *GitHubMembershipContext) TeamMembers(team string) ([]string, error) {
+	mc.mu.Lock()
 	members, ok := mc.teamMembers[team]
-	if !ok {
-		opt := &github.TeamListTeamMembersOptions{
-			ListOptions: github.ListOptions{
-				PerPage: 100,
-			},
-		}
-
-		org, slug, err := splitTeam(team)
-		if err != nil {
-			return nil, err
-		}
-
-		for {
-			users, resp, err := mc.client.Teams.ListTeamMembersBySlug(mc.ctx, org, slug, opt)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to list team %s members page %d", team, opt.Page)
-			}
-			for _, u := range users {
-				members = append(members, u.GetLogin())
-				// And cache these values for later lookups
-				mc.membership[membershipKey(team, u.GetLogin())] = true
-			}
-			if resp.NextPage == 0 {
-				break
-			}
-			opt.Page = resp.NextPage
-		}
-		mc.teamMembers[team] = members
+	mc.mu.Unlock()
+	if ok {
+		return members, nil
 	}
+
+	opt := &github.TeamListTeamMembersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: 100,
+		},
+	}
+
+	org, slug, err := splitTeam(team)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		users, resp, err := mc.client.Teams.ListTeamMembersBySlug(mc.ctx, org, slug, opt)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list team %s members page %d", team, opt.Page)
+		}
+		for _, u := range users {
+			members = append(members, u.GetLogin())
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	mc.mu.Lock()
+	mc.teamMembers[team] = members
+	for _, m := range members {
+		mc.membership[membershipKey(team, m)] = true
+	}
+	mc.mu.Unlock()
 	return members, nil
 }

--- a/server/handler/details_reviewers.go
+++ b/server/handler/details_reviewers.go
@@ -17,11 +17,13 @@ package handler
 import (
 	"net/http"
 	"slices"
+	"sync"
 
 	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/approval"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 type DetailsReviewers struct {
@@ -70,49 +72,13 @@ func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) err
 		return h.renderEmptyReviewers(w, r)
 	}
 
-	var reviewers []string
-	var incomplete bool
-
-	// Add direct users
-	reviewers = append(reviewers, requires.Actors.Users...)
-
-	// Add organization members
-	for _, org := range requires.Actors.Organizations {
-		members, err := prctx.OrganizationMembers(org)
-		if err != nil {
-			logger.Warn().Err(err).Str("organization", org).Msg("Error listing organization members, reviewers will be incomplete")
-			incomplete = true
-		} else {
-			reviewers = append(reviewers, members...)
-		}
-	}
-
-	// Add team members
-	for _, team := range requires.Actors.Teams {
-		members, err := prctx.TeamMembers(team)
-		if err != nil {
-			logger.Warn().Err(err).Str("team", team).Msg("Error listing team members, reviewers will be incomplete")
-			incomplete = true
-		} else {
-			reviewers = append(reviewers, members...)
-		}
-	}
-
-	// Add reviewers with permissions
-	perms := requires.Actors.GetPermissions()
-	if len(perms) > 0 {
-		userCollaborators, err := prctx.RepositoryCollaborators()
-		if err != nil {
-			logger.Warn().Err(err).Msg("Error listing user collaborators, reviewers will be incomplete")
-			incomplete = true
-		} else {
-			for _, user := range userCollaborators {
-				if userHasReviewerPermission(user, perms) {
-					reviewers = append(reviewers, user.Name)
-				}
-			}
-		}
-	}
+	reviewers := append([]string{}, requires.Actors.Users...)
+	orgMembers, teamMembers, collaborators, incomplete := fetchReviewerSources(
+		prctx, logger, requires.Actors.Organizations, requires.Actors.Teams, requires.Actors.GetPermissions(),
+	)
+	reviewers = append(reviewers, orgMembers...)
+	reviewers = append(reviewers, teamMembers...)
+	reviewers = append(reviewers, collaborators...)
 
 	// Order the reviewers and remove any duplicates
 	slices.Sort(reviewers)
@@ -122,6 +88,81 @@ func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) err
 		Reviewers:  reviewers,
 		Incomplete: incomplete,
 	})
+}
+
+// fetchReviewerSources fetches organization members, team members, and collaborators
+// in parallel. Returns members from each source and whether any errors occurred.
+func fetchReviewerSources(
+	prctx pull.Context,
+	logger zerolog.Logger,
+	orgs []string,
+	teams []string,
+	perms []pull.Permission,
+) (orgMembers, teamMembers, collaborators []string, incomplete bool) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	sem := make(chan struct{}, 20)
+
+	for _, org := range orgs {
+		wg.Add(1)
+		go func(org string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			members, err := prctx.OrganizationMembers(org)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				logger.Warn().Err(err).Str("organization", org).Msg("Error listing organization members, reviewers will be incomplete")
+				incomplete = true
+			} else {
+				orgMembers = append(orgMembers, members...)
+			}
+		}(org)
+	}
+
+	for _, team := range teams {
+		wg.Add(1)
+		go func(team string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			members, err := prctx.TeamMembers(team)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				logger.Warn().Err(err).Str("team", team).Msg("Error listing team members, reviewers will be incomplete")
+				incomplete = true
+			} else {
+				teamMembers = append(teamMembers, members...)
+			}
+		}(team)
+	}
+
+	if len(perms) > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			userCollaborators, err := prctx.RepositoryCollaborators()
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				logger.Warn().Err(err).Msg("Error listing user collaborators, reviewers will be incomplete")
+				incomplete = true
+			} else {
+				for _, user := range userCollaborators {
+					if userHasReviewerPermission(user, perms) {
+						collaborators = append(collaborators, user.Name)
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	return
 }
 
 func (h *DetailsReviewers) renderEmptyReviewers(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
## Before this PR
A common workflow when contributing to an unfamiliar repo is checking the policybot ui to determine which team(s) to get approval from. Sometimes the mapping is not obvious, and requires clicking to expand the set of valid reviewers for the corresponding node in the policy tree. In orgs with large numbers of teams and/or members, loading the reviewers for a given node of the tree can take multiple minutes, if it succeeds at all. The current implementation simply iterates over the list of relevant orgs and teams and loads their membership serially, which can be very slow.

## After this PR
Parallelize calls to the GH api to load org and team membership.

==COMMIT_MSG==
parallelize calls to load pr reviewers
==COMMIT_MSG==

## Possible downsides?
Increased load on the GH api. For now we'll bound the number of concurrent loads per context to 20, but can adjust later if needed.
