### PR TITLE
Add Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,6 +1174,20 @@ issue by using the `ignore_commits_by` option in combination with the
 other than GitHub. It is also safe to run multiple instances of the server,
 making it a good fit for container schedulers like Nomad or Kubernetes.
 
+### Helm Chart (Experimental)
+
+A Helm chart is available in the `chart/` directory for deploying policy-bot to
+Kubernetes. This chart is currently **experimental** and may change in future
+releases.
+
+```bash
+helm install policy-bot ./chart -f values.yaml
+```
+
+See `chart/values.yaml` for all available configuration options.
+
+### Docker and Binary
+
 We provide both a Docker container and a binary distribution of the server:
 
 - Binaries: https://github.com/palantir/policy-bot/releases

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Test files
+test-values.yaml

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: policy-bot
+description: GitHub App for enforcing approval policies on pull requests
+type: application
+version: 0.1.0
+appVersion: "1.40.0"
+maintainers:
+  - name: Palantir Technologies
+    url: https://github.com/palantir/policy-bot
+home: https://github.com/palantir/policy-bot
+sources:
+  - https://github.com/palantir/policy-bot

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,265 @@
+# policy-bot Helm Chart
+
+A Helm chart for deploying [policy-bot](https://github.com/palantir/policy-bot) to Kubernetes.
+
+> **Note:** This chart is currently **experimental** and may change in future releases.
+
+## Installation
+
+We recommend deploying policy-bot in its own namespace:
+
+```bash
+# Add your configuration
+cp values.yaml my-values.yaml
+# Edit my-values.yaml with your settings
+
+# Install the chart in a dedicated namespace
+helm install policy-bot ./chart -f my-values.yaml -n policy-bot --create-namespace
+```
+
+## Configuration
+
+### GitHub App Configuration
+
+Before deploying policy-bot, you need to create a GitHub App. See the [main documentation](https://github.com/palantir/policy-bot#github-app-configuration) for detailed instructions.
+
+You'll need the following values from your GitHub App:
+- **Integration ID** (App ID)
+- **Webhook Secret**
+- **Private Key** (PEM format)
+- **OAuth Client ID**
+- **OAuth Client Secret**
+
+### Providing Secrets
+
+There are two ways to provide sensitive configuration:
+
+#### Option 1: Let the chart create the Secret (default)
+
+```yaml
+secrets:
+  create: true
+  github:
+    integrationId: "12345"
+    webhookSecret: "your-webhook-secret"
+    privateKey: |
+      -----BEGIN RSA PRIVATE KEY-----
+      ...
+      -----END RSA PRIVATE KEY-----
+  oauth:
+    clientId: "your-client-id"
+    clientSecret: "your-client-secret"
+  session:
+    key: "a-random-string-at-least-32-characters"
+```
+
+#### Option 2: Use an existing Secret
+
+Create a Secret with the following keys:
+- `github-integration-id`
+- `github-webhook-secret`
+- `github-private-key`
+- `oauth-client-id`
+- `oauth-client-secret`
+- `session-key`
+
+Then reference it:
+
+```yaml
+secrets:
+  create: false
+  existingSecret: "my-policy-bot-secret"
+```
+
+### Providing Configuration
+
+#### Option 1: Let the chart create the ConfigMap (default)
+
+Configure options under the `config` key in values.yaml:
+
+```yaml
+config:
+  create: true
+  server:
+    address: "0.0.0.0"
+    port: 8080
+    publicUrl: "https://policy-bot.example.com"
+  github:
+    webUrl: "https://github.com"
+    v3ApiUrl: "https://api.github.com"
+    v4ApiUrl: "https://api.github.com/graphql"
+  # ... see values.yaml for all options
+```
+
+#### Option 2: Use an existing ConfigMap
+
+If you need configuration options not exposed in the chart or want to manage the ConfigMap yourself:
+
+```yaml
+config:
+  create: false
+  existingConfigMap: "my-policy-bot-config"
+  key: "policy-bot.yml"  # key in the ConfigMap containing the config
+```
+
+### GitHub Enterprise
+
+For GitHub Enterprise, update the GitHub URLs:
+
+```yaml
+config:
+  github:
+    webUrl: "https://github.mycompany.com"
+    v3ApiUrl: "https://github.mycompany.com/api/v3"
+    v4ApiUrl: "https://github.mycompany.com/api/graphql"
+```
+
+### Ingress
+
+To expose policy-bot via Ingress:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: policy-bot.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+### Metrics
+
+Policy-bot exposes Prometheus metrics at `/api/metrics`
+
+## Parameters
+
+### Deployment Settings
+
+| Name               | Description                                                                               | Value                             |
+| ------------------ | ----------------------------------------------------------------------------------------- | --------------------------------- |
+| `replicaCount`     | Number of replicas to deploy. policy-bot is stateless and safe to run multiple instances. | `2`                               |
+| `image.repository` | Docker image repository                                                                   | `palantirtechnologies/policy-bot` |
+| `image.pullPolicy` | Image pull policy (Always, IfNotPresent, Never)                                           | `IfNotPresent`                    |
+| `image.tag`        | Overrides the image tag whose default is the chart appVersion                             | `""`                              |
+| `imagePullSecrets` | Image pull secrets for private registries                                                 | `[]`                              |
+| `nameOverride`     | Override the name of the chart (used in resource names)                                   | `""`                              |
+| `fullnameOverride` | Override the full name of the chart (used in resource names)                              | `""`                              |
+
+### Service Account
+
+| Name                         | Description                                                     | Value  |
+| ---------------------------- | --------------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Create a service account for the deployment                     | `true` |
+| `serviceAccount.name`        | Name of the service account (defaults to fullname)              | `""`   |
+| `serviceAccount.annotations` | Annotations to add to the service account (e.g., for IAM roles) | `{}`   |
+
+### Pod Settings
+
+| Name                                       | Description                                   | Value            |
+| ------------------------------------------ | --------------------------------------------- | ---------------- |
+| `podAnnotations`                           | Additional annotations to add to pods         | `{}`             |
+| `podSecurityContext`                       | Pod-level security context                    | `{}`             |
+| `securityContext.readOnlyRootFilesystem`   | Prevents container from writing to filesystem | `true`           |
+| `securityContext.runAsNonRoot`             | Ensures container doesn't run as root         | `true`           |
+| `securityContext.runAsUser`                | Runs as non-privileged user (UID 1000)        | `1000`           |
+| `securityContext.runAsGroup`               | Runs as non-privileged group (GID 1000)       | `1000`           |
+| `securityContext.allowPrivilegeEscalation` | Prevents gaining additional privileges        | `false`          |
+| `securityContext.capabilities.drop`        | Linux capabilities to drop                    | `["ALL"]`        |
+| `securityContext.seccompProfile.type`      | Seccomp profile type                          | `RuntimeDefault` |
+| `terminationGracePeriodSeconds`            | Time to allow for graceful shutdown           | `60`             |
+| `resources.limits.memory`                  | Memory limit                                  | `2048Mi`         |
+| `resources.requests.cpu`                   | CPU request                                   | `100m`           |
+| `resources.requests.memory`                | Memory request                                | `2048Mi`         |
+| `nodeSelector`                             | Node selector for pod assignment              | `{}`             |
+| `tolerations`                              | Tolerations for pod assignment                | `[]`             |
+| `affinity`                                 | Affinity rules for pod assignment             | `{}`             |
+
+### Service Settings
+
+| Name                  | Description                                      | Value       |
+| --------------------- | ------------------------------------------------ | ----------- |
+| `service.type`        | Service type (ClusterIP, NodePort, LoadBalancer) | `ClusterIP` |
+| `service.port`        | Service port                                     | `8080`      |
+| `service.annotations` | Additional service annotations                   | `{}`        |
+
+### Ingress Settings
+
+| Name                                 | Description                                                   | Value              |
+| ------------------------------------ | ------------------------------------------------------------- | ------------------ |
+| `ingress.enabled`                    | Enable ingress resource creation                              | `false`            |
+| `ingress.className`                  | Ingress class name (e.g., nginx, traefik, alb)                | `""`               |
+| `ingress.annotations`                | Ingress annotations. Use for cert-manager or nginx config.    | `{}`               |
+| `ingress.hosts[0].host`              | Hostname for the ingress                                      | `policy-bot.local` |
+| `ingress.hosts[0].paths[0].path`     | Path for the ingress                                          | `/`                |
+| `ingress.hosts[0].paths[0].pathType` | Path type (Prefix, Exact, ImplementationSpecific)             | `Prefix`           |
+| `ingress.tls.enabled`                | Enable TLS termination at ingress                             | `false`            |
+| `ingress.tls.certificate`            | Base64 encoded TLS certificate (Option 1: provide directly)   | `""`               |
+| `ingress.tls.privateKey`             | Base64 encoded TLS private key (Option 1: provide directly)   | `""`               |
+| `ingress.tls.existingSecret`         | Name of existing TLS secret (Option 2: use existing)          | `""`               |
+| `ingress.tls.host`                   | Hostname for TLS certificate (defaults to first ingress host) | `""`               |
+
+### Policy-bot Configuration
+
+| Name                                     | Description                                                                    | Value                            |
+| ---------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------- |
+| `config.create`                          | Create a ConfigMap for the config file                                         | `true`                           |
+| `config.existingConfigMap`               | Name of existing ConfigMap to use (when create is false)                       | `""`                             |
+| `config.key`                             | Key in existing ConfigMap containing the config file                           | `policy-bot.yml`                 |
+| `config.server.address`                  | Server listen address                                                          | `0.0.0.0`                        |
+| `config.server.port`                     | Server port. The container and service will use this port.                     | `8080`                           |
+| `config.server.publicUrl`                | Public URL for OAuth callbacks and links. Auto-detected from ingress if empty. | `""`                             |
+| `config.logging.text`                    | Use human-readable text logs instead of JSON                                   | `false`                          |
+| `config.logging.level`                   | Log level (debug, info, warn, error)                                           | `info`                           |
+| `config.cache.maxSize`                   | Maximum size for the in-memory cache (e.g., 50MB)                              | `50MB`                           |
+| `config.workers.workers`                 | Number of workers processing webhook events                                    | `10`                             |
+| `config.workers.queueSize`               | Queue size for buffering incoming webhook events                               | `100`                            |
+| `config.workers.githubTimeout`           | Timeout for GitHub API requests (e.g., 10s, 1m)                                | `10s`                            |
+| `config.github.webUrl`                   | GitHub web URL. For GitHub Enterprise, use your instance URL.                  | `https://github.com`             |
+| `config.github.v3ApiUrl`                 | GitHub REST API (v3) URL                                                       | `https://api.github.com`         |
+| `config.github.v4ApiUrl`                 | GitHub GraphQL API (v4) URL                                                    | `https://api.github.com/graphql` |
+| `config.options.policyPath`              | Path to policy file in repositories                                            | `.policy.yml`                    |
+| `config.options.sharedRepository`        | Shared repository name for organization-wide policies                          | `.github`                        |
+| `config.options.sharedPolicyPath`        | Path to policy file in shared repository                                       | `policy.yml`                     |
+| `config.options.statusCheckContext`      | Context name for status checks on pull requests                                | `policy-bot`                     |
+| `config.options.expandRequiredReviewers` | Expand required reviewers to show individual users                             | `false`                          |
+| `config.options.forceSharedPolicy`       | Force use of shared policy for all repositories                                | `false`                          |
+| `config.metrics.quantiles.enabled`       | Enable custom quantile configuration                                           | `false`                          |
+| `config.metrics.quantiles.histogram`     | Histogram quantiles to track                                                   | `[]`                             |
+| `config.metrics.quantiles.timer`         | Timer quantiles to track                                                       | `[]`                             |
+| `config.metrics.labels`                  | Additional labels to add to metrics                                            | `{}`                             |
+
+### Secrets Configuration
+
+| Name                           | Description                                           | Value  |
+| ------------------------------ | ----------------------------------------------------- | ------ |
+| `secrets.create`               | Create a Kubernetes Secret for sensitive values       | `true` |
+| `secrets.existingSecret`       | Name of existing Secret to use (when create is false) | `""`   |
+| `secrets.github.integrationId` | GitHub App ID (Integration ID)                        | `""`   |
+| `secrets.github.webhookSecret` | Webhook secret configured in your GitHub App          | `""`   |
+| `secrets.github.privateKey`    | GitHub App private key in PEM format                  | `""`   |
+| `secrets.oauth.clientId`       | OAuth Client ID from your GitHub App                  | `""`   |
+| `secrets.oauth.clientSecret`   | OAuth Client Secret from your GitHub App              | `""`   |
+| `secrets.session.key`          | Session signing key for encrypting user sessions      | `""`   |
+
+### Additional Configuration
+
+| Name                | Description                                              | Value |
+| ------------------- | -------------------------------------------------------- | ----- |
+| `extraEnv`          | Additional environment variables to add to the container | `[]`  |
+| `extraVolumes`      | Additional volumes to add to the pod                     | `[]`  |
+| `extraVolumeMounts` | Additional volume mounts to add to the container         | `[]`  |
+
+## Upgrading
+
+```bash
+helm upgrade policy-bot ./chart -f my-values.yaml
+```
+
+## Uninstalling
+
+```bash
+helm uninstall policy-bot
+```

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,48 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your release is named: {{ .Release.Name }}
+
+To get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "policy-bot.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "policy-bot.fullname" . }}
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "policy-bot.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "policy-bot.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to access policy-bot"
+{{- end }}
+
+IMPORTANT: Before the application can function, you must configure:
+
+1. GitHub App credentials:
+   - Integration ID
+   - Webhook secret
+   - Private key (PEM format)
+
+2. OAuth credentials (for the web UI):
+   - Client ID
+   - Client secret
+
+3. Session key (for signing session cookies)
+
+These can be set in values.yaml under 'secrets' or via an existing Kubernetes Secret.
+
+For more information, see:
+  - GitHub App setup: https://github.com/palantir/policy-bot#github-app-configuration
+  - Documentation: https://github.com/palantir/policy-bot#readme
+
+Health check endpoint: /api/health
+Metrics endpoint: /api/metrics (Prometheus format)
+Webhook endpoint: /api/github/hook

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+If release name contains chart name it will be used can as a full name.
 */}}
 {{- define "policy-bot.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -48,17 +48,6 @@ Selector labels
 {{- define "policy-bot.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "policy-bot.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "policy-bot.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "policy-bot.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,118 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "policy-bot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "policy-bot.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "policy-bot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "policy-bot.labels" -}}
+helm.sh/chart: {{ include "policy-bot.chart" . }}
+{{ include "policy-bot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "policy-bot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "policy-bot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "policy-bot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "policy-bot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "policy-bot.secretName" -}}
+{{- if .Values.secrets.create }}
+{{- include "policy-bot.fullname" . }}
+{{- else }}
+{{- required "A valid .Values.secrets.existingSecret is required when secrets.create is false" .Values.secrets.existingSecret }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the configmap
+*/}}
+{{- define "policy-bot.configMapName" -}}
+{{- include "policy-bot.fullname" . }}-config
+{{- end }}
+
+{{/*
+Return the public URL
+*/}}
+{{- define "policy-bot.publicUrl" -}}
+{{- if .Values.config.server.publicUrl }}
+{{- .Values.config.server.publicUrl }}
+{{- else if .Values.ingress.enabled }}
+{{- $host := (index .Values.ingress.hosts 0).host }}
+{{- $hasCertManager := or (index .Values.ingress.annotations "cert-manager.io/cluster-issuer") (index .Values.ingress.annotations "cert-manager.io/issuer") }}
+{{- if or .Values.ingress.tls.enabled $hasCertManager }}
+{{- printf "https://%s" $host }}
+{{- else }}
+{{- printf "http://%s" $host }}
+{{- end }}
+{{- else }}
+{{- printf "http://localhost:%d" (int .Values.config.server.port) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the TLS secret name
+*/}}
+{{- define "policy-bot.tlsSecretName" -}}
+{{- if .Values.ingress.tls.existingSecret }}
+{{- .Values.ingress.tls.existingSecret }}
+{{- else }}
+{{- include "policy-bot.fullname" . }}-tls
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name
+*/}}
+{{- define "policy-bot.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -65,7 +65,18 @@ Create the name of the secret to use
 Create the name of the configmap
 */}}
 {{- define "policy-bot.configMapName" -}}
+{{- if .Values.config.create }}
 {{- include "policy-bot.fullname" . }}-config
+{{- else }}
+{{- required "A valid .Values.config.existingConfigMap is required when config.create is false" .Values.config.existingConfigMap }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the config key name
+*/}}
+{{- define "policy-bot.configKey" -}}
+{{- .Values.config.key | default "policy-bot.yml" }}
 {{- end }}
 
 {{/*
@@ -104,4 +115,15 @@ Return the image name
 {{- define "policy-bot.image" -}}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "policy-bot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "policy-bot.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
 {{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -56,28 +57,16 @@ data:
       expand_required_reviewers: {{ .Values.config.options.expandRequiredReviewers }}
       force_shared_policy: {{ .Values.config.options.forceSharedPolicy }}
 
-    {{- if .Values.config.datadog.enabled }}
-    # Datadog metrics configuration
-    datadog:
-      address: {{ .Values.config.datadog.address | quote }}
-      interval: {{ .Values.config.datadog.interval | quote }}
-      {{- if .Values.config.datadog.tags }}
-      tags:
-        {{- range .Values.config.datadog.tags }}
-        - {{ . | quote }}
-        {{- end }}
-      {{- end }}
-    {{- end }}
-
-    {{- if .Values.config.prometheus.enabled }}
-    # Prometheus metrics configuration
+    {{- if .Values.config.metrics.quantiles.enabled }}
+    # Prometheus metrics quantile configuration (optional)
     prometheus:
-      histogram_quantiles: {{ .Values.config.prometheus.histogramQuantiles | toJson }}
-      timer_quantiles: {{ .Values.config.prometheus.timerQuantiles | toJson }}
-      {{- if .Values.config.prometheus.labels }}
+      histogram_quantiles: {{ .Values.config.metrics.quantiles.histogram | toJson }}
+      timer_quantiles: {{ .Values.config.metrics.quantiles.timer | toJson }}
+      {{- if .Values.config.metrics.labels }}
       labels:
-        {{- range $key, $value := .Values.config.prometheus.labels }}
+        {{- range $key, $value := .Values.config.metrics.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
     {{- end }}
+{{- end }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "policy-bot.configMapName" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+data:
+  policy-bot.yml: |
+    # Server configuration
+    server:
+      address: {{ .Values.config.server.address | quote }}
+      port: {{ .Values.config.server.port }}
+      public_url: {{ include "policy-bot.publicUrl" . | quote }}
+
+    # Logging configuration
+    logging:
+      text: {{ .Values.config.logging.text }}
+      level: {{ .Values.config.logging.level | quote }}
+
+    # Cache configuration
+    cache:
+      max_size: {{ .Values.config.cache.maxSize | quote }}
+
+    # Worker configuration
+    workers:
+      workers: {{ .Values.config.workers.workers }}
+      queue_size: {{ .Values.config.workers.queueSize }}
+      github_timeout: {{ .Values.config.workers.githubTimeout | quote }}
+
+    # GitHub configuration
+    # Note: Sensitive values (integration_id, webhook_secret, private_key, oauth)
+    # are injected via environment variables from Kubernetes Secrets
+    github:
+      web_url: {{ .Values.config.github.webUrl | quote }}
+      v3_api_url: {{ .Values.config.github.v3ApiUrl | quote }}
+      v4_api_url: {{ .Values.config.github.v4ApiUrl | quote }}
+      app:
+        integration_id: 0  # Overridden by GITHUB_APP_INTEGRATION_ID env var
+        webhook_secret: ""  # Overridden by GITHUB_APP_WEBHOOK_SECRET env var
+        private_key: ""  # Overridden by GITHUB_APP_PRIVATE_KEY env var
+      oauth:
+        client_id: ""  # Overridden by GITHUB_OAUTH_CLIENT_ID env var
+        client_secret: ""  # Overridden by GITHUB_OAUTH_CLIENT_SECRET env var
+
+    # Session configuration
+    # Note: Session key is injected via environment variable from Kubernetes Secrets
+    sessions:
+      key: ""  # Overridden by POLICYBOT_SESSIONS_KEY env var
+
+    # Application options
+    options:
+      policy_path: {{ .Values.config.options.policyPath | quote }}
+      shared_repository: {{ .Values.config.options.sharedRepository | quote }}
+      shared_policy_path: {{ .Values.config.options.sharedPolicyPath | quote }}
+      status_check_context: {{ .Values.config.options.statusCheckContext | quote }}
+      expand_required_reviewers: {{ .Values.config.options.expandRequiredReviewers }}
+      force_shared_policy: {{ .Values.config.options.forceSharedPolicy }}
+
+    {{- if .Values.config.datadog.enabled }}
+    # Datadog metrics configuration
+    datadog:
+      address: {{ .Values.config.datadog.address | quote }}
+      interval: {{ .Values.config.datadog.interval | quote }}
+      {{- if .Values.config.datadog.tags }}
+      tags:
+        {{- range .Values.config.datadog.tags }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .Values.config.prometheus.enabled }}
+    # Prometheus metrics configuration
+    prometheus:
+      histogram_quantiles: {{ .Values.config.prometheus.histogramQuantiles | toJson }}
+      timer_quantiles: {{ .Values.config.prometheus.timerQuantiles | toJson }}
+      {{- if .Values.config.prometheus.labels }}
+      labels:
+        {{- range $key, $value := .Values.config.prometheus.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         {{- include "policy-bot.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "policy-bot.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -98,7 +100,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /secrets/policy-bot.yml
-              subPath: policy-bot.yml
+              subPath: {{ include "policy-bot.configKey" . }}
               readOnly: true
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "policy-bot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "policy-bot.fullname" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "policy-bot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/api/metrics"
+        prometheus.io/scheme: "http"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "policy-bot.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "policy-bot.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "policy-bot.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - server
+            - --config
+            - /secrets/policy-bot.yml
+          env:
+            - name: POLICYBOT_PUBLIC_URL
+              value: {{ include "policy-bot.publicUrl" . | quote }}
+            - name: GITHUB_APP_INTEGRATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: github-integration-id
+            - name: GITHUB_APP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: github-webhook-secret
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: github-private-key
+            - name: GITHUB_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: oauth-client-id
+            - name: GITHUB_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: oauth-client-secret
+            - name: POLICYBOT_SESSIONS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "policy-bot.secretName" . }}
+                  key: session-key
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.server.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /secrets/policy-bot.yml
+              subPath: policy-bot.yml
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "policy-bot.configMapName" . }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -40,8 +40,6 @@ spec:
             - --config
             - /secrets/policy-bot.yml
           env:
-            - name: POLICYBOT_PUBLIC_URL
-              value: {{ include "policy-bot.publicUrl" . | quote }}
             - name: GITHUB_APP_INTEGRATION_ID
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $tlsHost := .Values.ingress.tls.host | default (index .Values.ingress.hosts 0).host -}}
+{{- $hasCertManager := or (index .Values.ingress.annotations "cert-manager.io/cluster-issuer") (index .Values.ingress.annotations "cert-manager.io/issuer") -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "policy-bot.fullname" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if or .Values.ingress.tls.enabled $hasCertManager }}
+  tls:
+    - hosts:
+        - {{ $tlsHost | quote }}
+      secretName: {{ include "policy-bot.tlsSecretName" . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "policy-bot.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "policy-bot.fullname" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  github-integration-id: {{ .Values.secrets.github.integrationId | quote }}
+  github-webhook-secret: {{ .Values.secrets.github.webhookSecret | quote }}
+  github-private-key: {{ .Values.secrets.github.privateKey | quote }}
+  oauth-client-id: {{ .Values.secrets.oauth.clientId | quote }}
+  oauth-client-secret: {{ .Values.secrets.oauth.clientSecret | quote }}
+  session-key: {{ .Values.secrets.session.key | quote }}
+{{- end }}

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "policy-bot.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  github-integration-id: {{ .Values.secrets.github.integrationId | quote }}
-  github-webhook-secret: {{ .Values.secrets.github.webhookSecret | quote }}
-  github-private-key: {{ .Values.secrets.github.privateKey | quote }}
-  oauth-client-id: {{ .Values.secrets.oauth.clientId | quote }}
-  oauth-client-secret: {{ .Values.secrets.oauth.clientSecret | quote }}
-  session-key: {{ .Values.secrets.session.key | quote }}
+  github-integration-id: {{ required "secrets.github.integrationId is required when secrets.create is true" .Values.secrets.github.integrationId | quote }}
+  github-webhook-secret: {{ required "secrets.github.webhookSecret is required when secrets.create is true" .Values.secrets.github.webhookSecret | quote }}
+  github-private-key: {{ required "secrets.github.privateKey is required when secrets.create is true" .Values.secrets.github.privateKey | quote }}
+  oauth-client-id: {{ required "secrets.oauth.clientId is required when secrets.create is true" .Values.secrets.oauth.clientId | quote }}
+  oauth-client-secret: {{ required "secrets.oauth.clientSecret is required when secrets.create is true" .Values.secrets.oauth.clientSecret | quote }}
+  session-key: {{ required "secrets.session.key is required when secrets.create is true" .Values.secrets.session.key | quote }}
 {{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "policy-bot.fullname" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "policy-bot.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "policy-bot.serviceAccountName" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/tls-secret.yaml
+++ b/chart/templates/tls-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls.enabled (not .Values.ingress.tls.existingSecret) }}
+{{- if and .Values.ingress.tls.certificate .Values.ingress.tls.privateKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "policy-bot.tlsSecretName" . }}
+  labels:
+    {{- include "policy-bot.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.ingress.tls.certificate }}
+  tls.key: {{ .Values.ingress.tls.privateKey }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,15 +21,6 @@ nameOverride: ""
 # -- Override the full name of the chart
 fullnameOverride: ""
 
-serviceAccount:
-  # -- Specifies whether a service account should be created
-  create: true
-  # -- Annotations to add to the service account
-  annotations: {}
-  # -- The name of the service account to use
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
-
 # -- Pod annotations
 podAnnotations: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,191 +1,235 @@
 # Default values for policy-bot.
 # This is a YAML-formatted file.
+# See README.md for detailed documentation.
 
-# -- Number of replicas to deploy
-replicaCount: 1
+## @section Deployment Settings
 
+## @param replicaCount Number of replicas to deploy. policy-bot is stateless and safe to run multiple instances.
+replicaCount: 2
+
+## @param image.repository Docker image repository
+## @param image.pullPolicy Image pull policy (Always, IfNotPresent, Never)
+## @param image.tag Overrides the image tag whose default is the chart appVersion
 image:
-  # -- Docker image repository
   repository: palantirtechnologies/policy-bot
-  # -- Image pull policy
   pullPolicy: IfNotPresent
-  # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 
-# -- Image pull secrets for private registries
+## @param imagePullSecrets Image pull secrets for private registries
 imagePullSecrets: []
 
-# -- Override the name of the chart
+## @param nameOverride Override the name of the chart (used in resource names)
 nameOverride: ""
 
-# -- Override the full name of the chart
+## @param fullnameOverride Override the full name of the chart (used in resource names)
 fullnameOverride: ""
 
-# -- Pod annotations
+## @section Service Account
+
+## @param serviceAccount.create Create a service account for the deployment
+## @param serviceAccount.name Name of the service account (defaults to fullname)
+## @param serviceAccount.annotations Annotations to add to the service account (e.g., for IAM roles)
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+## @section Pod Settings
+
+## @param podAnnotations Additional annotations to add to pods
 podAnnotations: {}
 
-# -- Pod security context
+## @param podSecurityContext Pod-level security context
 podSecurityContext: {}
 
-# -- Container security context
+## @param securityContext.readOnlyRootFilesystem Prevents container from writing to filesystem
+## @param securityContext.runAsNonRoot Ensures container doesn't run as root
+## @param securityContext.runAsUser Runs as non-privileged user (UID 1000)
+## @param securityContext.runAsGroup Runs as non-privileged group (GID 1000)
+## @param securityContext.allowPrivilegeEscalation Prevents gaining additional privileges
+## @param securityContext.capabilities.drop Linux capabilities to drop
+## @param securityContext.seccompProfile.type Seccomp profile type
 securityContext:
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
+  runAsGroup: 1000
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
+## @param terminationGracePeriodSeconds Time to allow for graceful shutdown
+terminationGracePeriodSeconds: 60
+
+## @param resources.limits.memory Memory limit
+## @param resources.requests.cpu CPU request
+## @param resources.requests.memory Memory request
+resources:
+  limits:
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 2048Mi
+
+## @param nodeSelector Node selector for pod assignment
+nodeSelector: {}
+
+## @param tolerations Tolerations for pod assignment
+tolerations: []
+
+## @param affinity Affinity rules for pod assignment
+affinity: {}
+
+## @section Service Settings
+
+## @param service.type Service type (ClusterIP, NodePort, LoadBalancer)
+## @param service.port Service port
+## @param service.annotations Additional service annotations
 service:
-  # -- Service type
   type: ClusterIP
-  # -- Service port
   port: 8080
-  # -- Service annotations
   annotations: {}
 
+## @section Ingress Settings
+
+## @param ingress.enabled Enable ingress resource creation
+## @param ingress.className Ingress class name (e.g., nginx, traefik, alb)
+## @param ingress.annotations Ingress annotations. Use for cert-manager or nginx config.
+## @param ingress.hosts[0].host Hostname for the ingress
+## @param ingress.hosts[0].paths[0].path Path for the ingress
+## @param ingress.hosts[0].paths[0].pathType Path type (Prefix, Exact, ImplementationSpecific)
+## @param ingress.tls.enabled Enable TLS termination at ingress
+## @param ingress.tls.certificate Base64 encoded TLS certificate (Option 1: provide directly)
+## @param ingress.tls.privateKey Base64 encoded TLS private key (Option 1: provide directly)
+## @param ingress.tls.existingSecret Name of existing TLS secret (Option 2: use existing)
+## @param ingress.tls.host Hostname for TLS certificate (defaults to first ingress host)
 ingress:
-  # -- Enable ingress
   enabled: false
-  # -- Ingress class name
   className: ""
-  # -- Ingress annotations (use for cert-manager: cert-manager.io/cluster-issuer: "letsencrypt-prod")
   annotations: {}
-  # -- Ingress hosts configuration
   hosts:
     - host: policy-bot.local
       paths:
         - path: /
           pathType: Prefix
-  # TLS configuration (3 options):
-  # Option 1: Provide cert/key directly, chart creates the secret
-  # Option 2: Reference an existing secret via existingSecret
-  # Option 3: Use cert-manager by adding annotation above and leave false
+  # TLS configuration:
+  # Option 1: Provide cert/key directly (set enabled=true, provide certificate and privateKey)
+  # Option 2: Reference existing Secret (set enabled=true, provide existingSecret)
+  # Option 3: Use cert-manager (add cert-manager.io/cluster-issuer annotation, enabled can be false)
   tls:
-    # -- Enable TLS
     enabled: false
-    # -- Base64 encoded TLS certificate (Option 1)
     certificate: ""
-    # -- Base64 encoded TLS private key (Option 1)
     privateKey: ""
-    # -- Name of existing TLS secret (Option 2)
     existingSecret: ""
-    # -- Hostname for TLS (defaults to first ingress host)
     host: ""
 
-# -- Resource requests and limits
-resources: {}
-  # limits:
-  #   cpu: 500m
-  #   memory: 256Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+## @section Policy-bot Configuration
 
-# -- Node selector for pod assignment
-nodeSelector: {}
-
-# -- Tolerations for pod assignment
-tolerations: []
-
-# -- Affinity rules for pod assignment
-affinity: {}
-
-# Policy-bot specific configuration
+## @param config.create Create a ConfigMap for the config file
+## @param config.existingConfigMap Name of existing ConfigMap to use (when create is false)
+## @param config.key Key in existing ConfigMap containing the config file
 config:
+  create: true
+  existingConfigMap: ""
+  key: "policy-bot.yml"
+
+  ## @param config.server.address Server listen address
+  ## @param config.server.port Server port. The container and service will use this port.
+  ## @param config.server.publicUrl Public URL for OAuth callbacks and links. Auto-detected from ingress if empty.
   server:
-    # -- Server listen address
     address: "0.0.0.0"
-    # -- Server port
     port: 8080
-    # -- Public URL for the server (used for OAuth callbacks and links)
     publicUrl: ""
 
+  ## @param config.logging.text Use human-readable text logs instead of JSON
+  ## @param config.logging.level Log level (debug, info, warn, error)
   logging:
-    # -- Use human-readable text logs instead of JSON
     text: false
-    # -- Log level (debug, info, warn, error)
     level: info
 
+  ## @param config.cache.maxSize Maximum size for the in-memory cache (e.g., 50MB)
   cache:
-    # -- Maximum cache size
     maxSize: "50MB"
 
+  ## @param config.workers.workers Number of workers processing webhook events
+  ## @param config.workers.queueSize Queue size for buffering incoming webhook events
+  ## @param config.workers.githubTimeout Timeout for GitHub API requests (e.g., 10s, 1m)
   workers:
-    # -- Number of webhook processing workers
     workers: 10
-    # -- Queue size for webhook events
     queueSize: 100
-    # -- Timeout for GitHub API requests
     githubTimeout: 10s
 
+  ## @param config.github.webUrl GitHub web URL. For GitHub Enterprise, use your instance URL.
+  ## @param config.github.v3ApiUrl GitHub REST API (v3) URL
+  ## @param config.github.v4ApiUrl GitHub GraphQL API (v4) URL
   github:
-    # -- GitHub web URL (for GitHub Enterprise, change to your instance URL)
     webUrl: "https://github.com"
-    # -- GitHub REST API URL
     v3ApiUrl: "https://api.github.com"
-    # -- GitHub GraphQL API URL
     v4ApiUrl: "https://api.github.com/graphql"
 
+  ## @param config.options.policyPath Path to policy file in repositories
+  ## @param config.options.sharedRepository Shared repository name for organization-wide policies
+  ## @param config.options.sharedPolicyPath Path to policy file in shared repository
+  ## @param config.options.statusCheckContext Context name for status checks on pull requests
+  ## @param config.options.expandRequiredReviewers Expand required reviewers to show individual users
+  ## @param config.options.forceSharedPolicy Force use of shared policy for all repositories
   options:
-    # -- Path to policy file in repositories
     policyPath: ".policy.yml"
-    # -- Shared repository name for organization-wide policies
     sharedRepository: ".github"
-    # -- Path to policy file in shared repository
     sharedPolicyPath: "policy.yml"
-    # -- Context name for status checks
     statusCheckContext: "policy-bot"
-    # -- Expand required reviewers to individual users
     expandRequiredReviewers: false
-    # -- Force use of shared policy for all repositories
     forceSharedPolicy: false
 
-  # Datadog metrics (optional)
-  datadog:
-    enabled: false
-    address: "127.0.0.1:8125"
-    interval: "10s"
-    tags: []
-
-  # Prometheus metrics (optional)
-  prometheus:
-    enabled: false
-    histogramQuantiles: [0.5, 0.95]
-    timerQuantiles: [0.5, 0.95]
+  ## Prometheus metrics are always available at /api/metrics.
+  ## These settings allow customizing quantile tracking (optional).
+  ## @param config.metrics.quantiles.enabled Enable custom quantile configuration
+  ## @param config.metrics.quantiles.histogram [array] Histogram quantiles to track
+  ## @param config.metrics.quantiles.timer [array] Timer quantiles to track
+  ## @param config.metrics.labels [object] Additional labels to add to metrics
+  metrics:
+    quantiles:
+      enabled: false
+      histogram: [0.5, 0.95]
+      timer: [0.5, 0.95]
     labels: {}
 
-# Secrets configuration
+## @section Secrets Configuration
+
+## @param secrets.create Create a Kubernetes Secret for sensitive values
+## @param secrets.existingSecret Name of existing Secret to use (when create is false)
 secrets:
-  # -- Create a Kubernetes Secret for sensitive values
   create: true
-  # -- Name of an existing secret to use (if create is false)
   existingSecret: ""
 
+  ## @param secrets.github.integrationId GitHub App ID (Integration ID)
+  ## @param secrets.github.webhookSecret Webhook secret configured in your GitHub App
+  ## @param secrets.github.privateKey GitHub App private key in PEM format
   github:
-    # -- GitHub App integration ID
     integrationId: ""
-    # -- GitHub App webhook secret
     webhookSecret: ""
-    # -- GitHub App private key (PEM format)
     privateKey: ""
 
+  ## @param secrets.oauth.clientId OAuth Client ID from your GitHub App
+  ## @param secrets.oauth.clientSecret OAuth Client Secret from your GitHub App
   oauth:
-    # -- OAuth client ID
     clientId: ""
-    # -- OAuth client secret
     clientSecret: ""
 
+  ## @param secrets.session.key Session signing key for encrypting user sessions
   session:
-    # -- Session signing key
     key: ""
 
-# -- Additional environment variables
+## @section Additional Configuration
+
+## @param extraEnv Additional environment variables to add to the container
 extraEnv: []
 
-# -- Additional volumes
+## @param extraVolumes Additional volumes to add to the pod
 extraVolumes: []
 
-# -- Additional volume mounts
+## @param extraVolumeMounts Additional volume mounts to add to the container
 extraVolumeMounts: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,200 @@
+# Default values for policy-bot.
+# This is a YAML-formatted file.
+
+# -- Number of replicas to deploy
+replicaCount: 1
+
+image:
+  # -- Docker image repository
+  repository: palantirtechnologies/policy-bot
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Override the name of the chart
+nameOverride: ""
+
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod security context
+podSecurityContext: {}
+
+# -- Container security context
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 8080
+  # -- Service annotations
+  annotations: {}
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations (use for cert-manager: cert-manager.io/cluster-issuer: "letsencrypt-prod")
+  annotations: {}
+  # -- Ingress hosts configuration
+  hosts:
+    - host: policy-bot.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # TLS configuration (3 options):
+  # Option 1: Provide cert/key directly, chart creates the secret
+  # Option 2: Reference an existing secret via existingSecret
+  # Option 3: Use cert-manager by adding annotation above and leave false
+  tls:
+    # -- Enable TLS
+    enabled: false
+    # -- Base64 encoded TLS certificate (Option 1)
+    certificate: ""
+    # -- Base64 encoded TLS private key (Option 1)
+    privateKey: ""
+    # -- Name of existing TLS secret (Option 2)
+    existingSecret: ""
+    # -- Hostname for TLS (defaults to first ingress host)
+    host: ""
+
+# -- Resource requests and limits
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Node selector for pod assignment
+nodeSelector: {}
+
+# -- Tolerations for pod assignment
+tolerations: []
+
+# -- Affinity rules for pod assignment
+affinity: {}
+
+# Policy-bot specific configuration
+config:
+  server:
+    # -- Server listen address
+    address: "0.0.0.0"
+    # -- Server port
+    port: 8080
+    # -- Public URL for the server (used for OAuth callbacks and links)
+    publicUrl: ""
+
+  logging:
+    # -- Use human-readable text logs instead of JSON
+    text: false
+    # -- Log level (debug, info, warn, error)
+    level: info
+
+  cache:
+    # -- Maximum cache size
+    maxSize: "50MB"
+
+  workers:
+    # -- Number of webhook processing workers
+    workers: 10
+    # -- Queue size for webhook events
+    queueSize: 100
+    # -- Timeout for GitHub API requests
+    githubTimeout: 10s
+
+  github:
+    # -- GitHub web URL (for GitHub Enterprise, change to your instance URL)
+    webUrl: "https://github.com"
+    # -- GitHub REST API URL
+    v3ApiUrl: "https://api.github.com"
+    # -- GitHub GraphQL API URL
+    v4ApiUrl: "https://api.github.com/graphql"
+
+  options:
+    # -- Path to policy file in repositories
+    policyPath: ".policy.yml"
+    # -- Shared repository name for organization-wide policies
+    sharedRepository: ".github"
+    # -- Path to policy file in shared repository
+    sharedPolicyPath: "policy.yml"
+    # -- Context name for status checks
+    statusCheckContext: "policy-bot"
+    # -- Expand required reviewers to individual users
+    expandRequiredReviewers: false
+    # -- Force use of shared policy for all repositories
+    forceSharedPolicy: false
+
+  # Datadog metrics (optional)
+  datadog:
+    enabled: false
+    address: "127.0.0.1:8125"
+    interval: "10s"
+    tags: []
+
+  # Prometheus metrics (optional)
+  prometheus:
+    enabled: false
+    histogramQuantiles: [0.5, 0.95]
+    timerQuantiles: [0.5, 0.95]
+    labels: {}
+
+# Secrets configuration
+secrets:
+  # -- Create a Kubernetes Secret for sensitive values
+  create: true
+  # -- Name of an existing secret to use (if create is false)
+  existingSecret: ""
+
+  github:
+    # -- GitHub App integration ID
+    integrationId: ""
+    # -- GitHub App webhook secret
+    webhookSecret: ""
+    # -- GitHub App private key (PEM format)
+    privateKey: ""
+
+  oauth:
+    # -- OAuth client ID
+    clientId: ""
+    # -- OAuth client secret
+    clientSecret: ""
+
+  session:
+    # -- Session signing key
+    key: ""
+
+# -- Additional environment variables
+extraEnv: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []


### PR DESCRIPTION
This sets up an initial helm chart for policy bot which can be deployed via cloning this repository. Next steps would be to figure out publishing once a name/location is decided.

