### PR TITLE
fix: make IsActor handle 'permissions' via 'AND' condition

### DIFF
--- a/policy/common/actor.go
+++ b/policy/common/actor.go
@@ -73,6 +73,32 @@ func (a *Actors) GetPermissions() []pull.Permission {
 // IsActor returns true if the given user satisfies at least one of the
 // conditions in this structure.
 func (a *Actors) IsActor(ctx context.Context, prctx pull.Context, user string) (bool, error) {
+	permissions := a.GetPermissions()
+	if len(permissions) > 0 {
+		userPerm, err := prctx.CollaboratorPermission(user)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to get collaborator permission")
+		}
+		if userPerm == pull.PermissionNone {
+			return false, nil
+		}
+
+		satisfiesPermissions := false
+		for _, p := range permissions {
+			if userPerm >= p {
+				satisfiesPermissions = true
+				break
+			}
+		}
+		if !satisfiesPermissions {
+			return false, nil
+		}
+
+		if len(a.Users)+len(a.Teams)+len(a.Organizations) == 0 {
+			return true, nil
+		}
+	}
+
 	for _, u := range a.Users {
 		if user == u {
 			return true, nil
@@ -96,23 +122,6 @@ func (a *Actors) IsActor(ctx context.Context, prctx pull.Context, user string) (
 		}
 		if member {
 			return true, nil
-		}
-	}
-
-	permissions := a.GetPermissions()
-	if len(permissions) > 0 {
-		userPerm, err := prctx.CollaboratorPermission(user)
-		if err != nil {
-			return false, err
-		}
-		if userPerm == pull.PermissionNone {
-			return false, nil
-		}
-
-		for _, p := range permissions {
-			if userPerm >= p {
-				return true, nil
-			}
 		}
 	}
 

--- a/policy/common/actor_test.go
+++ b/policy/common/actor_test.go
@@ -113,6 +113,24 @@ func TestIsActor(t *testing.T) {
 		assertActor(t, a, "jstrawnickel")
 		assertNotActor(t, a, "ttest")
 	})
+
+	t.Run("identityAndPermissions", func(t *testing.T) {
+		prctx.TeamMemberships["lowpermuser"] = []string{"cool-org/team1"}
+		prctx.CollaboratorsValue = append(prctx.CollaboratorsValue, &pull.Collaborator{
+			Name: "lowpermuser",
+			Permissions: []pull.CollaboratorPermission{
+				{Permission: pull.PermissionRead},
+			},
+		})
+
+		a := &Actors{
+			Teams:       []string{"cool-org/team1"},
+			Permissions: []pull.Permission{pull.PermissionWrite},
+		}
+
+		assertNotActor(t, a, "lowpermuser")
+		assertActor(t, a, "mhaypenny")
+	})
 }
 
 func TestIsEmpty(t *testing.T) {


### PR DESCRIPTION
## Before this PR

Given the following rule:

```yaml
  - name: reviewer is an org member and has write access
    requires:
      count: 1
      organizations:
        - "our-org"
      permissions:
        - write
```

I would expect the following truth table to apply:

| org       | permissions | IsActor |
|-----------|-------------|---------|
| our-org   | write       | true    |
| our-org   | read        | false   |
| other-org | write       | false   |
| other-org | read        | false   |

However, the current code effectively treats these as an "OR" condition and produces the following truth table:

| org       | permissions | IsActor  |
|-----------|-------------|----------|
| our-org   | write       | true     |
| our-org   | read        | **true** |
| other-org | write       | **true** |
| other-org | read        | false    |

## After this PR

In reading the implementation, I understand why the other identity conditions (users, teams, organizations) all use OR logic. With the exception of permissions, it's essentially the same mental model as the "Collaborators and teams" page in a GitHub repo's settings:

<img width="786" height="218" alt="Screenshot 2026-01-08 at 1 15 01 PM" src="https://github.com/user-attachments/assets/26205760-da5b-4cb2-9dde-1969d49cf9fc" />

Note how `'permissions'` are treated in the GitHub model. This PR brings the `policy-bot` behavior in line with what seems to be the more likely expectation of the developer/maintainer of a rule set.

==COMMIT_MSG==
fix: make IsActor handle 'permissions' via 'AND' condition
==COMMIT_MSG==

## Possible downsides?

This is technically a breaking change for anyone who had been _intentionally_ relying on permissions to apply via an "OR" condition.

## Alternatives Considered

- The YML config could be expanded to support more explicit `- and:` and `-or:` mappings.
- The YML config could be expanded to nest permissions beneath individual identity requirements. (This is closest to the "Collaborators and teams" settings page.)
- Without any code changes, we can _sort of_ (but not entirely) get what we need via something like this:

```yaml
  - name: reviewer is an org member
    requires:
      count: 1
      organizations:
        - "our-org"
  - name: reviewer has write access
    requires:
      count: 1
      permissions:
        - write
```

However, our use case ideally enforces that **the reviewer from a given org be the _same_ reviewer as the one with the write permissions**. The above example results in the ability for _two reviewers_ (one with `write` access and the other with read-only org membership) to combine two reviews into a single policy bot approval.

Therefore, without some form of code change, it does not appear to be possible to enforce both an identity check and a permissions check for the same "actor". (Which, at the very least, is not in line with the way that permissions are typically expressed within the GitHub interface -- but please point me in the right direction if I'm missing anything!)
