### PR TITLE
Cache workflow runs in pull context

### DIFF
--- a/pull/github.go
+++ b/pull/github.go
@@ -932,15 +932,14 @@ func (ghc *GitHubContext) LatestWorkflowRuns() (map[string][]string, error) {
 		}
 		opt.Page = resp.NextPage
 	}
-	workflowRuns := make(map[string][]string, len(runsWithDate))
 
+	ghc.workflowRuns = make(map[string][]string, len(runsWithDate))
 	for path, eventRuns := range runsWithDate {
 		for _, run := range eventRuns {
-			workflowRuns[path] = append(workflowRuns[path], run.GetConclusion())
+			ghc.workflowRuns[path] = append(ghc.workflowRuns[path], run.GetConclusion())
 		}
 	}
-
-	return workflowRuns, nil
+	return ghc.workflowRuns, nil
 }
 
 func (ghc *GitHubContext) Labels() ([]string, error) {

--- a/pull/github_test.go
+++ b/pull/github_test.go
@@ -684,6 +684,13 @@ func TestLatestWorkflowRuns(t *testing.T) {
 	assert.ElementsMatch(t, runs[".github/workflows/b.yml"], []string{"failure"}, "incorrect conclusion for workflow run b")
 	assert.ElementsMatch(t, runs[".github/workflows/c.yml"], []string{"cancelled"}, "incorrect conclusion for workflow run c")
 	assert.Equal(t, 2, runsRule.Count, "incorrect http request count")
+
+	// verify that workflow runs are cached
+	runs, err = ctx.LatestWorkflowRuns()
+	require.NoError(t, err)
+
+	assert.Len(t, runs, 3, "incorrect number of workflow runs")
+	assert.Equal(t, 2, runsRule.Count, "incorrect http request count")
 }
 
 func TestLatestStatuses(t *testing.T) {


### PR DESCRIPTION
After fetching workflow runs, they were never stored in the context, causing each call to fetch them again.

Fixes #1152.

