### PR TITLE
Remove usage of strings.Title

### DIFF
--- a/server/handler/frontend.go
+++ b/server/handler/frontend.go
@@ -91,7 +91,12 @@ func LoadTemplates(c *FilesConfig, basePath string, githubURL string) (templatet
 				}
 				return path.Join(basePath, "static", r)
 			},
-			"titlecase": strings.Title,
+			"toFirstUpper": func(s string) string {
+				if s == "" {
+					return ""
+				}
+				return strings.ToUpper(s[:1]) + s[1:]
+			},
 			"sortByStatus": func(results []*common.Result) []*common.Result {
 				r := make([]*common.Result, len(results))
 				copy(r, results)

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -34,7 +34,7 @@
     {{ $s := (or (and .Result.Error "error") (.Result.Status | print)) }}
     <div class="status-banner {{$s}} flex flex-wrap items-center justify-between">
       <div>
-        <h2 class="mb-1 text-lg font-bold">Status: {{$s | titlecase}}</h2>
+        <h2 class="mb-1 text-lg font-bold">Status: {{$s | toFirstUpper}}</h2>
         <p>{{or .Result.Error .Result.StatusDescription}}</p>
       </div>
       <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
@@ -130,7 +130,7 @@
   {{ $s := (or (and .Error "error") (.Status | print)) }}
   <p class="mb-2 flex items-center">
     <b class="font-bold">{{.Name}}</b>
-    <span class="flex-none status-badge {{$s}}">{{$s | titlecase}}</span>
+    <span class="flex-none status-badge {{$s}}">{{$s | toFirstUpper}}</span>
   </p>
   {{if (and .Description (ne $s "skipped"))}}
   <p class="mb-2 text-dark-gray3 text-sm">{{.Description}}</p>


### PR DESCRIPTION
This method is deprecated because it doesn't handle certain Unicode sequences correctly. We only use it to captialize the first letter of ASCII status strings, so that doesn't matter, but linters that look for deprecated functions don't care. Instead of adding a dependency on the recommended replacement package, replace the function with a simpler implementation that only does what we need.

#1158 is an example PR that's trying to replace this deprecated function by adding a new dependency on `golang.org/x/text`.
