### PR TITLE
Only register reviewer route when enabled

### DIFF
--- a/server/handler/details_reviewers.go
+++ b/server/handler/details_reviewers.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/google/go-github/v81/github"
 	"github.com/palantir/policy-bot/policy"
 	"github.com/palantir/policy-bot/policy/approval"
 	"github.com/palantir/policy-bot/pull"
@@ -29,15 +30,12 @@ type DetailsReviewers struct {
 }
 
 type DetailsReviewersData struct {
-	Reviewers  []string
-	Incomplete bool
+	PullRequest *github.PullRequest
+	Reviewers   []string
+	Incomplete  bool
 }
 
 func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
-	if !h.PullOpts.ExpandRequiredReviewers {
-		return h.renderEmptyReviewers(w, r)
-	}
-
 	state := h.getStateIfAllowed(w, r)
 	if state == nil {
 		return nil
@@ -51,14 +49,17 @@ func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) err
 	switch {
 	case config.LoadError != nil:
 		logger.Warn().Err(config.LoadError).Msgf("Error loading policy from %s, reviewers will be incomplete", config.Source)
-		return h.renderReviewers(w, r, DetailsReviewersData{Incomplete: true})
+		return h.renderReviewers(w, r, DetailsReviewersData{
+			PullRequest: state.PullRequest,
+			Incomplete:  true,
+		})
 
 	case config.Config == nil:
 		// The repository either has no policy or the policy was invalid. This
 		// should never happen in normal use, because the expected way to hit
 		// this endpoint requires viewing a valid details page first. Hitting
 		// this case means something unexpected is hitting the API directly.
-		return h.renderEmptyReviewers(w, r)
+		return h.renderReviewers(w, r, DetailsReviewersData{PullRequest: state.PullRequest})
 	}
 
 	ruleName := r.URL.Query().Get("rule")
@@ -67,7 +68,7 @@ func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) err
 	if requires == nil || requires.Count == 0 || requires.Actors.IsZero() {
 		// If the rule does not exist, it does not require approval, or it has
 		// no actors specified, there's no need to list reviewers
-		return h.renderEmptyReviewers(w, r)
+		return h.renderReviewers(w, r, DetailsReviewersData{PullRequest: state.PullRequest})
 	}
 
 	var reviewers []string
@@ -119,13 +120,10 @@ func (h *DetailsReviewers) ServeHTTP(w http.ResponseWriter, r *http.Request) err
 	reviewers = slices.Compact(reviewers)
 
 	return h.renderReviewers(w, r, DetailsReviewersData{
-		Reviewers:  reviewers,
-		Incomplete: incomplete,
+		PullRequest: state.PullRequest,
+		Reviewers:   reviewers,
+		Incomplete:  incomplete,
 	})
-}
-
-func (h *DetailsReviewers) renderEmptyReviewers(w http.ResponseWriter, r *http.Request) error {
-	return h.renderReviewers(w, r, DetailsReviewersData{})
 }
 
 func (h *DetailsReviewers) renderReviewers(w http.ResponseWriter, r *http.Request, data DetailsReviewersData) error {

--- a/server/server.go
+++ b/server/server.go
@@ -263,9 +263,13 @@ func New(c *Config) (*Server, error) {
 	details := goji.SubMux()
 	details.Use(handler.RequireLogin(sessions, basePath))
 	details.Handle(pat.Get("/:owner/:repo/:number"), hatpear.Try(&detailsHandler))
-	details.Handle(pat.Get("/:owner/:repo/:number/reviewers"), hatpear.Try(&handler.DetailsReviewers{
-		Details: detailsHandler,
-	}))
+
+	if c.Options.ExpandRequiredReviewers {
+		details.Handle(pat.Get("/:owner/:repo/:number/reviewers"), hatpear.Try(&handler.DetailsReviewers{
+			Details: detailsHandler,
+		}))
+	}
+
 	mux.Handle(pat.New("/details/*"), details)
 
 	return &Server{


### PR DESCRIPTION
The details page provides an optional feature to expand reviewers for each rule. Previously, the route that implements this was always available, but returned an empty list when the feature was disabled. To minimize the API surface, switch to only registering the route when the feature is enabled.

This also fixes a bug where the handler returned a partial template when someone loaded the route directly in the browser rather than using the expected HTMX flow. This shouldn't happen, but the template data now includes the PullRequest field required to render the full template.

Closes #1161.

