### PR TITLE
Always run ci-all if prior steps don't succeed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,9 +135,16 @@ jobs:
 
   ci-all:
     runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
     needs:
       - Verify
       - Dist
     steps:
-    - name: Complete
-      run: exit 0
+    - name: Check required job results
+      run: |
+        if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+          echo "One or more required jobs did not succeed"
+          echo '${{ toJSON(needs) }}'
+          exit 1
+        fi
+        echo "All required jobs succeeded"

--- a/server/handler/cross_org.go
+++ b/server/handler/cross_org.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v81/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/pkg/errors"

--- a/server/handler/cross_org.go
+++ b/server/handler/cross_org.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v82/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/palantir/policy-bot/pull"
 	"github.com/pkg/errors"


### PR DESCRIPTION
## Before this PR
Attempting to resolve why #1166 merged

Github's [docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-jobs#defining-prerequisite-jobs) tell us that 

```
If a job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue. If a run contains a series of jobs that need each other, a failure or skip applies to all jobs in the dependency chain from the point of failure or skip onwards. If you would like a job to run even if a job it is dependent on did not succeed, use the always()
```

So, even though we Require the verify and dist jobs, the resulting ci-all collection job doesn't actually run. Our model here was adapted from circleci, where it treats the resulting build differently. If a prior required job fails, the downstream one fails too.

This PR attempts to reconcile our approach in github actions so that we continue to use a single final job, which depends on all upstream jobs completing successfully.