### PR TITLE
return full result tree through simulation endpoint

### DIFF
--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -34,14 +34,23 @@ type Simulate struct {
 	Base
 }
 
+// PartialError represents an error from a child rule that was suppressed by its
+// parent (e.g. an Or requirement that cleared the error because a sibling was
+// pending or approved)
+type PartialError struct {
+	Rule  string `json:"rule"`
+	Error string `json:"error"`
+}
+
 // SimulationResponse is the response returned from Simulate, this is a trimmed down version of common.Result with json
 // tags. This struct and the newSimulationResponse constructor can be extended to include extra content from common.Result.
 type SimulationResponse struct {
-	Name              string `json:"name"`
-	Description       string `json:"description:"`
-	StatusDescription string `json:"status_description"`
-	Status            string `json:"status"`
-	Error             string `json:"error"`
+	Name              string          `json:"name"`
+	Description       string          `json:"description:"`
+	StatusDescription string          `json:"status_description"`
+	Status            string          `json:"status"`
+	Error             string          `json:"error"`
+	PartialErrors     []*PartialError `json:"partial_errors,omitempty"`
 }
 
 type ErrorResponse struct {
@@ -174,9 +183,30 @@ func newSimulationResponse(result *common.Result) *SimulationResponse {
 		response.Description = result.Description
 		response.StatusDescription = result.StatusDescription
 		response.Status = result.Status.String()
+		response.PartialErrors = collectPartialErrors(result)
 	}
 
 	return &response
+}
+
+// collectPartialErrors walks the Result tree and returns errors from child
+// results where the child has a non-nil Error but the parent's Error is nil.
+func collectPartialErrors(result *common.Result) []*PartialError {
+	if result == nil {
+		return nil
+	}
+
+	var partials []*PartialError
+	for _, child := range result.Children {
+		if child.Error != nil && result.Error == nil {
+			partials = append(partials, &PartialError{
+				Rule:  child.Name,
+				Error: child.Error.Error(),
+			})
+		}
+		partials = append(partials, collectPartialErrors(child)...)
+	}
+	return partials
 }
 
 func writeAPIError(w http.ResponseWriter, code int, message string) error {

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -34,23 +34,15 @@ type Simulate struct {
 	Base
 }
 
-// PartialError represents an error from a child rule that was suppressed by its
-// parent (e.g. an Or requirement that cleared the error because a sibling was
-// pending or approved)
-type PartialError struct {
-	Rule  string `json:"rule"`
-	Error string `json:"error"`
-}
-
 // SimulationResponse is the response returned from Simulate, this is a trimmed down version of common.Result with json
 // tags. This struct and the newSimulationResponse constructor can be extended to include extra content from common.Result.
 type SimulationResponse struct {
-	Name              string          `json:"name"`
-	Description       string          `json:"description:"`
-	StatusDescription string          `json:"status_description"`
-	Status            string          `json:"status"`
-	Error             string          `json:"error"`
-	PartialErrors     []*PartialError `json:"partial_errors,omitempty"`
+	Name              string                `json:"name"`
+	Description       string                `json:"description"`
+	StatusDescription string                `json:"status_description"`
+	Status            string                `json:"status"`
+	Error             string                `json:"error"`
+	Children          []*SimulationResponse `json:"children,omitempty"`
 }
 
 type ErrorResponse struct {
@@ -183,30 +175,21 @@ func newSimulationResponse(result *common.Result) *SimulationResponse {
 		response.Description = result.Description
 		response.StatusDescription = result.StatusDescription
 		response.Status = result.Status.String()
-		response.PartialErrors = collectPartialErrors(result)
+		response.Children = buildChildren(result.Children)
 	}
 
 	return &response
 }
 
-// collectPartialErrors walks the Result tree and returns errors from child
-// results where the child has a non-nil Error but the parent's Error is nil.
-func collectPartialErrors(result *common.Result) []*PartialError {
-	if result == nil {
+func buildChildren(children []*common.Result) []*SimulationResponse {
+	if len(children) == 0 {
 		return nil
 	}
-
-	var partials []*PartialError
-	for _, child := range result.Children {
-		if child.Error != nil && result.Error == nil {
-			partials = append(partials, &PartialError{
-				Rule:  child.Name,
-				Error: child.Error.Error(),
-			})
-		}
-		partials = append(partials, collectPartialErrors(child)...)
+	result := make([]*SimulationResponse, len(children))
+	for i, child := range children {
+		result[i] = newSimulationResponse(child)
 	}
-	return partials
+	return result
 }
 
 func writeAPIError(w http.ResponseWriter, code int, message string) error {

--- a/server/handler/simulate_test.go
+++ b/server/handler/simulate_test.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectPartialErrors(t *testing.T) {
+	tests := map[string]struct {
+		Result   *common.Result
+		Expected []*PartialError
+	}{
+		"nil result": {
+			Result:   nil,
+			Expected: nil,
+		},
+		"no errors": {
+			Result: &common.Result{
+				Name:   "policy",
+				Status: common.StatusApproved,
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusApproved},
+					{Name: "rule-b", Status: common.StatusApproved},
+				},
+			},
+			Expected: nil,
+		},
+		"top-level error only, no children": {
+			Result: &common.Result{
+				Name:   "policy",
+				Status: common.StatusPending,
+				Error:  fmt.Errorf("top-level failure"),
+			},
+			Expected: nil,
+		},
+		"or: errored child with pending sibling": {
+			Result: &common.Result{
+				Name:   "or",
+				Status: common.StatusPending,
+				Error:  nil,
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusPending},
+					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+				},
+			},
+			Expected: []*PartialError{
+				{Rule: "rule-b", Error: "rule-b failed"},
+			},
+		},
+		"or: errored child with approved sibling": {
+			Result: &common.Result{
+				Name:   "or",
+				Status: common.StatusApproved,
+				Error:  nil,
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusApproved},
+					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+				},
+			},
+			Expected: []*PartialError{
+				{Rule: "rule-b", Error: "rule-b failed"},
+			},
+		},
+		"and: errored child not suppressed": {
+			Result: &common.Result{
+				Name:   "and",
+				Status: common.StatusPending,
+				Error:  fmt.Errorf("child error propagated"),
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusApproved},
+					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+				},
+			},
+			Expected: nil,
+		},
+		"nested: policy -> approval -> or -> children": {
+			Result: &common.Result{
+				Name:   "policy",
+				Status: common.StatusPending,
+				Error:  nil,
+				Children: []*common.Result{
+					{
+						Name:   "approval-rule",
+						Status: common.StatusPending,
+						Error:  nil,
+						Children: []*common.Result{
+							{
+								Name:   "or",
+								Status: common.StatusPending,
+								Error:  nil,
+								Children: []*common.Result{
+									{Name: "rule-a", Status: common.StatusPending},
+									{Name: "rule-b", Error: fmt.Errorf("deep error")},
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: []*PartialError{
+				{Rule: "rule-b", Error: "deep error"},
+			},
+		},
+		"multiple suppressed errors": {
+			Result: &common.Result{
+				Name:   "or",
+				Status: common.StatusPending,
+				Error:  nil,
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusPending},
+					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+					{Name: "rule-c", Error: fmt.Errorf("rule-c failed")},
+				},
+			},
+			Expected: []*PartialError{
+				{Rule: "rule-b", Error: "rule-b failed"},
+				{Rule: "rule-c", Error: "rule-c failed"},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := collectPartialErrors(test.Result)
+			assert.Equal(t, test.Expected, result)
+		})
+	}
+}
+
+func TestNewSimulationResponse(t *testing.T) {
+	tests := map[string]struct {
+		Result   *common.Result
+		Expected *SimulationResponse
+	}{
+		"nil result": {
+			Result:   nil,
+			Expected: &SimulationResponse{},
+		},
+		"result with no errors": {
+			Result: &common.Result{
+				Name:              "my-policy",
+				Description:       "a policy",
+				StatusDescription: "all rules approved",
+				Status:            common.StatusApproved,
+			},
+			Expected: &SimulationResponse{
+				Name:              "my-policy",
+				Description:       "a policy",
+				StatusDescription: "all rules approved",
+				Status:            "approved",
+			},
+		},
+		"result with top-level error": {
+			Result: &common.Result{
+				Name:   "my-policy",
+				Status: common.StatusPending,
+				Error:  fmt.Errorf("something broke"),
+			},
+			Expected: &SimulationResponse{
+				Name:   "my-policy",
+				Status: "pending",
+				Error:  "something broke",
+			},
+		},
+		"result with partial errors": {
+			Result: &common.Result{
+				Name:              "or",
+				Status:            common.StatusPending,
+				StatusDescription: "None of the rules are satisfied",
+				Error:             nil,
+				Children: []*common.Result{
+					{Name: "rule-a", Status: common.StatusPending},
+					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+				},
+			},
+			Expected: &SimulationResponse{
+				Name:              "or",
+				Status:            "pending",
+				StatusDescription: "None of the rules are satisfied",
+				PartialErrors: []*PartialError{
+					{Rule: "rule-b", Error: "rule-b failed"},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			response := newSimulationResponse(test.Result)
+			assert.Equal(t, test.Expected, response)
+		})
+	}
+}
+
+func TestSimulationResponseJSON(t *testing.T) {
+	t.Run("field names are correct", func(t *testing.T) {
+		resp := &SimulationResponse{
+			Name:              "my-policy",
+			Description:       "a policy",
+			StatusDescription: "all rules approved",
+			Status:            "approved",
+			Error:             "something broke",
+			PartialErrors: []*PartialError{
+				{Rule: "rule-b", Error: "rule-b failed"},
+			},
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var fields map[string]json.RawMessage
+		err = json.Unmarshal(data, &fields)
+		require.NoError(t, err)
+
+		expectedKeys := []string{"name", "description:", "status_description", "status", "error", "partial_errors"}
+		for _, key := range expectedKeys {
+			assert.Contains(t, fields, key, "missing expected JSON field %q", key)
+		}
+	})
+
+	t.Run("partial_errors omitted when empty", func(t *testing.T) {
+		resp := &SimulationResponse{
+			Name:   "my-policy",
+			Status: "approved",
+		}
+
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var fields map[string]json.RawMessage
+		err = json.Unmarshal(data, &fields)
+		require.NoError(t, err)
+
+		assert.NotContains(t, fields, "partial_errors")
+	})
+}

--- a/server/handler/simulate_test.go
+++ b/server/handler/simulate_test.go
@@ -24,128 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCollectPartialErrors(t *testing.T) {
-	tests := map[string]struct {
-		Result   *common.Result
-		Expected []*PartialError
-	}{
-		"nil result": {
-			Result:   nil,
-			Expected: nil,
-		},
-		"no errors": {
-			Result: &common.Result{
-				Name:   "policy",
-				Status: common.StatusApproved,
-				Children: []*common.Result{
-					{Name: "rule-a", Status: common.StatusApproved},
-					{Name: "rule-b", Status: common.StatusApproved},
-				},
-			},
-			Expected: nil,
-		},
-		"top-level error only, no children": {
-			Result: &common.Result{
-				Name:   "policy",
-				Status: common.StatusPending,
-				Error:  fmt.Errorf("top-level failure"),
-			},
-			Expected: nil,
-		},
-		"or: errored child with pending sibling": {
-			Result: &common.Result{
-				Name:   "or",
-				Status: common.StatusPending,
-				Error:  nil,
-				Children: []*common.Result{
-					{Name: "rule-a", Status: common.StatusPending},
-					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
-				},
-			},
-			Expected: []*PartialError{
-				{Rule: "rule-b", Error: "rule-b failed"},
-			},
-		},
-		"or: errored child with approved sibling": {
-			Result: &common.Result{
-				Name:   "or",
-				Status: common.StatusApproved,
-				Error:  nil,
-				Children: []*common.Result{
-					{Name: "rule-a", Status: common.StatusApproved},
-					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
-				},
-			},
-			Expected: []*PartialError{
-				{Rule: "rule-b", Error: "rule-b failed"},
-			},
-		},
-		"and: errored child not suppressed": {
-			Result: &common.Result{
-				Name:   "and",
-				Status: common.StatusPending,
-				Error:  fmt.Errorf("child error propagated"),
-				Children: []*common.Result{
-					{Name: "rule-a", Status: common.StatusApproved},
-					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
-				},
-			},
-			Expected: nil,
-		},
-		"nested: policy -> approval -> or -> children": {
-			Result: &common.Result{
-				Name:   "policy",
-				Status: common.StatusPending,
-				Error:  nil,
-				Children: []*common.Result{
-					{
-						Name:   "approval-rule",
-						Status: common.StatusPending,
-						Error:  nil,
-						Children: []*common.Result{
-							{
-								Name:   "or",
-								Status: common.StatusPending,
-								Error:  nil,
-								Children: []*common.Result{
-									{Name: "rule-a", Status: common.StatusPending},
-									{Name: "rule-b", Error: fmt.Errorf("deep error")},
-								},
-							},
-						},
-					},
-				},
-			},
-			Expected: []*PartialError{
-				{Rule: "rule-b", Error: "deep error"},
-			},
-		},
-		"multiple suppressed errors": {
-			Result: &common.Result{
-				Name:   "or",
-				Status: common.StatusPending,
-				Error:  nil,
-				Children: []*common.Result{
-					{Name: "rule-a", Status: common.StatusPending},
-					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
-					{Name: "rule-c", Error: fmt.Errorf("rule-c failed")},
-				},
-			},
-			Expected: []*PartialError{
-				{Rule: "rule-b", Error: "rule-b failed"},
-				{Rule: "rule-c", Error: "rule-c failed"},
-			},
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			result := collectPartialErrors(test.Result)
-			assert.Equal(t, test.Expected, result)
-		})
-	}
-}
-
 func TestNewSimulationResponse(t *testing.T) {
 	tests := map[string]struct {
 		Result   *common.Result
@@ -155,7 +33,7 @@ func TestNewSimulationResponse(t *testing.T) {
 			Result:   nil,
 			Expected: &SimulationResponse{},
 		},
-		"result with no errors": {
+		"result with no errors and no children": {
 			Result: &common.Result{
 				Name:              "my-policy",
 				Description:       "a policy",
@@ -181,23 +59,65 @@ func TestNewSimulationResponse(t *testing.T) {
 				Error:  "something broke",
 			},
 		},
-		"result with partial errors": {
+		"result with children": {
 			Result: &common.Result{
 				Name:              "or",
 				Status:            common.StatusPending,
 				StatusDescription: "None of the rules are satisfied",
-				Error:             nil,
 				Children: []*common.Result{
 					{Name: "rule-a", Status: common.StatusPending},
-					{Name: "rule-b", Error: fmt.Errorf("rule-b failed")},
+					{Name: "rule-b", Status: common.StatusApproved, Error: fmt.Errorf("rule-b failed")},
 				},
 			},
 			Expected: &SimulationResponse{
 				Name:              "or",
 				Status:            "pending",
 				StatusDescription: "None of the rules are satisfied",
-				PartialErrors: []*PartialError{
-					{Rule: "rule-b", Error: "rule-b failed"},
+				Children: []*SimulationResponse{
+					{Name: "rule-a", Status: "pending"},
+					{Name: "rule-b", Status: "approved", Error: "rule-b failed"},
+				},
+			},
+		},
+		"nested tree": {
+			Result: &common.Result{
+				Name:   "policy",
+				Status: common.StatusPending,
+				Children: []*common.Result{
+					{
+						Name:   "approval-rule",
+						Status: common.StatusPending,
+						Children: []*common.Result{
+							{
+								Name:   "or",
+								Status: common.StatusPending,
+								Children: []*common.Result{
+									{Name: "rule-a", Status: common.StatusPending},
+									{Name: "rule-b", Status: common.StatusSkipped, Error: fmt.Errorf("deep error")},
+								},
+							},
+						},
+					},
+				},
+			},
+			Expected: &SimulationResponse{
+				Name:   "policy",
+				Status: "pending",
+				Children: []*SimulationResponse{
+					{
+						Name:   "approval-rule",
+						Status: "pending",
+						Children: []*SimulationResponse{
+							{
+								Name:   "or",
+								Status: "pending",
+								Children: []*SimulationResponse{
+									{Name: "rule-a", Status: "pending"},
+									{Name: "rule-b", Status: "skipped", Error: "deep error"},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -219,8 +139,8 @@ func TestSimulationResponseJSON(t *testing.T) {
 			StatusDescription: "all rules approved",
 			Status:            "approved",
 			Error:             "something broke",
-			PartialErrors: []*PartialError{
-				{Rule: "rule-b", Error: "rule-b failed"},
+			Children: []*SimulationResponse{
+				{Name: "rule-a", Status: "approved"},
 			},
 		}
 
@@ -231,13 +151,13 @@ func TestSimulationResponseJSON(t *testing.T) {
 		err = json.Unmarshal(data, &fields)
 		require.NoError(t, err)
 
-		expectedKeys := []string{"name", "description:", "status_description", "status", "error", "partial_errors"}
+		expectedKeys := []string{"name", "description", "status_description", "status", "error", "children"}
 		for _, key := range expectedKeys {
 			assert.Contains(t, fields, key, "missing expected JSON field %q", key)
 		}
 	})
 
-	t.Run("partial_errors omitted when empty", func(t *testing.T) {
+	t.Run("children omitted when empty", func(t *testing.T) {
 		resp := &SimulationResponse{
 			Name:   "my-policy",
 			Status: "approved",
@@ -250,6 +170,6 @@ func TestSimulationResponseJSON(t *testing.T) {
 		err = json.Unmarshal(data, &fields)
 		require.NoError(t, err)
 
-		assert.NotContains(t, fields, "partial_errors")
+		assert.NotContains(t, fields, "children")
 	})
 }


### PR DESCRIPTION
## Before this PR
When Policy Bot's simulation API encountered partial failures (e.g., an or requirement where one child errors but a sibling is pending or approved), the child error is ignored. The API returns status: "pending" or status: "approved" with no error, giving callers no way to see that a branch is broken and impossible to satisfy.

## After this PR
The simulation API response includes a partial_errors field that returns suppressed child errors. Callers can check len(partial_errors) > 0 to detect broken branches and trigger fallback behavior, if needed. This change should be backwards compatible since it will be ignored unless the caller decides to deserialize partial_errors.

## Possible downsides?
Since it is backwards compatible there should be little downside. It may increase the response time but it only traversing the tree once so that should be minimal.


Tested by creating a pr with over 3000 files and hitting the simulation endpoint when the overall policy is returning status approved but still has child errors
