### PR TITLE
feat: auto approve flag

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -29,12 +29,12 @@ import (
 )
 
 type Rule struct {
-	Name        string               `yaml:"name,omitempty"`
-	Description string               `yaml:"description,omitempty"`
-	AutoApprove bool                 `yaml:"auto_approve,omitempty"`
-	Predicates  predicate.Predicates `yaml:"if,omitempty"`
-	Options     Options              `yaml:"options,omitempty"`
-	Requires    Requires             `yaml:"requires,omitempty"`
+	Name             string               `yaml:"name,omitempty"`
+	Description      string               `yaml:"description,omitempty"`
+	PostGithubReview bool                 `yaml:"post_github_review,omitempty"`
+	Predicates       predicate.Predicates `yaml:"if,omitempty"`
+	Options          Options              `yaml:"options,omitempty"`
+	Requires         Requires             `yaml:"requires,omitempty"`
 }
 
 type Requires struct {
@@ -80,7 +80,7 @@ func (r *Rule) Evaluate(ctx context.Context, prctx pull.Context) (res common.Res
 	res.Description = r.Description
 	res.Status = common.StatusSkipped
 	res.Methods = r.Options.GetMethods()
-	res.AutoApprove = r.AutoApprove
+	res.PostGithubReview = r.PostGithubReview
 
 	var predicateResults []*common.PredicateResult
 

--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -31,6 +31,7 @@ import (
 type Rule struct {
 	Name        string               `yaml:"name,omitempty"`
 	Description string               `yaml:"description,omitempty"`
+	AutoApprove bool                 `yaml:"auto_approve,omitempty"`
 	Predicates  predicate.Predicates `yaml:"if,omitempty"`
 	Options     Options              `yaml:"options,omitempty"`
 	Requires    Requires             `yaml:"requires,omitempty"`
@@ -79,6 +80,7 @@ func (r *Rule) Evaluate(ctx context.Context, prctx pull.Context) (res common.Res
 	res.Description = r.Description
 	res.Status = common.StatusSkipped
 	res.Methods = r.Options.GetMethods()
+	res.AutoApprove = r.AutoApprove
 
 	var predicateResults []*common.PredicateResult
 

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -69,9 +69,9 @@ type Result struct {
 	PredicateResults  []*PredicateResult
 	Methods           *Methods
 
-	// AutoApprove indicates this rule should trigger a GitHub APPROVE review
+	// PostGithubReview indicates this rule should trigger a GitHub APPROVE review
 	// when the overall policy evaluates to approved.
-	AutoApprove bool
+	PostGithubReview bool
 
 	// Requires contains the result of evaluating the rule's
 	// requirements.

--- a/policy/common/result.go
+++ b/policy/common/result.go
@@ -69,6 +69,10 @@ type Result struct {
 	PredicateResults  []*PredicateResult
 	Methods           *Methods
 
+	// AutoApprove indicates this rule should trigger a GitHub APPROVE review
+	// when the overall policy evaluates to approved.
+	AutoApprove bool
+
 	// Requires contains the result of evaluating the rule's
 	// requirements.
 	Requires RequiresResult

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -167,6 +167,10 @@ func (ec *EvalContext) EvaluatePolicy(ctx context.Context, evaluator common.Eval
 func (ec *EvalContext) RunPostEvaluateActions(ctx context.Context, result common.Result, trigger common.Trigger) {
 	logger := zerolog.Ctx(ctx)
 
+	if err := ec.autoApproveReviewsForResult(ctx, trigger, result); err != nil {
+		logger.Error().Err(err).Msg("Failed to auto approve the pr")
+	}
+
 	if err := ec.requestReviewsForResult(ctx, trigger, result); err != nil {
 		logger.Error().Err(err).Msg("Failed to request reviewers")
 	}

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -167,7 +167,7 @@ func (ec *EvalContext) EvaluatePolicy(ctx context.Context, evaluator common.Eval
 func (ec *EvalContext) RunPostEvaluateActions(ctx context.Context, result common.Result, trigger common.Trigger) {
 	logger := zerolog.Ctx(ctx)
 
-	if err := ec.autoApproveReviewsForResult(ctx, trigger, result); err != nil {
+	if err := ec.postGithubReviewsForResult(ctx, trigger, result); err != nil {
 		logger.Error().Err(err).Msg("Failed to auto approve the pr")
 	}
 

--- a/server/handler/eval_context_reviewers.go
+++ b/server/handler/eval_context_reviewers.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"slices"
 	"time"
@@ -27,6 +28,63 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
+
+func (ec *EvalContext) autoApproveReviewsForResult(ctx context.Context, trigger common.Trigger, result common.Result) error {
+	if !hasAutoApproveRule(&result) {
+		return nil
+	}
+
+	logger := zerolog.Ctx(ctx)
+	owner := ec.PullContext.RepositoryOwner()
+	repoName := ec.PullContext.RepositoryName()
+	number := ec.PullContext.Number()
+
+	if ec.PullContext.IsDraft() || result.Status != common.StatusApproved {
+		msg := fmt.Sprintf("pull request: %s/%s/%d is not approved", owner, repoName, number)
+		logger.Debug().Str("status", result.Status.String()).Msg(msg)
+		return nil
+	}
+
+	reviewTrigger := ^(common.TriggerComment | common.TriggerReview)
+	if !trigger.Matches(reviewTrigger) {
+		return nil
+	}
+
+	// if head commit is already approved, skip this step
+	headSha := ec.PullContext.HeadSHA()
+	reviews, err := ec.PullContext.Reviews()
+	if err != nil {
+		return err
+	}
+
+	for _, r := range reviews {
+		if headSha == r.SHA && r.State == pull.ReviewApproved {
+			msg := fmt.Sprintf("pull request: %s/%s/%d already approved. skipping auto approval", owner, repoName, number)
+			logger.Debug().Msg(msg)
+			return nil
+		}
+	}
+
+	//approve latest commit
+	rev := &github.PullRequestReviewRequest{
+		CommitID: github.String(headSha),
+		Body:     github.String("LGTM!"),
+		Event:    github.String("APPROVE"),
+	}
+
+	_, _, err = ec.Client.PullRequests.CreateReview(ctx, owner, repoName, number, rev)
+	if err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("Auto approving pr: %s/%s/%d", owner, repoName, number)
+	logger.Debug().
+		Str("event_trigger", trigger.String()).
+		Str("status", result.Status.String()).
+		Msg(msg)
+
+	return nil
+}
 
 func (ec *EvalContext) requestReviewsForResult(ctx context.Context, trigger common.Trigger, result common.Result) error {
 	logger := zerolog.Ctx(ctx)
@@ -159,4 +217,18 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 	req.TeamReviewers = slices.Compact(req.TeamReviewers)
 
 	return req
+}
+
+// hasAutoApproveRule walks the result tree and returns true if any approved
+// rule has AutoApprove set.
+func hasAutoApproveRule(result *common.Result) bool {
+	if result.AutoApprove && result.Status == common.StatusApproved {
+		return true
+	}
+	for _, child := range result.Children {
+		if hasAutoApproveRule(child) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/handler/eval_context_reviewers.go
+++ b/server/handler/eval_context_reviewers.go
@@ -29,8 +29,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func (ec *EvalContext) autoApproveReviewsForResult(ctx context.Context, trigger common.Trigger, result common.Result) error {
-	if !hasAutoApproveRule(&result) {
+func (ec *EvalContext) postGithubReviewsForResult(ctx context.Context, trigger common.Trigger, result common.Result) error {
+	if !hasPostGithubReviewRule(&result) {
 		return nil
 	}
 
@@ -219,14 +219,14 @@ func selectionToReviewersRequest(s reviewer.Selection) github.ReviewersRequest {
 	return req
 }
 
-// hasAutoApproveRule walks the result tree and returns true if any approved
-// rule has AutoApprove set.
-func hasAutoApproveRule(result *common.Result) bool {
-	if result.AutoApprove && result.Status == common.StatusApproved {
+// hasPostGithubReviewRule walks the result tree and returns true if any approved
+// rule has PostGithubReview set.
+func hasPostGithubReviewRule(result *common.Result) bool {
+	if result.PostGithubReview && result.Status == common.StatusApproved {
 		return true
 	}
 	for _, child := range result.Children {
-		if hasAutoApproveRule(child) {
+		if hasPostGithubReviewRule(child) {
 			return true
 		}
 	}

--- a/server/handler/eval_context_reviewers_test.go
+++ b/server/handler/eval_context_reviewers_test.go
@@ -21,39 +21,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHasAutoApproveRule(t *testing.T) {
+func TestHasPostGithubReviewRule(t *testing.T) {
 	tests := map[string]struct {
 		Result   *common.Result
 		Expected bool
 	}{
-		"noAutoApprove": {
+		"noPostGithubReview": {
 			Result: &common.Result{
 				Status: common.StatusApproved,
 			},
 			Expected: false,
 		},
-		"autoApproveAndApproved": {
+		"postGithubReviewAndApproved": {
 			Result: &common.Result{
-				AutoApprove: true,
-				Status:      common.StatusApproved,
+				PostGithubReview: true,
+				Status:           common.StatusApproved,
 			},
 			Expected: true,
 		},
-		"autoApproveButPending": {
+		"postGithubReviewButPending": {
 			Result: &common.Result{
-				AutoApprove: true,
-				Status:      common.StatusPending,
+				PostGithubReview: true,
+				Status:           common.StatusPending,
 			},
 			Expected: false,
 		},
-		"autoApproveButSkipped": {
+		"postGithubReviewButSkipped": {
 			Result: &common.Result{
-				AutoApprove: true,
-				Status:      common.StatusSkipped,
+				PostGithubReview: true,
+				Status:           common.StatusSkipped,
 			},
 			Expected: false,
 		},
-		"childHasAutoApproveAndApproved": {
+		"childHasPostGithubReviewAndApproved": {
 			Result: &common.Result{
 				Status: common.StatusApproved,
 				Children: []*common.Result{
@@ -61,26 +61,26 @@ func TestHasAutoApproveRule(t *testing.T) {
 						Status: common.StatusApproved,
 					},
 					{
-						AutoApprove: true,
-						Status:      common.StatusApproved,
+						PostGithubReview: true,
+						Status:           common.StatusApproved,
 					},
 				},
 			},
 			Expected: true,
 		},
-		"childHasAutoApproveButPending": {
+		"childHasPostGithubReviewButPending": {
 			Result: &common.Result{
 				Status: common.StatusPending,
 				Children: []*common.Result{
 					{
-						AutoApprove: true,
-						Status:      common.StatusPending,
+						PostGithubReview: true,
+						Status:           common.StatusPending,
 					},
 				},
 			},
 			Expected: false,
 		},
-		"deeplyNestedAutoApprove": {
+		"deeplyNestedPostGithubReview": {
 			Result: &common.Result{
 				Status: common.StatusApproved,
 				Children: []*common.Result{
@@ -88,8 +88,8 @@ func TestHasAutoApproveRule(t *testing.T) {
 						Status: common.StatusApproved,
 						Children: []*common.Result{
 							{
-								AutoApprove: true,
-								Status:      common.StatusApproved,
+								PostGithubReview: true,
+								Status:           common.StatusApproved,
 							},
 						},
 					},
@@ -97,7 +97,7 @@ func TestHasAutoApproveRule(t *testing.T) {
 			},
 			Expected: true,
 		},
-		"multipleChildrenOnlyOneAutoApprove": {
+		"multipleChildrenOnlyOnePostGithubReview": {
 			Result: &common.Result{
 				Status: common.StatusApproved,
 				Children: []*common.Result{
@@ -108,8 +108,8 @@ func TestHasAutoApproveRule(t *testing.T) {
 						Status: common.StatusApproved,
 					},
 					{
-						AutoApprove: true,
-						Status:      common.StatusApproved,
+						PostGithubReview: true,
+						Status:           common.StatusApproved,
 					},
 				},
 			},
@@ -123,7 +123,7 @@ func TestHasAutoApproveRule(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := hasAutoApproveRule(test.Result)
+			actual := hasPostGithubReviewRule(test.Result)
 			assert.Equal(t, test.Expected, actual)
 		})
 	}

--- a/server/handler/eval_context_reviewers_test.go
+++ b/server/handler/eval_context_reviewers_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasAutoApproveRule(t *testing.T) {
+	tests := map[string]struct {
+		Result   *common.Result
+		Expected bool
+	}{
+		"noAutoApprove": {
+			Result: &common.Result{
+				Status: common.StatusApproved,
+			},
+			Expected: false,
+		},
+		"autoApproveAndApproved": {
+			Result: &common.Result{
+				AutoApprove: true,
+				Status:      common.StatusApproved,
+			},
+			Expected: true,
+		},
+		"autoApproveButPending": {
+			Result: &common.Result{
+				AutoApprove: true,
+				Status:      common.StatusPending,
+			},
+			Expected: false,
+		},
+		"autoApproveButSkipped": {
+			Result: &common.Result{
+				AutoApprove: true,
+				Status:      common.StatusSkipped,
+			},
+			Expected: false,
+		},
+		"childHasAutoApproveAndApproved": {
+			Result: &common.Result{
+				Status: common.StatusApproved,
+				Children: []*common.Result{
+					{
+						Status: common.StatusApproved,
+					},
+					{
+						AutoApprove: true,
+						Status:      common.StatusApproved,
+					},
+				},
+			},
+			Expected: true,
+		},
+		"childHasAutoApproveButPending": {
+			Result: &common.Result{
+				Status: common.StatusPending,
+				Children: []*common.Result{
+					{
+						AutoApprove: true,
+						Status:      common.StatusPending,
+					},
+				},
+			},
+			Expected: false,
+		},
+		"deeplyNestedAutoApprove": {
+			Result: &common.Result{
+				Status: common.StatusApproved,
+				Children: []*common.Result{
+					{
+						Status: common.StatusApproved,
+						Children: []*common.Result{
+							{
+								AutoApprove: true,
+								Status:      common.StatusApproved,
+							},
+						},
+					},
+				},
+			},
+			Expected: true,
+		},
+		"multipleChildrenOnlyOneAutoApprove": {
+			Result: &common.Result{
+				Status: common.StatusApproved,
+				Children: []*common.Result{
+					{
+						Status: common.StatusSkipped,
+					},
+					{
+						Status: common.StatusApproved,
+					},
+					{
+						AutoApprove: true,
+						Status:      common.StatusApproved,
+					},
+				},
+			},
+			Expected: true,
+		},
+		"noChildren": {
+			Result:   &common.Result{},
+			Expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := hasAutoApproveRule(test.Result)
+			assert.Equal(t, test.Expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Hey guys, 

I've added support for an auto_approve option on approval rules. This allows policy-bot to submit a GitHub APPROVE review when a rule's predicates and conditions are satisfied, which is useful for repos that require both status
checks and approving reviews as branch protection rules.

Happy to adjust the implementation based on your feedback. Let me know if this is something you'd be open to merging!


## Before this PR
```
When a policy rule evaluates to approved based on predicates (e.g., only docs files changed), policy-bot posts a passing commit status but does not submit a GitHub APPROVE review. Repos that require both status checks and approving
reviews still block these PRs, requiring a human to rubber-stamp them.
```

## After this PR
```
Rules can set auto_approve: true in .policy.yml. When the overall policy evaluates to approved and an auto-approve rule is satisfied, policy-bot submits a GitHub APPROVE review on the head commit, satisfying the required reviews branch
protection rule without human intervention.
```

## Possible downsides?
```
The bot's APPROVE review counts toward GitHub's required reviewers. Teams that rely on required review counts for human oversight should be careful not to set auto_approve on rules where human review is still expected.
```

example usage that we currently leverage: 
```
policy:
    approval:
      - or:
        - human approval
        - auto approve

  approval_rules:
    - name: auto approve
      auto_approve: true
      if:
        has_author_in:
          teams: ["<org>/<team>"]
          users: ["<bot-user>"]
        no_changed_files:
          paths:
            - "^<path-pattern>$"
      requires:
        conditions:
          opa_check:
            checks:
              - "<opa-policy>"
    - name: human approval
      requires:
        count: 1
        teams:
          - "<org>/<team>"
```
