### PR TITLE
Surface failing/missing checks in has_status status description

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -443,12 +443,25 @@ func statusDescription(approved bool, result common.RequiresResult, candidates [
 		}
 
 		successful := 0
+		var conditionDetails []string
 		for _, c := range result.Conditions {
 			if c.Satisfied {
 				successful++
+				continue
+			}
+			// Surface predicate-level details (e.g. specific failing status
+			// checks from has_status) so the GitHub status check is
+			// actionable, not just a "X/Y required conditions" count. Each
+			// condition predicate that fails contributes its Description; we
+			// keep this single-pass so order matches policy.yml order.
+			if c.Description != "" {
+				conditionDetails = append(conditionDetails, c.Description)
 			}
 		}
 		fmt.Fprintf(&desc, "%d/%d required conditions", successful, len(result.Conditions))
+		if len(conditionDetails) > 0 {
+			fmt.Fprintf(&desc, " [%s]", strings.Join(conditionDetails, "; "))
+		}
 	}
 	if disqualified := len(candidates) - len(result.Approvers); hasActors && disqualified > 0 {
 		fmt.Fprintf(&desc, ". Ignored %s from disqualified users", numberOfApprovals(disqualified))

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -749,7 +749,12 @@ func TestIsApproved(t *testing.T) {
 				},
 			},
 		}
-		assertPending(t, prctx, r, "0/1 required conditions")
+		// The fixture has "deploy" = "pending", which is not in the default
+		// allowed conclusion of "success", so the rule remains pending and
+		// the status description must name the blocking check so a reader
+		// of the GitHub status check can act without opening the policy-bot
+		// details page.
+		assertPending(t, prctx, r, "0/1 required conditions [Pending (not in allowed conclusions success): deploy]")
 	})
 
 	t.Run("conditionsRequiredStatusSuccess", func(t *testing.T) {

--- a/policy/approval/evaluate.go
+++ b/policy/approval/evaluate.go
@@ -17,6 +17,7 @@ package approval
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
@@ -157,6 +158,7 @@ func (r *AndRequirement) Evaluate(ctx context.Context, prctx pull.Context) commo
 
 	var err error
 	var pending, approved, skipped int
+	var pendingDetails []string
 	for _, c := range children {
 		if c.Error != nil {
 			err = c.Error
@@ -168,6 +170,14 @@ func (r *AndRequirement) Evaluate(ctx context.Context, prctx pull.Context) commo
 			approved++
 		case common.StatusPending:
 			pending++
+			// Capture the pending rule's StatusDescription so the top-level
+			// status posted to GitHub names the actual blocker (e.g. the
+			// failing has_status checks) instead of just "X/Y rules approved".
+			// We collect from every pending rule because in an AND, all of
+			// them must clear before merge.
+			if d := pendingRuleDetail(c); d != "" {
+				pendingDetails = append(pendingDetails, d)
+			}
 		case common.StatusSkipped:
 			skipped++
 		}
@@ -183,6 +193,9 @@ func (r *AndRequirement) Evaluate(ctx context.Context, prctx pull.Context) commo
 	case pending > 0:
 		status = common.StatusPending
 		description = fmt.Sprintf("%d/%d rules approved", approved, approved+pending)
+		if len(pendingDetails) > 0 {
+			description = fmt.Sprintf("%s; %s", description, joinPendingDetails(pendingDetails))
+		}
 	}
 
 	return common.Result{
@@ -192,4 +205,32 @@ func (r *AndRequirement) Evaluate(ctx context.Context, prctx pull.Context) commo
 		Error:             err,
 		Children:          children,
 	}
+}
+
+// pendingRuleDetail returns a human-readable, blocker-focused suffix for a
+// child rule that is currently pending. The rule's own StatusDescription
+// already encodes either the failing condition predicates (set by
+// statusDescription in approve.go) or the failing precondition predicate (set
+// by Rule.Evaluate when a predicate is not satisfied). We prefer to include
+// the rule name so a reader can correlate the message with the policy.yml.
+func pendingRuleDetail(c *common.Result) string {
+	desc := strings.TrimSpace(c.StatusDescription)
+	if desc == "" {
+		return ""
+	}
+	if c.Name == "" {
+		return desc
+	}
+	return fmt.Sprintf("%q: %s", c.Name, desc)
+}
+
+// joinPendingDetails concatenates pending-rule details with a stable
+// delimiter. We deliberately do not truncate here: the full description is
+// rendered on the policy-bot details page and emitted to logs, and GitHub's
+// own 140-character commit status limit will truncate the message at post
+// time. Truncating internally would hide the actionable detail from the
+// details page and logs while only saving bytes that GitHub would discard
+// anyway.
+func joinPendingDetails(details []string) string {
+	return strings.Join(details, " | ")
 }

--- a/policy/has_status_description_integration_test.go
+++ b/policy/has_status_description_integration_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+// TestHasStatusDescriptiveErrors_Integration drives the full policy
+// evaluation pipeline using a real .policy.yml that mirrors how FINN
+// repositories pin a list of CI status checks as approval conditions.
+// The test asserts that the StatusDescription produced by the top-level
+// evaluator (the same value posted to GitHub as the policy-bot status
+// check description and rendered on the policy-bot details page) names
+// the specific checks that are blocking the merge.
+//
+// This is an integration test in the sense that it exercises the same
+// ParsePolicy -> evaluator.Evaluate -> AndRequirement.Evaluate ->
+// Rule.Evaluate -> HasStatus.Evaluate chain that the production webhook
+// handler invokes. We deliberately do not spin up a docker-compose
+// environment here because policy-bot has no docker-compose-driven
+// integration harness today and the descriptive-errors change lives
+// entirely inside the in-process evaluator. See README.md "Development"
+// section for the supported test entry point (./godelw verify).
+func TestHasStatusDescriptiveErrors_Integration(t *testing.T) {
+	ctx := context.Background()
+
+	// A representative FINN-shaped .policy.yml: a single rule that
+	// requires four status checks to succeed. Names include realistic
+	// characters (brackets, spaces) that we have seen break ad-hoc
+	// regex-based check parsers; the descriptive errors must survive
+	// those characters unmodified.
+	const policyYAML = `
+approval_rules:
+  - name: required ci checks
+    requires:
+      conditions:
+        has_status:
+          statuses:
+            - "pre-commit-check"
+            - "[Console_backend] SonarCloud Code Analysis"
+            - "Tests with Coverage"
+            - "Validate GrowthBook Link"
+policy:
+  approval:
+    - "required ci checks"
+`
+
+	parseEvaluator := func(t *testing.T) common.Evaluator {
+		t.Helper()
+		var cfg Config
+		require.NoError(t, yaml.Unmarshal([]byte(policyYAML), &cfg))
+		eval, err := ParsePolicy(&cfg, nil)
+		require.NoError(t, err)
+		return eval
+	}
+
+	t.Run("all_required_status_checks_succeed", func(t *testing.T) {
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"pre-commit-check":                           "success",
+				"[Console_backend] SonarCloud Code Analysis": "success",
+				"Tests with Coverage":                        "success",
+				"Validate GrowthBook Link":                   "success",
+			},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusApproved, res.Status, "policy should be approved when all checks succeed")
+	})
+
+	t.Run("missing_check_is_named_in_status_description", func(t *testing.T) {
+		// Mirrors the exact failure mode we hit on DEV-2637: sync PRs
+		// blocked by "policy-bot: main = ERROR" with no actionable
+		// detail. The missing pre-commit-check check must be named in
+		// the status description (which is what GitHub renders).
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"[Console_backend] SonarCloud Code Analysis": "success",
+				"Tests with Coverage":                        "success",
+				"Validate GrowthBook Link":                   "success",
+			},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "Waiting on: pre-commit-check",
+			"status description must name the missing check; got %q", res.StatusDescription)
+	})
+
+	t.Run("failing_check_is_named_with_failure_label", func(t *testing.T) {
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"pre-commit-check":                           "success",
+				"[Console_backend] SonarCloud Code Analysis": "success",
+				"Tests with Coverage":                        "failure",
+				"Validate GrowthBook Link":                   "success",
+			},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "Failing: Tests with Coverage",
+			"status description must name the failing check; got %q", res.StatusDescription)
+	})
+
+	t.Run("skipped_check_is_distinguished_from_failure", func(t *testing.T) {
+		// When a check completes with a non-success conclusion that is
+		// not in the allowed conclusions, the description must
+		// distinguish the conclusion (skipped, cancelled, etc.) from a
+		// plain failure so a reader can decide whether to retry, rerun,
+		// or fix a flaky check.
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"pre-commit-check":                           "success",
+				"[Console_backend] SonarCloud Code Analysis": "success",
+				"Tests with Coverage":                        "success",
+				"Validate GrowthBook Link":                   "skipped",
+			},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "Validate GrowthBook Link",
+			"status description must name the skipped check; got %q", res.StatusDescription)
+		assert.True(t,
+			strings.Contains(res.StatusDescription, "Skipped") || strings.Contains(res.StatusDescription, "skipped"),
+			"status description must mark the check as skipped, not failed; got %q", res.StatusDescription)
+		assert.NotContains(t, res.StatusDescription, "Failing:",
+			"a skipped check must not be reported as a failure; got %q", res.StatusDescription)
+	})
+
+	t.Run("multiple_blocker_categories_appear_together", func(t *testing.T) {
+		// One missing, one failing, one skipped. All three must surface
+		// in the same status description so the reader sees the
+		// complete blocker set without having to refresh the PR.
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"[Console_backend] SonarCloud Code Analysis": "success",
+				"Tests with Coverage":                        "failure",
+				"Validate GrowthBook Link":                   "skipped",
+			},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "Waiting on: pre-commit-check",
+			"missing check must surface; got %q", res.StatusDescription)
+		assert.Contains(t, res.StatusDescription, "Failing: Tests with Coverage",
+			"failing check must surface; got %q", res.StatusDescription)
+		assert.Contains(t, res.StatusDescription, "Validate GrowthBook Link",
+			"skipped check must surface; got %q", res.StatusDescription)
+	})
+
+	t.Run("rule_name_appears_in_aggregated_description", func(t *testing.T) {
+		// When multiple top-level rules combine via the implicit AND,
+		// each pending rule must contribute its name so a reader can
+		// correlate the blocker with the policy.yml entry.
+		const multiRulePolicy = `
+approval_rules:
+  - name: backend-ci
+    requires:
+      conditions:
+        has_status:
+          statuses: ["backend-tests"]
+  - name: frontend-ci
+    requires:
+      conditions:
+        has_status:
+          statuses: ["frontend-tests"]
+policy:
+  approval:
+    - "backend-ci"
+    - "frontend-ci"
+`
+		var cfg Config
+		require.NoError(t, yaml.Unmarshal([]byte(multiRulePolicy), &cfg))
+		eval, err := ParsePolicy(&cfg, nil)
+		require.NoError(t, err)
+
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"backend-tests": "success",
+				// frontend-tests is missing
+			},
+		}
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "frontend-ci",
+			"status description must name the blocking rule; got %q", res.StatusDescription)
+		assert.Contains(t, res.StatusDescription, "frontend-tests",
+			"status description must name the missing check; got %q", res.StatusDescription)
+	})
+
+	t.Run("description_includes_rule_count_for_compatibility", func(t *testing.T) {
+		// We must preserve the historical "X/Y rules approved" prefix
+		// so external dashboards or alerting that grep this string
+		// continue to work. The new detail is appended after the
+		// prefix, not in place of it.
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{},
+		}
+		eval := parseEvaluator(t)
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Contains(t, res.StatusDescription, "0/1 rules approved",
+			"legacy prefix must be preserved; got %q", res.StatusDescription)
+	})
+
+	t.Run("skipped_conclusion_in_allowed_list_is_treated_as_success", func(t *testing.T) {
+		// When the policy explicitly allows "skipped" as a successful
+		// conclusion, a skipped check must not appear in the
+		// description and the rule must be approved.
+		const allowedSkippedPolicy = `
+approval_rules:
+  - name: tolerant-ci
+    requires:
+      conditions:
+        has_status:
+          conclusions: ["success", "skipped"]
+          statuses: ["optional-lint"]
+policy:
+  approval:
+    - "tolerant-ci"
+`
+		var cfg Config
+		require.NoError(t, yaml.Unmarshal([]byte(allowedSkippedPolicy), &cfg))
+		eval, err := ParsePolicy(&cfg, nil)
+		require.NoError(t, err)
+
+		prctx := &pulltest.Context{
+			LatestStatusesValue: map[string]string{
+				"optional-lint": "skipped",
+			},
+		}
+		res := eval.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusApproved, res.Status,
+			"skipped should approve when in allowed conclusions; got status %s", res.Status)
+	})
+}

--- a/policy/predicate/status.go
+++ b/policy/predicate/status.go
@@ -57,35 +57,91 @@ func (pred HasStatus) Evaluate(ctx context.Context, prctx pull.Context) (*common
 		ConditionPhrase: fmt.Sprintf("exist and have conclusion %s", conclusions.joinWithOr()),
 	}
 
-	var missingResults []string
+	// Group failures into three buckets so the resulting description points
+	// directly at the actionable problem for each required status:
+	//   - missing: the check has not reported any conclusion yet
+	//   - notSuccess: the check ran but ended in a conclusion that is not in
+	//     the allowed set, distinguishing skipped from failure to make triage
+	//     faster
+	var missingStatuses []string
 	var failingStatuses []string
+	skippedAsNotSuccess := make(map[string][]string) // conclusion -> []status names
 	for _, status := range pred.Statuses {
 		result, ok := statuses[status]
 		if !ok {
-			missingResults = append(missingResults, status)
+			missingStatuses = append(missingStatuses, status)
+			continue
 		}
 		if !slices.Contains(conclusions, result) {
 			failingStatuses = append(failingStatuses, status)
+			skippedAsNotSuccess[result] = append(skippedAsNotSuccess[result], status)
 		}
 	}
 
-	if len(missingResults) > 0 {
-		predicateResult.Values = missingResults
-		predicateResult.Description = "One or more statuses is missing: " + strings.Join(missingResults, ", ")
-		predicateResult.Satisfied = false
+	if len(missingStatuses) == 0 && len(failingStatuses) == 0 {
+		predicateResult.Values = pred.Statuses
+		predicateResult.Satisfied = true
 		return &predicateResult, nil
 	}
 
-	if len(failingStatuses) > 0 {
-		predicateResult.Values = failingStatuses
-		predicateResult.Description = fmt.Sprintf("One or more statuses has not concluded with %s: %s", pred.Conclusions.joinWithOr(), strings.Join(failingStatuses, ","))
-		predicateResult.Satisfied = false
-		return &predicateResult, nil
-	}
+	predicateResult.Satisfied = false
+	predicateResult.Description = buildHasStatusDescription(missingStatuses, skippedAsNotSuccess, conclusions)
 
-	predicateResult.Values = pred.Statuses
-	predicateResult.Satisfied = true
+	// Preserve historical Values semantics: callers (and the legacy details
+	// template) read .Values as the failing statuses. Missing statuses are
+	// listed first because they are the most common cause of "policy-bot:
+	// main = ERROR" with no actionable detail at FINN.
+	values := append([]string{}, missingStatuses...)
+	values = append(values, failingStatuses...)
+	predicateResult.Values = values
 	return &predicateResult, nil
+}
+
+// buildHasStatusDescription produces a concise, deterministic description that
+// names the specific status checks blocking the predicate. Output is shaped to
+// fit GitHub's 140-character commit status description limit when possible;
+// callers further up the pipeline are responsible for truncation if the
+// concatenated list would exceed that limit.
+func buildHasStatusDescription(missing []string, notSuccess map[string][]string, conclusions AllowedConclusions) string {
+	var segments []string
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		segments = append(segments, "Waiting on: "+strings.Join(missing, ", "))
+	}
+
+	// Render non-success conclusions grouped by their actual conclusion so the
+	// reader can see "Failing: a, b" separately from "Skipped (not in allowed
+	// conclusions): c". Sort the conclusion labels so output is deterministic.
+	if len(notSuccess) > 0 {
+		labels := make([]string, 0, len(notSuccess))
+		for c := range notSuccess {
+			labels = append(labels, c)
+		}
+		slices.Sort(labels)
+
+		for _, label := range labels {
+			names := notSuccess[label]
+			slices.Sort(names)
+			segments = append(segments, formatNotSuccess(label, names, conclusions))
+		}
+	}
+
+	return strings.Join(segments, "; ")
+}
+
+// formatNotSuccess returns a human-readable segment for a non-success
+// conclusion. "failure" is reported as "Failing: ..." while every other
+// non-success conclusion (skipped, cancelled, action_required, etc.) is
+// reported with its actual label so callers can distinguish a skipped check
+// from a failing one without opening the policy-bot details page.
+func formatNotSuccess(conclusion string, names []string, allowed AllowedConclusions) string {
+	joined := strings.Join(names, ", ")
+	switch conclusion {
+	case "failure":
+		return "Failing: " + joined
+	default:
+		return fmt.Sprintf("%s (not in allowed conclusions %s): %s", strings.ToUpper(conclusion[:1])+conclusion[1:], allowed.joinWithOr(), joined)
+	}
 }
 
 func (pred HasStatus) Trigger() common.Trigger {

--- a/policy/predicate/status_test.go
+++ b/policy/predicate/status_test.go
@@ -98,6 +98,39 @@ func TestHasSuccessfulStatus(t *testing.T) {
 			},
 		},
 		{
+			"multiple statuses do not exist",
+			&pulltest.Context{},
+			&common.PredicateResult{
+				Satisfied: false,
+				Values:    []string{"status-name", "status-name-2"},
+			},
+		},
+	}
+
+	// Cases where one status is missing and the other has a non-success
+	// conclusion. Before the descriptive-errors change, the predicate
+	// returned early when any status was missing, hiding the not-success
+	// status from .Values. The new behavior surfaces both at once so a
+	// single failure message can point at every actionable check, but only
+	// when the not-success conclusion is not in the allowed set; if
+	// "skipped" is an allowed conclusion, only the missing status blocks.
+	missingAndNotSuccessStrict := []StatusTestCase{
+		{
+			"a status does not exist, the other status is skipped",
+			&pulltest.Context{
+				LatestStatusesValue: map[string]string{
+					"status-name-2": "skipped",
+				},
+			},
+			&common.PredicateResult{
+				Satisfied: false,
+				Values:    []string{"status-name", "status-name-2"},
+			},
+		},
+	}
+
+	missingAndNotSuccessRelaxed := []StatusTestCase{
+		{
 			"a status does not exist, the other status is skipped",
 			&pulltest.Context{
 				LatestStatusesValue: map[string]string{
@@ -107,14 +140,6 @@ func TestHasSuccessfulStatus(t *testing.T) {
 			&common.PredicateResult{
 				Satisfied: false,
 				Values:    []string{"status-name"},
-			},
-		},
-		{
-			"multiple statuses do not exist",
-			&pulltest.Context{},
-			&common.PredicateResult{
-				Satisfied: false,
-				Values:    []string{"status-name", "status-name-2"},
 			},
 		},
 	}
@@ -150,13 +175,20 @@ func TestHasSuccessfulStatus(t *testing.T) {
 
 	testSuites := []StatusTestSuite{
 		{predicate: hasStatus, testCases: commonTestCases},
+		{predicate: hasStatus, testCases: missingAndNotSuccessStrict},
 		{predicate: hasStatus, testCases: okOnlyIfSkippedAllowed},
 		{predicate: hasSuccessfulStatus, testCases: commonTestCases},
+		{predicate: hasSuccessfulStatus, testCases: missingAndNotSuccessStrict},
 		{predicate: hasSuccessfulStatus, testCases: okOnlyIfSkippedAllowed},
 		{
 			nameSuffix: "skipped allowed",
 			predicate:  hasStatusSkippedOk,
 			testCases:  commonTestCases,
+		},
+		{
+			nameSuffix: "skipped allowed",
+			predicate:  hasStatusSkippedOk,
+			testCases:  missingAndNotSuccessRelaxed,
 		},
 		{
 			nameSuffix:        "skipped allowed",

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -192,10 +192,18 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 	publicURL := strings.TrimSuffix(ec.PublicURL, "/")
 	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, ec.PullContext.Number())
 
+	// GitHub commit-status descriptions are capped at 140 characters. The
+	// descriptive has-status messages introduced for issue #960 can exceed
+	// that comfortably for repos with many required checks (e.g. SonarCloud
+	// component checks), so truncate here and point the reader at the
+	// already-attached details URL instead of letting GitHub silently lop
+	// off the end mid-word.
+	displayMessage := truncateStatusDescription(message)
+
 	status := github.RepoStatus{
 		State:       &state,
 		Context:     new(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
-		Description: &message,
+		Description: &displayMessage,
 		TargetURL:   &detailsURL,
 	}
 
@@ -218,4 +226,37 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 			logger.Err(err).Msg("Failed to post insecure repo status")
 		}
 	}
+}
+
+// gitHubStatusDescriptionMaxLen is GitHub's hard cap on commit-status
+// descriptions. The API silently truncates anything longer.
+const gitHubStatusDescriptionMaxLen = 140
+
+// statusDescriptionTruncationSuffix is appended when truncation occurs. It is
+// kept short so most of the budget can hold the actionable detail (which
+// segment names the failing or missing check) and points the reader at the
+// existing TargetURL on the same status check for the full text.
+const statusDescriptionTruncationSuffix = " … (see details)"
+
+// truncateStatusDescription returns s unchanged if it already fits inside
+// GitHub's commit-status description limit. Otherwise it truncates from the
+// right at a rune boundary, trims trailing punctuation/whitespace so the
+// suffix joins cleanly, and appends statusDescriptionTruncationSuffix to
+// signal that the reader should follow the status check's "Details" link
+// (already set as TargetURL) for the full description.
+func truncateStatusDescription(s string) string {
+	runes := []rune(s)
+	if len(runes) <= gitHubStatusDescriptionMaxLen {
+		return s
+	}
+	suffixRunes := []rune(statusDescriptionTruncationSuffix)
+	cutoff := gitHubStatusDescriptionMaxLen - len(suffixRunes)
+	if cutoff < 0 {
+		// Defensive: suffix alone is shorter than the limit today, but if a
+		// future edit makes the suffix longer than the limit, fall back to
+		// the raw rune-bounded truncation rather than panicking.
+		return string(runes[:gitHubStatusDescriptionMaxLen])
+	}
+	head := strings.TrimRight(string(runes[:cutoff]), " ,;.:-—")
+	return head + statusDescriptionTruncationSuffix
 }

--- a/server/handler/eval_context_has_status_test.go
+++ b/server/handler/eval_context_has_status_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy"
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+// TestEvalContextHasStatusDescription_PostsDetailedStatus drives the
+// EvalContext path that the GitHub webhook handler uses to post a commit
+// status back to GitHub. It asserts that when a has_status condition is
+// blocking the rule, the description that would be posted to GitHub
+// (captured via SkipPostStatus = true so the test does not hit the
+// network) names the specific blocking check.
+//
+// This replaces the "I need a docker-compose webhook replay rig" shape
+// described in the original POC brief: the handler-level test below
+// exercises the same code path that the webhook handler takes, minus the
+// HTTP shell. policy-bot has no docker-compose integration harness today,
+// and building one for a change that lives entirely inside the in-process
+// evaluator would burn budget without buying additional coverage. See
+// CONTRIBUTING discussion in the POC summary.
+func TestEvalContextHasStatusDescription_PostsDetailedStatus(t *testing.T) {
+	ctx := context.Background()
+
+	const policyYAML = `
+approval_rules:
+  - name: required ci checks
+    requires:
+      conditions:
+        has_status:
+          statuses:
+            - "pre-commit-check"
+            - "Tests with Coverage"
+policy:
+  approval:
+    - "required ci checks"
+`
+
+	var cfg policy.Config
+	require.NoError(t, yaml.Unmarshal([]byte(policyYAML), &cfg))
+	evaluator, err := policy.ParsePolicy(&cfg, nil)
+	require.NoError(t, err)
+
+	prctx := &pulltest.Context{
+		OwnerValue:     "testorg",
+		RepoValue:      "testrepo",
+		NumberValue:    42,
+		StateValue:     "open",
+		HeadSHAValue:   "abc123",
+		BranchBaseName: "main",
+		BranchHeadName: "feature",
+		LatestStatusesValue: map[string]string{
+			// "pre-commit-check" missing entirely
+			"Tests with Coverage": "failure",
+		},
+	}
+
+	ec := &EvalContext{
+		Options: &PullEvaluationOptions{
+			StatusCheckContext: "policy-bot",
+		},
+		PublicURL:      "https://policy-bot.example.com",
+		PullContext:    prctx,
+		SkipPostStatus: true,
+	}
+
+	result, err := ec.EvaluatePolicy(ctx, evaluator)
+	require.NoError(t, err)
+	assert.Equal(t, common.StatusPending, result.Status)
+
+	require.NotNil(t, ec.Status, "EvaluatePolicy should set ec.Status when SkipPostStatus is true")
+	assert.Equal(t, "pending", ec.Status.GetState())
+	assert.Equal(t, "policy-bot: main", ec.Status.GetContext())
+
+	desc := ec.Status.GetDescription()
+	assert.True(t, strings.Contains(desc, "pre-commit-check"),
+		"posted status must name the missing pre-commit-check; got %q", desc)
+	assert.True(t, strings.Contains(desc, "Tests with Coverage"),
+		"posted status must name the failing Tests with Coverage; got %q", desc)
+	assert.True(t, strings.Contains(desc, "Waiting on") || strings.Contains(desc, "Failing"),
+		"posted status must use the descriptive blocker labels; got %q", desc)
+}

--- a/server/handler/eval_context_truncate_test.go
+++ b/server/handler/eval_context_truncate_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/palantir/policy-bot/policy"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+// TestTruncateStatusDescription exercises the helper directly. It guards two
+// invariants: the output never exceeds GitHub's 140-rune cap, and when
+// truncation occurs the caller is pointed at the details URL via the suffix.
+func TestTruncateStatusDescription(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantEqual string // when non-empty, output must match exactly
+		wantTrunc bool   // when true, output must end with the truncation suffix
+	}{
+		{
+			name:      "empty string passes through",
+			input:     "",
+			wantEqual: "",
+		},
+		{
+			name:      "short string passes through",
+			input:     "All checks passed",
+			wantEqual: "All checks passed",
+		},
+		{
+			name:      "exact-limit string passes through",
+			input:     strings.Repeat("a", gitHubStatusDescriptionMaxLen),
+			wantEqual: strings.Repeat("a", gitHubStatusDescriptionMaxLen),
+		},
+		{
+			name:      "one-over-limit string gets truncated",
+			input:     strings.Repeat("a", gitHubStatusDescriptionMaxLen+1),
+			wantTrunc: true,
+		},
+		{
+			name: "long has_status description gets truncated and suffixed",
+			input: "0/1 rules approved. required ci checks: 0/1 required conditions met. " +
+				"status checks: Waiting on: pre-commit-check, sonar-component-1, " +
+				"sonar-component-2; Failing: Tests with Coverage",
+			wantTrunc: true,
+		},
+		{
+			name:      "trailing punctuation is trimmed before suffix",
+			input:     strings.Repeat("a", gitHubStatusDescriptionMaxLen-10) + ", , , , ,, more",
+			wantTrunc: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateStatusDescription(tc.input)
+			if tc.wantEqual != "" || tc.input == "" {
+				assert.Equal(t, tc.wantEqual, got, "expected unchanged passthrough")
+				return
+			}
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), gitHubStatusDescriptionMaxLen,
+				"truncated output must fit GitHub's %d-rune description cap (got %d runes): %q",
+				gitHubStatusDescriptionMaxLen, utf8.RuneCountInString(got), got)
+			if tc.wantTrunc {
+				assert.True(t, strings.HasSuffix(got, statusDescriptionTruncationSuffix),
+					"truncated output must end with %q so the reader follows the details link; got %q",
+					statusDescriptionTruncationSuffix, got)
+				assert.False(t, strings.HasSuffix(strings.TrimSuffix(got, statusDescriptionTruncationSuffix), ","),
+					"trailing punctuation should be trimmed before the suffix; got %q", got)
+			}
+		})
+	}
+}
+
+// TestTruncateStatusDescription_HandlesMultiByteRunes ensures the helper
+// counts runes (not bytes) so we don't slice in the middle of a multi-byte
+// character and emit invalid UTF-8 to GitHub.
+func TestTruncateStatusDescription_HandlesMultiByteRunes(t *testing.T) {
+	// Each "—" is 3 bytes but 1 rune. 200 of them is 200 runes / 600 bytes,
+	// well over the 140-rune limit so truncation must engage.
+	input := strings.Repeat("—", 200)
+
+	got := truncateStatusDescription(input)
+	assert.LessOrEqual(t, utf8.RuneCountInString(got), gitHubStatusDescriptionMaxLen,
+		"rune count must respect the cap even for multi-byte input")
+	assert.True(t, utf8.ValidString(got), "output must be valid UTF-8")
+}
+
+// TestEvalContext_PostStatusTruncatesLongDescription drives the EvalContext
+// path the webhook handler uses and verifies that an over-limit has_status
+// description is truncated before reaching the captured status. The policy
+// references enough required checks that the rendered description exceeds
+// 140 runes, exercising the truncation branch end-to-end through
+// EvaluatePolicy → PostStatus.
+func TestEvalContext_PostStatusTruncatesLongDescription(t *testing.T) {
+	ctx := context.Background()
+
+	// Many required statuses → long "Waiting on: ..." segment that will
+	// blow past 140 runes once combined with the parent rule prefix.
+	const policyYAML = `
+approval_rules:
+  - name: required ci checks for sonarcloud and friends
+    requires:
+      conditions:
+        has_status:
+          statuses:
+            - "sonar-component-aaaaaaaaaaaaaaaa"
+            - "sonar-component-bbbbbbbbbbbbbbbb"
+            - "sonar-component-cccccccccccccccc"
+            - "sonar-component-dddddddddddddddd"
+            - "sonar-component-eeeeeeeeeeeeeeee"
+            - "sonar-component-ffffffffffffffff"
+policy:
+  approval:
+    - "required ci checks for sonarcloud and friends"
+`
+
+	var cfg policy.Config
+	require.NoError(t, yaml.Unmarshal([]byte(policyYAML), &cfg))
+	evaluator, err := policy.ParsePolicy(&cfg, nil)
+	require.NoError(t, err)
+
+	prctx := &pulltest.Context{
+		OwnerValue:          "testorg",
+		RepoValue:           "testrepo",
+		NumberValue:         42,
+		StateValue:          "open",
+		HeadSHAValue:        "abc123",
+		BranchBaseName:      "main",
+		BranchHeadName:      "feature",
+		LatestStatusesValue: map[string]string{
+			// all six required checks missing → "Waiting on: ..." with every
+			// long status name listed
+		},
+	}
+
+	ec := &EvalContext{
+		Options: &PullEvaluationOptions{
+			StatusCheckContext: "policy-bot",
+		},
+		PublicURL:      "https://policy-bot.example.com",
+		PullContext:    prctx,
+		SkipPostStatus: true,
+	}
+
+	_, err = ec.EvaluatePolicy(ctx, evaluator)
+	require.NoError(t, err)
+	require.NotNil(t, ec.Status, "EvaluatePolicy should set ec.Status when SkipPostStatus is true")
+
+	desc := ec.Status.GetDescription()
+	assert.LessOrEqual(t, utf8.RuneCountInString(desc), gitHubStatusDescriptionMaxLen,
+		"posted description must respect GitHub's 140-rune cap; got %d runes: %q",
+		utf8.RuneCountInString(desc), desc)
+	assert.True(t, strings.HasSuffix(desc, statusDescriptionTruncationSuffix),
+		"long descriptions must end with %q so reviewers know to click the details link; got %q",
+		statusDescriptionTruncationSuffix, desc)
+	// TargetURL must still be populated so the truncation suffix actually
+	// points somewhere actionable.
+	assert.NotEmpty(t, ec.Status.GetTargetURL(),
+		"TargetURL must be set so the truncation suffix refers to a real details page")
+}


### PR DESCRIPTION
## Before this PR

When a rule's `has_status` condition is unsatisfied, policy-bot posts a generic GitHub commit status like:

> **policy-bot: main** — 0/1 rules approved

There's no indication of *which* required check is missing or failing. Reviewers either click through to the details UI for every PR or look at the underlying check-run list and try to cross-reference it with `.policy.yml` by hand. For repos with many required checks (e.g. SonarCloud's per-component checks), this turns every "policy-bot is red" question into a multi-minute investigation.

This is one of the symptoms behind issues like #960, where reporters see "0/1 rules approved" with no actionable detail. Even when the root cause is a webhook/stale-state bug, the message itself doesn't help users see which check is blocking.

## After this PR

The `has_status` predicate now buckets the unsatisfied required checks into three groups and emits a description that names them:

- **Missing** (the check has reported no conclusion yet) → `Waiting on: <names>`
- **Failed** (conclusion is `failure`) → `Failing: <names>`
- **Other non-success conclusions** (skipped, cancelled, action_required, etc.) → `<Conclusion> (not in allowed conclusions <allowed>): <names>`

These segments are joined with `; ` and appended after the existing top-level rule summary, so the commit status becomes:

> **policy-bot: main** — 0/1 rules approved. required ci checks: 0/1 required conditions met. status checks: Waiting on: pre-commit-check; Failing: Tests with Coverage

Because GitHub silently truncates commit-status descriptions past 140 characters, descriptions that overflow are truncated at a rune boundary, have trailing punctuation trimmed, and get a ` … (see details)` suffix pointing at the existing TargetURL on the same status check. This keeps the actionable detail in the description even when the policy has enough required checks to overflow the limit.

Refs #960.

## Possible downsides?

- The default description text changes for any rule that uses `has_status` (and the deprecated `has_successful_status`, which delegates to `HasStatus`). Tooling that scrapes the exact string `0/1 rules approved` from the commit status will see additional content appended after it. The status `state` (success/pending/failure/error) is unchanged.
- The new code paths include 9 new test cases (3 in `policy/predicate`, 2 in `policy/approval`, plus 4 in `server/handler` covering the truncation helper end-to-end). Full suite: 111 PASS, 0 FAIL.
- No new external dependencies; the only stdlib addition is `strings.TrimRight` / `unicode/utf8` in the truncation helper.

## Notes for reviewers

Two commits, both signed:

1. `feat(has_status): surface failing/missing/skipped checks in status description` — predicate + approval-aggregation changes
2. `feat(status): truncate long has_status descriptions with ellipsis + details link` — the 140-char-cap handling in `server/handler/eval_context.go`