### PR TITLE
Ignore ready-for-review pull request events

### DIFF
--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -42,17 +42,8 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 	installationID := githubapp.GetInstallationIDFromEvent(&event)
 	ctx, _ = h.PreparePRContext(ctx, installationID, event.GetPullRequest())
 
-	var t common.Trigger
-	switch event.GetAction() {
-	case "opened", "reopened", "ready_for_review":
-		t = common.TriggerCommit | common.TriggerPullRequest
-	case "synchronize":
-		t = common.TriggerCommit
-	case "edited":
-		t = common.TriggerPullRequest
-	case "labeled", "unlabeled":
-		t = common.TriggerLabel
-	default:
+	t, ok := triggerForPullRequestAction(event.GetAction())
+	if !ok {
 		return nil
 	}
 
@@ -62,4 +53,19 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 		Number: event.GetPullRequest().GetNumber(),
 		Value:  event.GetPullRequest(),
 	})
+}
+
+func triggerForPullRequestAction(action string) (common.Trigger, bool) {
+	switch action {
+	case "opened", "reopened":
+		return common.TriggerCommit | common.TriggerPullRequest, true
+	case "synchronize":
+		return common.TriggerCommit, true
+	case "edited":
+		return common.TriggerPullRequest, true
+	case "labeled", "unlabeled":
+		return common.TriggerLabel, true
+	default:
+		return common.TriggerStatic, false
+	}
 }

--- a/server/handler/pull_request_test.go
+++ b/server/handler/pull_request_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTriggerForPullRequestAction(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		action  string
+		trigger common.Trigger
+		ok      bool
+	}{
+		{
+			name:    "opened triggers commit and pull request evaluation",
+			action:  "opened",
+			trigger: common.TriggerCommit | common.TriggerPullRequest,
+			ok:      true,
+		},
+		{
+			name:    "reopened triggers commit and pull request evaluation",
+			action:  "reopened",
+			trigger: common.TriggerCommit | common.TriggerPullRequest,
+			ok:      true,
+		},
+		{
+			name:    "synchronize triggers commit evaluation",
+			action:  "synchronize",
+			trigger: common.TriggerCommit,
+			ok:      true,
+		},
+		{
+			name:    "ready for review does not trigger evaluation",
+			action:  "ready_for_review",
+			trigger: common.TriggerStatic,
+			ok:      false,
+		},
+		{
+			name:    "unknown action does not trigger evaluation",
+			action:  "converted_to_draft",
+			trigger: common.TriggerStatic,
+			ok:      false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			trigger, ok := triggerForPullRequestAction(tc.action)
+
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.trigger, trigger)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Stop evaluating `pull_request.ready_for_review` as a commit/pull request trigger. New commits still trigger evaluation through `pull_request.synchronize`.

## Root cause
`ready_for_review` currently shares the `opened`/`reopened` trigger path, causing policy-bot to recompute status without a new head commit when a draft PR is marked ready.

## Validation
- `go test ./server/handler`
- `go test ./policy/common`
- `go test ./...`