### PR TITLE
Add macOS (darwin) binaries to release distribution

### DIFF
--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -15,6 +15,10 @@ products:
         arch: amd64
       - os: linux
         arch: arm64
+      - os: darwin
+        arch: amd64
+      - os: darwin
+        arch: arm64
     dist:
       output-dir: build
       disters:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The release distribution only ships Linux binaries (`linux-amd64`, `linux-arm64`).
Each release asset (`policy-bot-<version>.tgz`) contains:

```
policy-bot-<version>/
  bin/
    linux-amd64/policy-bot
    linux-arm64/policy-bot
```

Because of this, macOS users who want to run helper commands such as
`policy-bot validate` locally have no prebuilt binary to download. It can still
be installed via `go install`, but that requires a Go toolchain and a local
build. Having a prebuilt binary available for download is much more convenient.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add darwin (macOS) binaries to the release distribution.

`darwin/amd64` and `darwin/arm64` are added to the `os-archs` list in
`godel/config/dist-plugin.yml`, so `./godelw dist` now also produces macOS
binaries and they are bundled into the same release `.tgz`:

```
policy-bot-<version>/
  bin/
    linux-amd64/policy-bot
    linux-arm64/policy-bot
    darwin-amd64/policy-bot   # new (Intel Mac)
    darwin-arm64/policy-bot   # new (Apple Silicon)
```

macOS users can now download the release archive and use the prebuilt binary
(e.g. for `policy-bot validate`) without needing a Go toolchain.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
- None for existing users. The release archive layout is unchanged; only two
  additional `bin/<os>-<arch>/` directories are added.
- The release archive becomes slightly larger due to the two extra binaries.
- The binaries are built with `CGO_ENABLED=0` (matching the existing Linux
  builds), so they cross-compile cleanly and require no new build dependencies.
  The Docker image is unaffected since its Dockerfile explicitly references
  `bin/linux-amd64/policy-bot`.
