### PR TITLE
Fail closed when a PR contributor cannot be attributed to a GitHub user

### DIFF
--- a/policy/approval/approve.go
+++ b/policy/approval/approve.go
@@ -104,6 +104,34 @@ func (r *Rule) Evaluate(ctx context.Context, prctx pull.Context) (res common.Res
 	}
 	res.PredicateResults = predicateResults
 
+	// When contributors are banned from approving their own changes, every
+	// contributing commit must be attributable to a GitHub user. A commit whose
+	// author or committer cannot be resolved to an account could hide a
+	// contributor who is also an approver, so the contributor restriction
+	// cannot be enforced — fail the rule closed.
+	if r.Requires.Count > 0 && !r.Options.IsAllowContributor() && !r.Options.IsAllowNonAuthorContributor() {
+		commits, err := r.filteredCommits(ctx, prctx)
+		if err != nil {
+			res.Error = errors.Wrap(err, "failed to list commits")
+			return
+		}
+		for _, c := range commits {
+			if desc, ok := c.UnattributedContributor(); ok {
+				log.Warn().
+					Str("sha", c.SHA).
+					Str("unattributed", desc).
+					Msg("commit contributor could not be attributed to a GitHub user; failing rule closed")
+
+				res.Status = common.StatusPending
+				res.StatusDescription = fmt.Sprintf(
+					"Cannot verify contributors: commit %.10s has an %s that is not a GitHub user",
+					c.SHA, desc)
+				res.ReviewRequestRule = r.getReviewRequestRule()
+				return
+			}
+		}
+	}
+
 	candidates, dismissals, err := r.FilteredCandidates(ctx, prctx)
 	if err != nil {
 		res.Error = errors.Wrap(err, "failed to filter candidates")

--- a/policy/approval/approve_test.go
+++ b/policy/approval/approve_test.go
@@ -327,6 +327,85 @@ func TestIsApproved(t *testing.T) {
 		assertApproved(t, prctx, r, "Approved by comment-approver, mhaypenny, contributor-author, contributor-committer, review-approver")
 	})
 
+	// A contributor whose commit cannot be attributed to a GitHub user must not
+	// silently drop out of the banned set: when the contributor approval
+	// restriction is enforced, such a commit fails the rule closed.
+	// See HackerOne #3788981.
+	t.Run("unattributedContributorFailsClosed", func(t *testing.T) {
+		prctx := basePullContext()
+		prctx.HeadSHAValue = "674832587eaaf416371b30f5bc5a47e377f534ec"
+		prctx.CommitsValue = []*pull.Commit{
+			{
+				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
+				Author:    "mhaypenny",
+				Committer: "mhaypenny",
+			},
+			{
+				SHA:         "674832587eaaf416371b30f5bc5a47e377f534ec",
+				Author:      "",
+				AuthorName:  "Sneaky Contributor",
+				AuthorEmail: "sneaky@noreply.invalid",
+				Committer:   "mhaypenny",
+				Parents:     []string{"c6ade256ecfc755d8bc877ef22cc9e01745d46bb"},
+			},
+		}
+
+		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
+			Requires: Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Organizations: []string{"everyone"},
+				},
+			},
+		}
+
+		res := r.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusPending, res.Status)
+		assert.Equal(t, "Cannot verify contributors: commit 674832587e has an author Sneaky Contributor <sneaky@noreply.invalid> that is not a GitHub user", res.StatusDescription)
+	})
+
+	// Control for the case above: the only delta is the contributing commit's
+	// author login. With the author attributed, the rule evaluates normally and
+	// the non-contributor approvers satisfy it.
+	t.Run("attributedContributorEvaluatesNormally", func(t *testing.T) {
+		prctx := basePullContext()
+		prctx.HeadSHAValue = "674832587eaaf416371b30f5bc5a47e377f534ec"
+		prctx.CommitsValue = []*pull.Commit{
+			{
+				SHA:       "c6ade256ecfc755d8bc877ef22cc9e01745d46bb",
+				Author:    "mhaypenny",
+				Committer: "mhaypenny",
+			},
+			{
+				SHA:       "674832587eaaf416371b30f5bc5a47e377f534ec",
+				Author:    "contributor-author",
+				Committer: "mhaypenny",
+				Parents:   []string{"c6ade256ecfc755d8bc877ef22cc9e01745d46bb"},
+			},
+		}
+
+		r := &Rule{
+			Options: Options{
+				Defaults: &defaultOptions,
+			},
+			Requires: Requires{
+				Count: 1,
+				Actors: common.Actors{
+					Organizations: []string{"everyone"},
+				},
+			},
+		}
+
+		res := r.Evaluate(ctx, prctx)
+		require.NoError(t, res.Error)
+		assert.Equal(t, common.StatusApproved, res.Status)
+		assert.Equal(t, "Approved by comment-approver, contributor-committer, review-approver", res.StatusDescription)
+	})
+
 	t.Run("specificUserApproves", func(t *testing.T) {
 		prctx := basePullContext()
 		r := &Rule{

--- a/pull/context.go
+++ b/pull/context.go
@@ -15,6 +15,7 @@
 package pull
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -167,6 +168,15 @@ type Commit struct {
 	// committer is not a real user.
 	Committer string
 
+	// AuthorName, AuthorEmail, CommitterName, and CommitterEmail are the raw
+	// git identity recorded in the commit. They are populated even when the
+	// identity cannot be resolved to a GitHub user, in which case the
+	// corresponding Author or Committer login above is empty.
+	AuthorName     string
+	AuthorEmail    string
+	CommitterName  string
+	CommitterEmail string
+
 	// Signature is the signature and details that was extracted from the commit.
 	// It is nil if the commit has no signature
 	Signature *Signature
@@ -182,6 +192,45 @@ func (c *Commit) Users() []string {
 		users = append(users, c.Committer)
 	}
 	return users
+}
+
+// HasUnattributedContributor reports whether the commit has an author or
+// committer that could not be resolved to a GitHub user. The committer is
+// exempt for commits made via the GitHub web interface, because GitHub sets
+// the committer in that case (matching AuthorIsOnlyContributor).
+func (c *Commit) HasUnattributedContributor() bool {
+	_, ok := c.UnattributedContributor()
+	return ok
+}
+
+// UnattributedContributor returns a human-readable description of the first
+// git identity (author, then committer) on the commit that could not be
+// resolved to a GitHub user, and whether such an identity exists. It is used
+// to fail closed for the contributor approval restriction: a contributor that
+// GitHub cannot attribute to an account cannot be excluded from the approver
+// pool.
+func (c *Commit) UnattributedContributor() (string, bool) {
+	if c.Author == "" {
+		return "author " + gitIdentity(c.AuthorName, c.AuthorEmail), true
+	}
+	if !c.CommittedViaWeb && c.Committer == "" {
+		return "committer " + gitIdentity(c.CommitterName, c.CommitterEmail), true
+	}
+	return "", false
+}
+
+// gitIdentity formats a raw git name/email pair for display.
+func gitIdentity(name, email string) string {
+	switch {
+	case name != "" && email != "":
+		return fmt.Sprintf("%s <%s>", name, email)
+	case email != "":
+		return fmt.Sprintf("<%s>", email)
+	case name != "":
+		return name
+	default:
+		return "unknown"
+	}
 }
 
 type SignatureType string

--- a/pull/context_test.go
+++ b/pull/context_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pull
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitUnattributedContributor(t *testing.T) {
+	tests := map[string]struct {
+		commit  Commit
+		wantOK  bool
+		wantDsc string
+	}{
+		"bothAttributed": {
+			commit: Commit{Author: "alice", Committer: "bob"},
+			wantOK: false,
+		},
+		"unattributedAuthorWithNameAndEmail": {
+			commit: Commit{
+				Author:      "",
+				AuthorName:  "Mallory",
+				AuthorEmail: "mallory@noreply.invalid",
+				Committer:   "bob",
+			},
+			wantOK:  true,
+			wantDsc: "author Mallory <mallory@noreply.invalid>",
+		},
+		"unattributedAuthorWithEmailOnly": {
+			commit: Commit{
+				Author:      "",
+				AuthorEmail: "mallory@noreply.invalid",
+				Committer:   "bob",
+			},
+			wantOK:  true,
+			wantDsc: "author <mallory@noreply.invalid>",
+		},
+		"unattributedAuthorWithNoIdentity": {
+			commit:  Commit{Author: "", Committer: "bob"},
+			wantOK:  true,
+			wantDsc: "author unknown",
+		},
+		"unattributedCommitter": {
+			commit: Commit{
+				Author:        "alice",
+				Committer:     "",
+				CommitterName: "Mallory",
+			},
+			wantOK:  true,
+			wantDsc: "committer Mallory",
+		},
+		"unattributedCommitterViaWebIsExempt": {
+			commit: Commit{Author: "alice", Committer: "", CommittedViaWeb: true},
+			wantOK: false,
+		},
+		"unattributedAuthorTakesPrecedenceOverCommitter": {
+			commit: Commit{
+				Author:      "",
+				AuthorEmail: "mallory@noreply.invalid",
+				Committer:   "",
+			},
+			wantOK:  true,
+			wantDsc: "author <mallory@noreply.invalid>",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			desc, ok := test.commit.UnattributedContributor()
+			assert.Equal(t, test.wantOK, ok, "UnattributedContributor ok mismatch")
+			assert.Equal(t, test.wantOK, test.commit.HasUnattributedContributor(), "HasUnattributedContributor mismatch")
+			if test.wantOK {
+				assert.Equal(t, test.wantDsc, desc)
+			}
+		})
+	}
+}

--- a/pull/github.go
+++ b/pull/github.go
@@ -1237,6 +1237,10 @@ func (c *v4Commit) ToCommit() *Commit {
 		CommittedViaWeb: c.CommittedViaWeb,
 		Author:          c.Author.User.GetV3Login(),
 		Committer:       c.Committer.User.GetV3Login(),
+		AuthorName:      c.Author.Name,
+		AuthorEmail:     c.Author.Email,
+		CommitterName:   c.Committer.Name,
+		CommitterEmail:  c.Committer.Email,
 		Signature:       signature,
 	}
 }
@@ -1283,7 +1287,9 @@ func (a *v4Actor) GetV3Login() string {
 }
 
 type v4GitActor struct {
-	User *v4Actor
+	Name  string
+	Email string
+	User  *v4Actor
 }
 
 func isNotFound(err error) bool {


### PR DESCRIPTION
## Before this PR

policy-bot's default contributor approval restriction (`allow_contributor` / `allow_non_author_contributor`, both off by default) bans a pull request's contributors from supplying its required approval. The banned set was built solely from `Commit.Users()`, which returns only resolved GitHub logins.

A commit whose author and committer emails map to no GitHub account resolved to an empty login meaning that `Commit.Users()` returned nothing and that contributor silently dropped out of the banned set. A contributer could therefore approve code they had contributed by pushing a commit with an author email tied to no account, defeating the restriction. The bypass left no trace in the approval audit trail as there was no logging around this edge case.

## After this PR

When the contributor restriction is enforced, a pull request containing a commit whose author or committer cannot be attributed to a GitHub account the policy condition no longer passes. This is communicated via the status and logged as a warning for auditing purposes. Commits made through the GitHub API by apps and bots resolve to a `name[bot]` identity and are unaffected, and web-flow commits remain exempt.

==COMMIT_MSG==
Fix a bypass of the contributor approval restriction.
==COMMIT_MSG==

## Possible downsides?

- A pull request containing a commit whose author/committer email is tied to no GitHub account (e.g. CI/automation committing with an unlinked email, or imported/vendored history) will now be held pending under the default restriction, where previously it would have evaluated. The remedy is to re-author the commit with a GitHub-linked email.
- There is currently no way to have a legitimately unattributable commit as `ignore_commits_by` matches on a GitHub login, which such a commit lacks.
