### PR TITLE
Fail only_has_contributors_in closed for unattributable contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,10 @@ if:
 
   # "only_has_contributors_in" is satisfied if all of the commits on the pull
   # request have an author or committer in the users list or that belong to
-  # any of the listed organizations or teams.
+  # any of the listed organizations or teams. A commit whose author or
+  # committer cannot be attributed to a GitHub account (for example, a commit
+  # made with an email address that is not registered to any user) is treated
+  # as a contributor outside the set, so the predicate is not satisfied.
   only_has_contributors_in:
     users: ["user1", "user2", ...]
     organizations: ["org1", "org2", ...]

--- a/policy/predicate/author.go
+++ b/policy/predicate/author.go
@@ -85,6 +85,17 @@ func (pred *OnlyHasContributorsIn) Evaluate(ctx context.Context, prctx pull.Cont
 	users[prctx.Author()] = struct{}{}
 
 	for _, c := range commits {
+		// A commit whose author or committer cannot be resolved to a GitHub
+		// user contributes an identity we cannot membership-check, so we cannot
+		// assert that only permitted contributors touched the pull request.
+		// Fail closed.
+		if desc, ok := c.UnattributedContributor(); ok {
+			predicateResult.Description = fmt.Sprintf("Commit %.10s has an %s that is not a GitHub user", c.SHA, desc)
+			predicateResult.Values = []string{}
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
+		}
+
 		for _, u := range c.Users() {
 			users[u] = struct{}{}
 		}

--- a/policy/predicate/author_test.go
+++ b/policy/predicate/author_test.go
@@ -261,6 +261,39 @@ func TestOnlyHasContributorsIn(t *testing.T) {
 
 	runAuthorTests(t, p, []AuthorTestCase{
 		{
+			// A contributor whose commit cannot be attributed to a GitHub user
+			// must fail the predicate closed: an identity we cannot resolve
+			// cannot be confirmed to be in the permitted set. See HackerOne
+			// #3788981.
+			"unattributedContributorFailsClosed",
+			&pulltest.Context{
+				AuthorValue: "mhaypenny",
+				CommitsValue: []*pull.Commit{
+					{
+						SHA:       "abcdef123456789",
+						Author:    "mhaypenny",
+						Committer: "mhaypenny",
+					},
+					{
+						SHA:         "fedcba987654321",
+						Author:      "",
+						AuthorName:  "Sneaky Contributor",
+						AuthorEmail: "sneaky@noreply.invalid",
+						Committer:   "mhaypenny",
+					},
+				},
+			},
+			&common.PredicateResult{
+				Satisfied: false,
+				Values:    []string{},
+				ConditionsMap: map[string][]string{
+					"Organizations": p.Organizations,
+					"Teams":         p.Teams,
+					"Users":         p.Users,
+				},
+			},
+		},
+		{
 			"authorNotInList",
 			&pulltest.Context{
 				AuthorValue: "ttest",


### PR DESCRIPTION
## Before this PR

The `only_has_contributors_in` condition is satisfied when every commit on a pull request has an author or committer in the configured set of users, organisations or teams. That set of contributors was built solely from `Commit.Users()`, which returns only resolved GitHub logins.

A commit whose author and committer emails map to no GitHub account resolved to an empty login, so that contributor was never added to the set and never checked. The condition could therefore pass, reporting that all contributors were in the set, while an unattributed contributor was present. This is the same gap fixed for the contributor approval restriction in #1263, in a different condition.

## After this PR

When `only_has_contributors_in` is evaluated, a pull request containing a commit whose author or committer cannot be attributed to a GitHub account no longer satisfies the condition, and the offending commit is named in the status. An identity that does not map to any known GitHub user cannot be confirmed to be in the configured set, so the condition can only become stricter. Commits made through the GitHub API by apps and bots resolve to a `name[bot]` identity and are unaffected, and web-flow commits remain exempt.

The `has_contributor_in` condition is left unchanged: it is satisfied when any contributor is in the set, so an unattributed contributor that cannot be matched only ever makes it harder to satisfy.

==COMMIT_MSG==
Fail only_has_contributors_in closed for unattributable contributors.
==COMMIT_MSG==

## Possible downsides?

- A pull request containing a commit whose author/committer email is tied to no GitHub account (e.g. CI/automation committing with an unlinked email, or imported/vendored history) will no longer satisfy `only_has_contributors_in`, where previously it would have. The remedy is to re-author the commit with a GitHub-linked email. Unlike the approval restriction, this condition reads every commit on the pull request with no `ignore_commits_by` filtering, so there is no way to bypass it.