### PR TITLE
Repo Topics policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,12 @@ if:
     - "label-1"
     - "label-2"
 
+  # "has_topics" is satisfied if the repository has all of the specified topics.
+  # Topics are the values returned by the GitHub API as "topics" for a repository.
+  has_topics:
+    - "lib"
+    - "go"
+
   # "repository" is satisfied if the pull request repository matches any one of the
   # patterns within the "matches" list or does not match all of the patterns
   # within the "not_matches" list.

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -555,6 +555,26 @@ func TestConfigMarshalYaml(t *testing.T) {
       additions: '> 10'
 `,
 		},
+		{
+			name: "hasTopics",
+			config: Config{
+				ApprovalRules: []*approval.Rule{
+					{
+						Name: "rule1",
+						Predicates: predicate.Predicates{
+							HasTopics: &predicate.HasTopics{"lib", "go"},
+						},
+					},
+				},
+			},
+			expected: `approval_rules:
+- name: rule1
+  if:
+    has_topics:
+    - lib
+    - go
+`,
+		},
 	}
 
 	for _, test := range tests {

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -42,6 +42,7 @@ type Predicates struct {
 	HasWorkflowResult *HasWorkflowResult `yaml:"has_workflow_result,omitempty"`
 
 	HasLabels *HasLabels `yaml:"has_labels,omitempty"`
+	HasTopics *HasTopics `yaml:"has_topics,omitempty"`
 
 	Repository *Repository `yaml:"repository,omitempty"`
 	Title      *Title      `yaml:"title,omitempty"`
@@ -123,6 +124,10 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.HasLabels != nil {
 		ps = append(ps, Predicate(p.HasLabels))
+	}
+
+	if p.HasTopics != nil {
+		ps = append(ps, Predicate(p.HasTopics))
 	}
 
 	if p.Repository != nil {

--- a/policy/predicate/topics.go
+++ b/policy/predicate/topics.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"strings"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type HasTopics []string
+
+var _ Predicate = HasTopics([]string{})
+
+func (pred HasTopics) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "topics",
+		ConditionPhrase: "contain the topics",
+	}
+	if len(pred) > 0 {
+		topics, err := prctx.RepositoryTopics()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list repository topics")
+		}
+		predicateResult.Values = topics
+		for _, requiredTopic := range pred {
+			if !contains(topics, strings.ToLower(requiredTopic)) {
+				predicateResult.ConditionValues = []string{requiredTopic}
+				predicateResult.Description = "Missing topic: " + requiredTopic
+				predicateResult.Satisfied = false
+				return &predicateResult, nil
+			}
+		}
+	}
+	predicateResult.ConditionValues = pred
+	predicateResult.Satisfied = true
+	return &predicateResult, nil
+}
+
+func (pred HasTopics) Trigger() common.Trigger {
+	return common.TriggerStatic
+}

--- a/policy/predicate/topics_test.go
+++ b/policy/predicate/topics_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasTopics(t *testing.T) {
+	p := HasTopics([]string{"lib", "go"})
+
+	runTopicsTestCase(t, p, []HasTopicsTestCase{
+		{
+			"all topics",
+			&pulltest.Context{
+				RepositoryTopicsValue: []string{"lib", "go"},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"lib", "go"},
+				ConditionValues: []string{"lib", "go"},
+			},
+		},
+		{
+			"missing a topic",
+			&pulltest.Context{
+				RepositoryTopicsValue: []string{"lib"},
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{"lib"},
+				ConditionValues: []string{"go"},
+			},
+		},
+		{
+			"no topics",
+			&pulltest.Context{
+				RepositoryTopicsValue: []string{},
+			},
+			&common.PredicateResult{
+				Satisfied:       false,
+				Values:          []string{},
+				ConditionValues: []string{"lib"},
+			},
+		},
+		{
+			"error from context",
+			&pulltest.Context{
+				RepositoryTopicsError: errors.New("api error"),
+			},
+			nil,
+		},
+	})
+}
+
+func TestHasTopicsEmpty(t *testing.T) {
+	p := HasTopics([]string{})
+
+	runTopicsTestCase(t, p, []HasTopicsTestCase{
+		{
+			"empty predicate is satisfied",
+			&pulltest.Context{
+				RepositoryTopicsValue: []string{"lib"},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          nil,
+				ConditionValues: []string{},
+			},
+		},
+	})
+}
+
+func TestHasTopicsMixedCase(t *testing.T) {
+	p := HasTopics([]string{"Lib", "Go"})
+
+	runTopicsTestCase(t, p, []HasTopicsTestCase{
+		{
+			"mixed case requirement matches lowercase topics",
+			&pulltest.Context{
+				RepositoryTopicsValue: []string{"lib", "go"},
+			},
+			&common.PredicateResult{
+				Satisfied:       true,
+				Values:          []string{"lib", "go"},
+				ConditionValues: []string{"Lib", "Go"},
+			},
+		},
+	})
+}
+
+func TestHasTopicsTrigger(t *testing.T) {
+	p := HasTopics([]string{"lib"})
+	assert.Equal(t, common.TriggerStatic, p.Trigger())
+}
+
+type HasTopicsTestCase struct {
+	name                    string
+	context                 pull.Context
+	ExpectedPredicateResult *common.PredicateResult
+}
+
+func runTopicsTestCase(t *testing.T, p Predicate, cases []HasTopicsTestCase) {
+	ctx := context.Background()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			predicateResult, err := p.Evaluate(ctx, tc.context)
+			if tc.ExpectedPredicateResult == nil {
+				assert.Error(t, err)
+				return
+			}
+			if assert.NoError(t, err, "evaluation failed") {
+				assertPredicateResult(t, tc.ExpectedPredicateResult, predicateResult)
+			}
+		})
+	}
+}

--- a/pull/context.go
+++ b/pull/context.go
@@ -59,6 +59,9 @@ type Context interface {
 	// For an unset property, the key is _not_ present in the map.
 	RepositoryCustomProperties() (map[string]CustomProperty, error)
 
+	// RepositoryTopics returns the topics of the repo that the pull request targets.
+	RepositoryTopics() ([]string, error)
+
 	// Number returns the number of the pull request.
 	Number() int
 

--- a/pull/github.go
+++ b/pull/github.go
@@ -146,6 +146,7 @@ type GitHubContext struct {
 	pushedAt                   map[string]time.Time
 	workflowRuns               map[string][]string
 	repositoryCustomProperties map[string]CustomProperty
+	repositoryTopics           []string
 }
 
 // NewGitHubContext creates a new pull.Context that makes GitHub requests to
@@ -229,6 +230,26 @@ func (ghc *GitHubContext) loadRepositoryCustomProperties() error {
 		ghc.repositoryCustomProperties[value.PropertyName] = result
 	}
 
+	return nil
+}
+
+func (ghc *GitHubContext) RepositoryTopics() ([]string, error) {
+	if ghc.repositoryTopics == nil {
+		if err := ghc.loadRepositoryTopics(); err != nil {
+			return nil, err
+		}
+	}
+
+	return ghc.repositoryTopics, nil
+}
+
+func (ghc *GitHubContext) loadRepositoryTopics() error {
+	topics, _, err := ghc.client.Repositories.ListAllTopics(ghc.ctx, ghc.owner, ghc.repo, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to load repository topics")
+	}
+
+	ghc.repositoryTopics = topics
 	return nil
 }
 

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -81,6 +81,9 @@ type Context struct {
 	RepositoryCustomPropertiesValue map[string]pull.CustomProperty
 	RepositoryCustomPropertiesError error
 
+	RepositoryTopicsValue []string
+	RepositoryTopicsError error
+
 	Draft bool
 }
 
@@ -269,6 +272,10 @@ func (c *Context) Labels() ([]string, error) {
 
 func (c *Context) RepositoryCustomProperties() (map[string]pull.CustomProperty, error) {
 	return c.RepositoryCustomPropertiesValue, c.RepositoryCustomPropertiesError
+}
+
+func (c *Context) RepositoryTopics() ([]string, error) {
+	return c.RepositoryTopicsValue, c.RepositoryTopicsError
 }
 
 // assert that the test object implements the full interface


### PR DESCRIPTION
## Before this PR

policy-bot had no way to match approval rules based on repo topics/labels/tags.
GitHub exposes these as `topics` via the REST API (shown as tags on the repository page), so users who want to apply different policies to repos labeled `lib`, `go`, etc. cannot express that condition today.

## After this PR

Adds `has_topics` predicate that is satisfied when a repository has all of the specified topics.

Example:

```yaml
approval_rules:
  - name: library rule
    if:
      has_topics: ["lib"]
```

## Possible downsides?

None.