### PR TITLE
handler: skip re-evaluation when an approved review body is edited

### DIFF
--- a/changelog/@unreleased/pr-1276.v2.yml
+++ b/changelog/@unreleased/pr-1276.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix: prevent text edits to approved reviews from revoking approval when no review body patterns are configured"
+  links:
+    - href: https://github.com/palantir/policy-bot/pull/1276
+      text: "1276"

--- a/server/handler/pull_request_review.go
+++ b/server/handler/pull_request_review.go
@@ -76,6 +76,24 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 		return nil
 	}
 
+	// When a user edits the body of an approved review, GitHub fires a
+	// pull_request_review event with action "edited". The review state remains
+	// "approved"; only the comment text changed. Re-evaluating in this case
+	// would cause ignore_edited_comments to dismiss the review candidate
+	// (because LastEditedAt becomes non-zero), incorrectly revoking approval.
+	//
+	// Skip re-evaluation when:
+	//   - the event action is "edited" (body text changed, not state change)
+	//   - the review state is still "approved"
+	//   - no rules match on github_review_comment_patterns (which would need
+	//     the body to re-match after an edit)
+	if event.GetAction() == "edited" &&
+		pull.ReviewState(event.GetReview().GetState()) == pull.ReviewApproved &&
+		!h.anyRuleUsesReviewCommentPatterns(evalCtx.Config.Config) {
+		logger.Debug().Msg("Skipping evaluation: edited approved review body does not affect approval state")
+		return nil
+	}
+
 	result, err := evalCtx.EvaluatePolicy(ctx, evaluator)
 	if err != nil {
 		return err
@@ -83,6 +101,19 @@ func (h *PullRequestReview) Handle(ctx context.Context, eventType, deliveryID st
 
 	evalCtx.RunPostEvaluateActions(ctx, result, common.TriggerReview)
 	return nil
+}
+
+// anyRuleUsesReviewCommentPatterns returns true if any approval rule in the
+// policy uses github_review_comment_patterns. When such a rule exists, the
+// body of a review affects whether it qualifies as a candidate, so an edit to
+// the review body must trigger re-evaluation.
+func (h *PullRequestReview) anyRuleUsesReviewCommentPatterns(config *policy.Config) bool {
+	for _, rule := range config.ApprovalRules {
+		if len(rule.Options.GetMethods().GetGithubReviewCommentPatterns()) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *PullRequestReview) affectsApproval(review *github.PullRequestReview, config *policy.Config) bool {


### PR DESCRIPTION
## Summary

When a user edits the body text of an already-approved review, GitHub fires a `pull_request_review` event with action `edited`. The review state remains `approved`; only the comment text changed. Policy-bot currently re-evaluates on this event, which causes `ignore_edited_comments` to dismiss the review candidate (because `LastEditedAt` becomes non-zero), incorrectly revoking a still-valid approval.

This change adds a guard in `PullRequestReview.Handle` that skips re-evaluation when:

- the event action is `edited`
- the review state is still `approved`
- no approval rule uses `github_review_comment_patterns`

The third condition is important: rules that match on `github_review_comment_patterns` must still re-evaluate because the body text they pattern-match against may have changed in the edit.

All existing tests pass (`go test ./...`).

Fixes #1083