### PR TITLE
Upgrade Node to v24 in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Cache node_modules
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5


### PR DESCRIPTION
Recent dependency updates (notably `cssnano`) no longer support Node 20.

