### PR TITLE
Add dark mode support to the frontend

### DIFF
--- a/server/assets/css/main.css
+++ b/server/assets/css/main.css
@@ -187,7 +187,7 @@ details summary > * {
   display: inline-block;
 
   @apply w-8 h-8 mr-2 -ml-10 py-2;
-  @apply bg-light-gray3 rounded-full;
+  @apply bg-light-gray3 dark:bg-dark-gray4 rounded-full;
   @apply text-center;
 }
 

--- a/server/assets/index.js
+++ b/server/assets/index.js
@@ -1,5 +1,6 @@
 // Policy Bot Javascript
 import './js/filter.js';
+import './js/theme.js';
 
 // Policy Bot CSS
 import './css/main.css';

--- a/server/assets/js/theme.js
+++ b/server/assets/js/theme.js
@@ -1,0 +1,10 @@
+(function() {
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    toggle.checked = document.documentElement.classList.contains('dark');
+    toggle.addEventListener('change', ({ target }) => {
+      document.documentElement.classList.toggle('dark', target.checked);
+      localStorage.setItem('theme', target.checked ? 'dark' : 'light');
+    });
+  }
+})();

--- a/server/templates/details.html.tmpl
+++ b/server/templates/details.html.tmpl
@@ -8,9 +8,9 @@
 
 {{define "body-class"}}bg-light-gray5 text-dark-gray1 flex flex-col h-screen{{end}}
 {{define "body"}}
-  <header class="w-full tripart p-4 bg-white shadow-sm z-10 relative">
+  <header class="w-full tripart p-4 bg-white dark:bg-dark-gray3 shadow-sm z-10 relative">
     <a href="{{.PolicyURL}}" title="View the policy definition on GitHub"
-       class="px-2 py-1 text-xs text-dark-gray3 bg-light-gray3 border border-light-gray2 rounded-sm truncate max-w-full hover:bg-light-gray2 no-underline hover:no-underline">
+       class="px-2 py-1 text-xs text-dark-gray3 dark:text-light-gray3 bg-light-gray3 dark:bg-dark-gray4 border border-light-gray2 dark:border-dark-gray5 rounded-sm truncate max-w-full hover:bg-light-gray2 dark:hover:bg-dark-gray5 no-underline hover:no-underline">
       {{.PullRequest.GetBase.GetRepo.GetFullName}}: {{.PullRequest.GetBase.GetRef}}
     </a>
     <h1 class="text-xl font-normal tracking-tight text-center">
@@ -18,7 +18,7 @@
         #{{.PullRequest.GetNumber}}</a>:
       {{.PullRequest.GetTitle}}
     </h1>
-    <span class="text-xs text-dark-gray3 truncate max-w-full">
+    <span class="text-xs text-dark-gray3 dark:text-light-gray3 truncate max-w-full">
       {{.User}}
     </span>
   </header>
@@ -37,7 +37,7 @@
         <h2 class="mb-1 text-lg font-bold">Status: {{$s | toFirstUpper}}</h2>
         <p>{{or .Result.Error .Result.StatusDescription}}</p>
       </div>
-      <div class="p-2 rounded-md bg-white text-dark-gray1 text-sm text-shadow-none">
+      <div class="p-2 rounded-md bg-white dark:bg-dark-gray3 text-dark-gray1 dark:text-light-gray4 text-sm text-shadow-none">
         <div class="toggle">
             <input id="filter-toggle" type="checkbox" autocomplete="off" checked/>
             <label for="filter-toggle">Hide skipped rules</label>
@@ -66,19 +66,19 @@
 {{ $s := (or (and .Error "error") (.Status | print)) }}
 {{ $showReviewers := (and $root.ExpandRequiredReviewers (eq $s "pending")) }}
 <li class="node" data-status="{{$s}}" {{if not (eq $s $nextStatus)}}data-next-status="{{$nextStatus}}"{{end}}>
-  <div class="bg-white p-2 shadow-sm max-w-lg status-stripe {{$s}}">
+  <div class="bg-white dark:bg-dark-gray3 p-2 shadow-sm max-w-lg status-stripe {{$s}}">
     {{template "result-details" .}}
     {{if (or (.PredicateResults) (hasActors .Requires) (hasActorsPermissions .Requires) (gt (len .Requires.Conditions) 0))}}
     <details
-      class="bg-light-gray5 p-2 mt-2 text-sm"
+      class="bg-light-gray5 dark:bg-dark-gray2 p-2 mt-2 text-sm"
       {{if $showReviewers}}
       hx-get="{{$root.BasePath}}/details/{{$root.PullRequest.GetBase.GetRepo.GetFullName}}/{{$root.PullRequest.GetNumber}}/reviewers?rule={{.Name | urlencode}}"
       hx-trigger="toggle once"
       hx-target="find .reviewers"
       {{end}}
     >
-      <summary class="text-dark-gray3 font-semibold">Details</summary>
-      <div class="border-t border-light-gray3 mt-2 overflow-x-auto whitespace-nowrap">
+      <summary class="text-dark-gray3 dark:text-light-gray3 font-semibold">Details</summary>
+      <div class="border-t border-light-gray3 dark:border-dark-gray4 mt-2 overflow-x-auto whitespace-nowrap">
         {{if .PredicateResults}}
           <div class="pt-2">
             {{template "result-predicates-details" .}}

--- a/server/templates/index.html.tmpl
+++ b/server/templates/index.html.tmpl
@@ -14,12 +14,12 @@
   <a class="block px-4 py-2 bg-blue3 hover:bg-blue2 bg-highlight border border-blue2 rounded text-lg text-white hover:text-white no-underline" href="{{$appURL}}">Install</a>
 </header>
 <div class="max-w-3xl">
-  <section class="bg-white py-4 px-8 mb-8 rounded shadow-sm">
+  <section class="bg-white dark:bg-dark-gray3 py-4 px-8 mb-8 rounded shadow-sm">
     <h2 class="mb-2 font-bold">Getting Started</h2>
     <ol class="list-numbers">
       <li><a href="{{$appURL}}">Install <code>{{.AppName}}</code></a> on your repository</li>
       <li>Add a <code>{{.PolicyPath}}</code> file on the default branch (<a href="{{$docsURL}}#configuration">docs</a>):
-        <pre class="p-2 text-sm bg-light-gray3">policy:
+        <pre class="p-2 text-sm bg-light-gray3 dark:bg-dark-gray1">policy:
   approval:
     - one approval from palantir
 
@@ -32,7 +32,7 @@ approval_rules:
       <li>Open a pull request and watch the status change based on the policy!</li>
     </ol>
   </section>
-  <section class="bg-white py-4 px-8 rounded shadow-sm">
+  <section class="bg-white dark:bg-dark-gray3 py-4 px-8 rounded shadow-sm">
     <h2 class="mb-2 font-bold">Learn More</h2>
     <ul class="pl-4 list-disc">
       <li><a href="{{$docsURL}}">Documentation</a></li>

--- a/server/templates/page.html.tmpl
+++ b/server/templates/page.html.tmpl
@@ -9,9 +9,20 @@
 
     <link rel="icon" href="{{ resource "img/favicon.ico" }}" />
     <link rel="stylesheet" href="{{ resource "css/main.css" }}">
-    {{block "scripts" .}}{{end}}
+    <script>
+      (function() {
+        var stored = localStorage.getItem("theme");
+        var dark = stored ? stored === "dark" : window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (dark) document.documentElement.classList.add("dark");
+      })();
+    </script>
+    {{block "scripts" .}}<script defer src="{{ resource "js/main.js" }}"></script>{{end}}
   </head>
-  <body class="{{block "body-class" .}}bg-light-gray5 text-dark-gray1{{end}}">
+  <body class="{{block "body-class" .}}bg-light-gray5 text-dark-gray1{{end}} dark:bg-dark-gray1 dark:text-light-gray4">
+    <div class="toggle fixed bottom-4 right-4 z-50 bg-white dark:bg-dark-gray3 rounded-full px-3 py-1 shadow-sm text-xs text-dark-gray1 dark:text-light-gray4">
+      <input id="theme-toggle" type="checkbox" autocomplete="off"/>
+      <label for="theme-toggle">Dark mode</label>
+    </div>
     {{block "body" .}}{{end}}
   </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: {
     relative: true,
     files: [


### PR DESCRIPTION
## Before this PR
The frontend only supports a single light theme, with hardcoded Tailwind color classes (`bg-white`, `text-dark-gray1`, etc.) throughout the templates and CSS. Users with a dark OS/browser preference get a bright UI with no way to opt out.

## After this PR
- Adds `darkMode: 'class'` to the Tailwind config and `dark:` variants across `page.html.tmpl`, `details.html.tmpl`, `index.html.tmpl`, and `main.css`.
- Adds a toggle switch (bottom-right on every page, reusing the existing `.toggle` component styling) to manually switch themes, persisted in `localStorage`.
- Defaults to the OS/browser `prefers-color-scheme` when no manual preference is stored, applied via an inline script in `<head>` to avoid a flash of the wrong theme.
- Fixes a latent bug where `index.html.tmpl` didn't load any JS at all (it never overrode the `scripts` block), by making `main.js` load by default from `page.html.tmpl`.

## Possible downsides?
None expected, this is additive. The default (light) appearance is unchanged for users who don't opt into dark mode and whose system preference is light.