### PR TITLE
Retry config fetch on any server 5XX

### DIFF
--- a/server/handler/fetcher.go
+++ b/server/handler/fetcher.go
@@ -17,7 +17,6 @@ package handler
 import (
 	"context"
 	"errors"
-	"net/http"
 	"os"
 	"time"
 
@@ -108,10 +107,7 @@ func (cf *ConfigFetcher) ConfigForRepositoryBranch(ctx context.Context, client *
 func isServerError(err error) bool {
 	var ghErr *github.ErrorResponse
 	if errors.As(err, &ghErr) {
-		switch ghErr.Response.StatusCode {
-		case http.StatusInternalServerError, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-			return true
-		}
+		return ghErr.Response.StatusCode >= 500 && ghErr.Response.StatusCode <= 599
 	}
 	return false
 }

--- a/server/handler/fetcher_test.go
+++ b/server/handler/fetcher_test.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-github/v89/github"
@@ -24,6 +25,60 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func githubErr(statusCode int) error {
+	return &github.ErrorResponse{
+		Response: &http.Response{StatusCode: statusCode},
+	}
+}
+
+func TestIsServerError(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"bad gateway", githubErr(http.StatusBadGateway), true},
+		{"internal server error", githubErr(http.StatusInternalServerError), true},
+		{"service unavailable", githubErr(http.StatusServiceUnavailable), true},
+		{"gateway timeout", githubErr(http.StatusGatewayTimeout), true},
+		{"not found", githubErr(http.StatusNotFound), false},
+		{"unauthorized", githubErr(http.StatusUnauthorized), false},
+		{"ok", githubErr(http.StatusOK), false},
+		{"non-github error", errors.New("request failed"), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isServerError(test.err))
+		})
+	}
+}
+
+func TestConfigFetcherRetriesServerError(t *testing.T) {
+	cache := NewSeenPolicyCache()
+
+	calls := 0
+	fetcher := ConfigFetcher{
+		Loader: mockConfigLoader{
+			loadConfig: func(ctx context.Context, client *github.Client, owner, repo, ref string) (appconfig.Config, error) {
+				calls++
+				if calls == 1 {
+					return appconfig.Config{}, githubErr(http.StatusBadGateway)
+				}
+				return appconfig.Config{
+					Content: []byte("policy:\n  approval: []\n"),
+					Source:  "testorg/testrepo@main",
+					Path:    ".policy.yml",
+				}, nil
+			},
+		},
+		SeenPolicyCache: cache,
+	}
+
+	fc := fetcher.ConfigForRepositoryBranch(context.Background(), nil, "testorg", "testrepo", "main")
+	require.NoError(t, fc.LoadError)
+	require.NoError(t, fc.ParseError)
+	assert.Equal(t, 2, calls)
+}
 
 type mockConfigLoader struct {
 	loadConfig func(ctx context.Context, client *github.Client, owner, repo, ref string) (appconfig.Config, error)


### PR DESCRIPTION
## Before this PR

We are expanding the `isServerError` to return `true` for all 5XX status codes instead of a small subset.
This issue was raised in https://github.com/palantir/policy-bot/issues/1298

## After this PR
https://github.com/palantir/policy-bot/issues/1298 will be addressed and config fetching will retry GitHub 502s.

## Possible downsides?

None, unless someone is misusing 5XX status codes in lieu of a 4XX like a 404 or 429.
