### PR TITLE
Allow validate command to test remote config syntax

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -18,6 +18,7 @@ import (
 	"io/fs"
 	"os"
 
+	"github.com/palantir/go-githubapp/appconfig"
 	"github.com/palantir/policy-bot/policy"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -45,7 +46,7 @@ func validationCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "failed to read policy file: %s", validateCmdConfig.Path)
 	}
 
-	remoteRef, err := appconfig.YAMLRemoteRefParser("", requestPolicy)
+	remoteRef, err := appconfig.YAMLRemoteRefParser("", policyData)
 	if err == nil && remoteRef != nil {
 		return nil
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -45,6 +45,11 @@ func validationCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrapf(err, "failed to read policy file: %s", validateCmdConfig.Path)
 	}
 
+	remoteRef, err := appconfig.YAMLRemoteRefParser("", requestPolicy)
+	if err == nil && remoteRef != nil {
+		return nil
+	}
+
 	var policyConfig policy.Config
 	if err := yaml.UnmarshalStrict(policyData, &policyConfig); err != nil {
 		return errors.Wrapf(err, "failed to parse policy from yaml file")


### PR DESCRIPTION
## Before this PR
The Validate API endpoint will test both remote and local configs, but the validate subcommand errors on remote configs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Extend the validate subcommand to handle remote configurations.

As with API endpoint, only checks remote config for syntax; does not load the actual referenced config.
==COMMIT_MSG==
