### PR TITLE
Request reviews from teams with inherited repository permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,8 +1030,8 @@ supported options:
 
  * `all-users` to request all users who can approve
  * `random-users` to randomly select the number of users that are required
- * `teams` to request teams for review. Teams must be repository collaborators
-   with at least read access.
+ * `teams` to request teams for review. Teams must have at least read access
+   to the repository, either directly or inherited from a parent team.
 
 ```yaml
 options:

--- a/policy/reviewer/reviewer.go
+++ b/policy/reviewer/reviewer.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/palantir/policy-bot/policy/common"
 	"github.com/palantir/policy-bot/pull"
@@ -196,12 +197,35 @@ func selectTeamReviewers(ctx context.Context, prctx pull.Context, selection *Sel
 	}
 
 	var teams []string
+	selected := make(map[string]bool)
 	for team, perm := range eligibleTeams {
 		switch {
 		case requestsTeam(result, prctx.RepositoryOwner()+"/"+team):
 			teams = append(teams, team)
+			selected[team] = true
 		case requestsPermission(result, perm):
 			teams = append(teams, team)
+			selected[team] = true
+		}
+	}
+
+	// Teams that only have permission inherited from a parent team are not
+	// repository collaborators, so they do not appear in the eligible team
+	// list. Resolve the remaining requested teams individually to include
+	// inherited permissions.
+	for _, qualifiedTeam := range result.ReviewRequestRule.Teams {
+		team, ok := strings.CutPrefix(qualifiedTeam, prctx.RepositoryOwner()+"/")
+		if !ok || selected[team] {
+			continue
+		}
+
+		perm, err := prctx.TeamPermission(team)
+		if err != nil {
+			return err
+		}
+		if perm != pull.PermissionNone {
+			teams = append(teams, team)
+			selected[team] = true
 		}
 	}
 

--- a/policy/reviewer/reviewer_test.go
+++ b/policy/reviewer/reviewer_test.go
@@ -368,6 +368,29 @@ func TestSelectReviewers_TeamNotCollaborator(t *testing.T) {
 	require.Len(t, selection.Users, 0, "policy should request no people")
 }
 
+func TestSelectReviewers_TeamInheritedPermission(t *testing.T) {
+	r := rand.New(rand.NewSource(42))
+	results := []*common.Result{
+		{
+			Name:   "team-inherited",
+			Status: common.StatusPending,
+			ReviewRequestRule: &common.ReviewRequestRule{
+				Teams:         []string{"everyone/team-write", "everyone/team-inherited", "other-org/team-other"},
+				RequiredCount: 1,
+				Mode:          common.RequestModeTeams,
+			},
+		},
+	}
+
+	prctx := makeContext()
+	selection, err := SelectReviewers(context.Background(), prctx, results, r)
+	require.NoError(t, err)
+	require.Len(t, selection.Teams, 2, "two teams should be returned")
+	require.Contains(t, selection.Teams, "team-write", "team-write should be selected")
+	require.Contains(t, selection.Teams, "team-inherited", "team with inherited permission should be selected")
+	require.Len(t, selection.Users, 0, "policy should request no people")
+}
+
 func TestSelectReviewers_Org(t *testing.T) {
 	r := rand.New(rand.NewSource(42))
 	results := []*common.Result{
@@ -499,6 +522,12 @@ func makeContext() pull.Context {
 			"team-write":    pull.PermissionWrite,
 			"team-admin":    pull.PermissionAdmin,
 			"team-maintain": pull.PermissionMaintain,
+		},
+		TeamPermissionsValue: map[string]pull.Permission{
+			"team-write":     pull.PermissionWrite,
+			"team-admin":     pull.PermissionAdmin,
+			"team-maintain":  pull.PermissionMaintain,
+			"team-inherited": pull.PermissionWrite,
 		},
 		TeamMemberships: map[string][]string{
 			"user-team-admin":    {"everyone/team-admin"},

--- a/pull/context.go
+++ b/pull/context.go
@@ -123,6 +123,11 @@ type Context interface {
 	// permission on a repo.
 	Teams() (map[string]Permission, error)
 
+	// TeamPermission returns the permission of the named team on the
+	// repository, including permission inherited from parent teams. It
+	// returns PermissionNone if the team does not exist or has no access.
+	TeamPermission(team string) (Permission, error)
+
 	// RequestedReviewers returns any current and dismissed review requests on
 	// the pull request.
 	RequestedReviewers() ([]*Reviewer, error)

--- a/pull/github.go
+++ b/pull/github.go
@@ -141,6 +141,7 @@ type GitHubContext struct {
 	collaborators              map[Permission][]*Collaborator
 	permissions                map[string]Permission
 	teams                      map[string]Permission
+	teamPermissions            map[string]Permission
 	statuses                   map[string]string
 	labels                     []string
 	pushedAt                   map[string]time.Time
@@ -778,6 +779,29 @@ func (ghc *GitHubContext) Teams() (map[string]Permission, error) {
 		ghc.teams = allTeams
 	}
 	return ghc.teams, nil
+}
+
+func (ghc *GitHubContext) TeamPermission(team string) (Permission, error) {
+	if perm, ok := ghc.teamPermissions[team]; ok {
+		return perm, nil
+	}
+
+	perm := PermissionNone
+	repo, _, err := ghc.client.Teams.IsTeamRepoBySlug(ghc.ctx, ghc.owner, team, ghc.owner, ghc.repo)
+	switch {
+	case isNotFound(err):
+		// the team does not exist or has no access to the repository
+	case err != nil:
+		return PermissionNone, errors.Wrapf(err, "failed to get repository permission for team %s", team)
+	default:
+		perm = ParseRepositoryPermissions(repo.GetPermissions())
+	}
+
+	if ghc.teamPermissions == nil {
+		ghc.teamPermissions = make(map[string]Permission)
+	}
+	ghc.teamPermissions[team] = perm
+	return perm, nil
 }
 
 func (ghc *GitHubContext) LatestStatuses() (map[string]string, error) {

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -60,6 +60,9 @@ type Context struct {
 	TeamsValue map[string]pull.Permission
 	TeamsError error
 
+	TeamPermissionsValue map[string]pull.Permission
+	TeamPermissionsError error
+
 	OrgMemberships     map[string][]string
 	OrgMembershipError error
 
@@ -253,6 +256,13 @@ func (c *Context) Reviews() ([]*pull.Review, error) {
 
 func (c *Context) Teams() (map[string]pull.Permission, error) {
 	return c.TeamsValue, c.TeamsError
+}
+
+func (c *Context) TeamPermission(team string) (pull.Permission, error) {
+	if c.TeamPermissionsError != nil {
+		return pull.PermissionNone, c.TeamPermissionsError
+	}
+	return c.TeamPermissionsValue[team], nil
 }
 
 func (c *Context) LatestStatuses() (map[string]string, error) {


### PR DESCRIPTION
## Before this PR

When `request_review` is enabled with `mode: teams`, policy-bot only requests reviews from teams that appear in the repository team list (`GET /repos/{owner}/{repo}/teams`). Teams whose access is only inherited from a parent team do not reliably appear in that list, so they are silently skipped — even though the GitHub API accepts review requests for such teams (confirmed manually, and noted in #165 where a maintainer reproduced requesting a child team whose parent had read access via the GitHub UI).

Fixes #165

## After this PR
==COMMIT_MSG==
Request reviews from teams with inherited repository permissions
==COMMIT_MSG==

Teams listed in `requires.teams` now receive review requests even when their repository permission is inherited from a parent team.

Implementation:

- After matching against the repository team list as before, any remaining requested teams are resolved individually via the [check team permissions endpoint](https://docs.github.com/en/rest/teams/teams#check-team-permissions-for-a-repository) (`Teams.IsTeamRepoBySlug`), which is documented to include permissions inherited through parent teams
- Adds `TeamPermission(team)` to `pull.Context`, implemented with a per-team cache on `GitHubContext`; extra API calls are only made for requested teams missing from the repository team list
- Teams with no access at all resolve to 404 → `PermissionNone` and remain excluded; teams from other organizations are ignored, as before; permission-based selection (`requires.permissions`) is unchanged
- Updates the README caveat for `mode: teams` accordingly

Verification, in addition to the new unit test:

- Verified against a real organization where child teams inherit access from an umbrella parent team: `IsTeamRepoBySlug` + `ParseRepositoryPermissions` resolves inherited-only teams to `write` (404 for unknown teams), with both a user token and a GitHub App installation token holding org Members read — the same class of credentials policy-bot uses
- Verified that `POST /pulls/{n}/requested_reviewers` succeeds for an inherited-access team that is not a direct repository collaborator

## Possible downsides?

- One additional API request per requested team that is not in the repository team list, per evaluation (cached within an evaluation context)
- Behavior change: teams that were previously skipped silently will start receiving review requests. Organizations relying on the old behavior to suppress requests for inherited-access teams will see new notifications