### PR TITLE
Fix 500 errors being cached by httpcache

### DIFF
--- a/server/error_filter_transport.go
+++ b/server/error_filter_transport.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http"
+)
+
+// errorFilteringTransport wraps an http.RoundTripper and prevents 5xx error
+// responses from being cached. This fixes the issue where httpcache caches
+// error responses in violation of RFC 7231.
+type errorFilteringTransport struct {
+	transport http.RoundTripper
+}
+
+// NewErrorFilteringTransport creates a new error filtering transport that wraps
+// the provided RoundTripper.
+func NewErrorFilteringTransport(transport http.RoundTripper) http.RoundTripper {
+	return &errorFilteringTransport{transport: transport}
+}
+
+// RoundTrip implements http.RoundTripper. It calls the wrapped transport and
+// strips cache-related headers from 5xx error responses to prevent them from
+// being cached.
+func (t *errorFilteringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	// If the response is a 5xx error, remove cache headers to prevent httpcache
+	// from caching the error response. This is required by RFC 7231 section 6.6.
+	if resp.StatusCode >= 500 && resp.StatusCode <= 599 {
+		resp.Header.Del("ETag")
+		resp.Header.Del("Cache-Control")
+		resp.Header.Del("Expires")
+		resp.Header.Del("Last-Modified")
+	}
+
+	return resp, nil
+}

--- a/server/error_filter_transport_test.go
+++ b/server/error_filter_transport_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRoundTripper struct {
+	response *http.Response
+	err      error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.response, m.err
+}
+
+func TestErrorFilteringTransport_Allows5xxWithoutCacheHeaders(t *testing.T) {
+	req := &http.Request{}
+
+	resp := &http.Response{
+		StatusCode: 500,
+		Header: http.Header{
+			"ETag":           []string{"123"},
+			"Cache-Control":  []string{"public"},
+			"Content-Length": []string{"0"},
+		},
+		Body: io.NopCloser(strings.NewReader("")),
+	}
+
+	mock := &mockRoundTripper{response: resp}
+	transport := NewErrorFilteringTransport(mock)
+
+	result, err := transport.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 500, result.StatusCode)
+	assert.Empty(t, result.Header.Get("ETag"))
+	assert.Empty(t, result.Header.Get("Cache-Control"))
+	assert.Empty(t, result.Header.Get("Expires"))
+	assert.Empty(t, result.Header.Get("Last-Modified"))
+	assert.Equal(t, "0", result.Header.Get("Content-Length"))
+}
+
+func TestErrorFilteringTransport_Allows200WithCacheHeaders(t *testing.T) {
+	req := &http.Request{}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header: http.Header{
+			"ETag":          []string{"123"},
+			"Cache-Control": []string{"public"},
+		},
+		Body: io.NopCloser(strings.NewReader("")),
+	}
+
+	mock := &mockRoundTripper{response: resp}
+	transport := NewErrorFilteringTransport(mock)
+
+	result, err := transport.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, result.StatusCode)
+	assert.Equal(t, "123", result.Header.Get("ETag"))
+	assert.Equal(t, "public", result.Header.Get("Cache-Control"))
+}
+
+func TestErrorFilteringTransport_PropagatesErrors(t *testing.T) {
+	req := &http.Request{}
+	expectedErr := errors.New("network error")
+
+	mock := &mockRoundTripper{err: expectedErr}
+	transport := NewErrorFilteringTransport(mock)
+
+	_, err := transport.RoundTrip(req)
+
+	assert.Equal(t, expectedErr, err)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -117,6 +117,9 @@ func New(c *Config) (*Server, error) {
 			return lrucache.New(maxSize, 0)
 		}),
 		githubapp.WithClientMiddleware(
+			func(rt http.RoundTripper) http.RoundTripper {
+				return NewErrorFilteringTransport(rt)
+			},
 			githubapp.ClientLogging(
 				zerolog.DebugLevel,
 				githubapp.LogRequestBody("^"+v4URL.Path+"$"),


### PR DESCRIPTION
## Problem

When GitHub API returns a 500 error, the httpcache library caches the error response. Consecutive requests for the same resource return the cached 500 error instead of retrying the API, causing policy evaluation to fail repeatedly.

**Root cause:** The httpcache library's `canStore()` function only checks for `no-store` directives and doesn't validate HTTP status codes. This violates RFC 7231, which requires that 5xx responses must not be cached by default.

## Solution

Add an error filtering transport middleware that intercepts responses and strips cache headers from 5xx responses before they reach httpcache. This prevents error caching while preserving conditional request support (ETags, 304 Not Modified) for successful responses.

### How it works

- Transport strips ETag, Cache-Control, Expires, Last-Modified headers from 5xx responses
- Headers remain intact on success responses (200, 404, etc.)
- Allows conditional requests to work normally
- RFC 7231 compliant

### Impact

- Fixes repeated 500 errors blocking policy evaluation
- Maintains rate limit efficiency via conditional requests
- No impact on other API calls or functionality

Related to https://github.com/palantir/policy-bot/issues/1333