### PR TITLE
Add policy_from_default_branch option

### DIFF
--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -122,7 +122,13 @@ sessions:
 #   # POLICYBOT_OPTIONS_STATUS_CHECK_CONTEXT environment variable.
 #   status_check_context: policy-bot
 #
-#   # If true, expand teams, organizations, and permissions in the detils UI to
+#   # Load the policy from the default branch instead of the base branch and
+#   # drop the branch name from the status context. Assumes the default branch
+#   # is protected. Can also be set by the
+#   # POLICYBOT_OPTIONS_POLICY_FROM_DEFAULT_BRANCH environment variable.
+#   policy_from_default_branch: false
+#
+#   # If true, expand teams, organizations, and permissions in the details UI to
 #   # a list of users. This option has security implications; see the README.
 #   # Can also be set by the POLICYBOT_OPTIONS_EXPAND_REQUIRED_REVIEWERS
 #   # environment variable.

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -79,7 +79,12 @@ func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pul
 	owner := prctx.RepositoryOwner()
 	repository := prctx.RepositoryName()
 
-	fetchedConfig := b.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	policyBranch, err := b.policyBranch(ctx, client, owner, repository, baseBranch, loc.Value.GetBase().GetRepo().GetDefaultBranch())
+	if err != nil {
+		return nil, err
+	}
+
+	fetchedConfig := b.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyBranch)
 
 	return &EvalContext{
 		Client:   client,
@@ -99,4 +104,21 @@ func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger commo
 		return errors.Wrap(err, "failed to create evaluation context")
 	}
 	return evalCtx.Evaluate(ctx, trigger)
+}
+
+func (b *Base) policyBranch(ctx context.Context, client *github.Client, owner, repo, baseBranch, payloadDefaultBranch string) (string, error) {
+	if !b.PullOpts.PolicyFromDefaultBranch {
+		return baseBranch, nil
+	}
+	if payloadDefaultBranch != "" {
+		return payloadDefaultBranch, nil
+	}
+	repoInfo, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load repository for default branch")
+	}
+	if branch := repoInfo.GetDefaultBranch(); branch != "" {
+		return branch, nil
+	}
+	return "", errors.Errorf("repository %s/%s has no default branch", owner, repo)
 }

--- a/server/handler/base_test.go
+++ b/server/handler/base_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyBranch(t *testing.T) {
+	off := &Base{PullOpts: &PullEvaluationOptions{}}
+	branch, err := off.policyBranch(context.Background(), nil, "testorg", "testrepo", "feat-b", "main")
+	require.NoError(t, err)
+	assert.Equal(t, "feat-b", branch)
+
+	on := &Base{PullOpts: &PullEvaluationOptions{PolicyFromDefaultBranch: true}}
+	branch, err = on.policyBranch(context.Background(), nil, "testorg", "testrepo", "feat-b", "main")
+	require.NoError(t, err)
+	assert.Equal(t, "main", branch, "uses the payload default branch without an API call")
+}

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -194,7 +194,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 
 	status := github.RepoStatus{
 		State:       &state,
-		Context:     new(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
+		Context:     new(ec.Options.StatusContext(base)),
 		Description: &message,
 		TargetURL:   &detailsURL,
 	}
@@ -212,7 +212,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 	if err := PostStatus(ctx, ec.Client, owner, repo, sha, status); err != nil {
 		logger.Err(err).Msg("Failed to post repo status")
 	}
-	if ec.Options.PostInsecureStatusChecks {
+	if ec.Options.ShouldPostInsecureStatus() {
 		status.Context = new(ec.Options.StatusCheckContext)
 		if err := PostStatus(ctx, ec.Client, owner, repo, sha, status); err != nil {
 			logger.Err(err).Msg("Failed to post insecure repo status")

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"encoding"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -59,6 +60,11 @@ type PullEvaluationOptions struct {
 	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
 	// context behaviour, and will be removed in 2.0
 	PostInsecureStatusChecks bool `yaml:"post_insecure_status_checks"`
+
+	// PolicyFromDefaultBranch loads the policy from the default branch instead of the base branch and drops the
+	// branch suffix from the status context. It also suppresses the insecure status, which would otherwise
+	// duplicate the bare context. Off by default.
+	PolicyFromDefaultBranch bool `yaml:"policy_from_default_branch"`
 
 	// IgnoreEditedComments enables ignoring comments that have been edited when evaluating approval rules.
 	// This provides a server-side option to ignore edited comments across all rules.
@@ -109,6 +115,17 @@ func (p *PullEvaluationOptions) fillDefaults() {
 	}
 }
 
+func (p *PullEvaluationOptions) StatusContext(branch string) string {
+	if p.PolicyFromDefaultBranch {
+		return p.StatusCheckContext
+	}
+	return fmt.Sprintf("%s: %s", p.StatusCheckContext, branch)
+}
+
+func (p *PullEvaluationOptions) ShouldPostInsecureStatus() bool {
+	return p.PostInsecureStatusChecks && !p.PolicyFromDefaultBranch
+}
+
 func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setStringFromEnv("POLICY_PATH", prefix, &p.PolicyPath)
 	setStringPtrFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
@@ -118,6 +135,7 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setBoolFromEnv("EXPAND_REQUIRED_REVIEWERS", prefix, &p.ExpandRequiredReviewers)
 	setBoolFromEnv("STRICT_REVIEW_DISMISSAL", prefix, &p.StrictReviewDismissal)
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)
+	setBoolFromEnv("POLICY_FROM_DEFAULT_BRANCH", prefix, &p.PolicyFromDefaultBranch)
 	setBoolPtrFromEnv("IGNORE_EDITED_COMMENTS", prefix, &p.IgnoreEditedComments)
 
 	p.setApprovalDefaultsFromEnv(prefix + "APPROVAL_DEFAULTS_")

--- a/server/handler/eval_options_test.go
+++ b/server/handler/eval_options_test.go
@@ -24,11 +24,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStatusContext(t *testing.T) {
+	byBranch := &PullEvaluationOptions{StatusCheckContext: "policy-bot"}
+	assert.Equal(t, "policy-bot: main", byBranch.StatusContext("main"))
+
+	fromDefault := &PullEvaluationOptions{StatusCheckContext: "policy-bot", PolicyFromDefaultBranch: true}
+	assert.Equal(t, "policy-bot", fromDefault.StatusContext("feat-b"))
+}
+
+func TestShouldPostInsecureStatus(t *testing.T) {
+	assert.True(t, (&PullEvaluationOptions{PostInsecureStatusChecks: true}).ShouldPostInsecureStatus())
+	assert.False(t, (&PullEvaluationOptions{PostInsecureStatusChecks: true, PolicyFromDefaultBranch: true}).ShouldPostInsecureStatus())
+	assert.False(t, (&PullEvaluationOptions{}).ShouldPostInsecureStatus())
+}
+
 func TestPullEvaluationOptions_SetValuesFromEnv(t *testing.T) {
 	tests := map[string]struct {
 		Env         map[string]string
 		SetExpected func(*PullEvaluationOptions)
 	}{
+		"PolicyFromDefaultBranch": {
+			Env: map[string]string{"PEO_POLICY_FROM_DEFAULT_BRANCH": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.PolicyFromDefaultBranch = true
+			},
+		},
 		"PolicyPath": {
 			Env: map[string]string{"PEO_POLICY_PATH": "test/policy.yml"},
 			SetExpected: func(opts *PullEvaluationOptions) {

--- a/server/handler/installation.go
+++ b/server/handler/installation.go
@@ -98,11 +98,11 @@ func (h *Installation) postRepoInstallationStatus(ctx context.Context, client *g
 	}
 
 	head := branch.GetCommit().GetSHA()
-	contextWithBranch := fmt.Sprintf("%s: %s", h.PullOpts.StatusCheckContext, defaultBranch)
+	statusContext := h.PullOpts.StatusContext(defaultBranch)
 	state := "success"
 	message := fmt.Sprintf("%s successfully installed.", h.AppName)
 	status := github.RepoStatus{
-		Context:     &contextWithBranch,
+		Context:     &statusContext,
 		State:       &state,
 		Description: &message,
 	}

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -59,17 +59,21 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 	headSHA := mergeGroup.GetHeadSHA()
 
 	// If a PR is added to the merge queue, presumably the policy existed and was valid at the time of merge,
-	// so we're just checking for the existance of a policy here and don't care about its validity.
-	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	// so we're just checking for the existence of a policy here and don't care about its validity.
+	policyBranch, err := h.policyBranch(ctx, client, owner, repository, baseBranch, event.GetRepo().GetDefaultBranch())
+	if err != nil {
+		return err
+	}
+	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyBranch)
 	if fetchedConfig.Config == nil {
 		return nil
 	}
 
-	contextWithBranch := fmt.Sprintf("%s: %s", h.PullOpts.StatusCheckContext, baseBranch)
+	statusContext := h.PullOpts.StatusContext(baseBranch)
 	state := "success"
 	message := fmt.Sprintf("%s previously approved original pull request.", h.AppName)
 	status := github.RepoStatus{
-		Context:     &contextWithBranch,
+		Context:     &statusContext,
 		State:       &state,
 		Description: &message,
 	}
@@ -78,7 +82,7 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 		logger.Err(errors.WithStack(err)).Msg("Failed to post status check for merge group")
 	}
 
-	if h.PullOpts.PostInsecureStatusChecks {
+	if h.PullOpts.ShouldPostInsecureStatus() {
 		status.Context = new(h.PullOpts.StatusCheckContext)
 		if err := PostStatus(ctx, client, owner, repository, headSHA, status); err != nil {
 			logger.Err(err).Msg("Failed to post insecure repo status")

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -169,7 +169,11 @@ func (h *Simulate) newSimulatedContext(ctx context.Context, installationID int64
 	baseBranch, _ := simulatedPRCtx.Branches()
 	owner := simulatedPRCtx.RepositoryOwner()
 	repository := simulatedPRCtx.RepositoryName()
-	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	policyBranch, err := h.policyBranch(ctx, client, owner, repository, baseBranch, loc.Value.GetBase().GetRepo().GetDefaultBranch())
+	if err != nil {
+		return nil, nil, err
+	}
+	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyBranch)
 	return simulatedPRCtx, &fetchedConfig, nil
 }
 


### PR DESCRIPTION
## Summary

This is a draft implementation of the default-branch policy option from the discussion in [#1316](https://github.com/palantir/policy-bot/discussions/1316). It is open to show the proposed behaviour.

It adds a single opt-in `policy_from_default_branch` option, off by default. When it is on, the policy gets loaded from the repository's default branch rather than the pull request's base branch. Its status gets posted under a bare context with no branch suffix. The pull request still gets evaluated against its real base, so `targets_branch` still works where a repository needs different policies per branch.

Feedback on the approach and the option name is welcome.
