### PR TITLE
feat(logging): enable logging of github request IDs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -119,6 +119,7 @@ func New(c *Config) (*Server, error) {
 		githubapp.WithClientMiddleware(
 			githubapp.ClientLogging(
 				zerolog.DebugLevel,
+				githubapp.LogGitHubRequestID(),
 				githubapp.LogRequestBody("^"+v4URL.Path+"$"),
 			),
 			githubapp.ClientMetrics(base.Registry()),


### PR DESCRIPTION
## Before this PR

GitHub client logs do not include GitHub request IDs, making it more difficult to troubleshoot issues with GitHub.

## After this PR

==COMMIT_MSG==
GitHub request logs now include the request ID returned by GitHub.
==COMMIT_MSG==

## Possible downsides?

A very small increase in debug log size.

Closes https://github.com/palantir/policy-bot/issues/1333.