### PR TITLE
Add policy_from_default_branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,6 +1149,45 @@ approve and merge a pull request before `policy-bot` can detect the problem.
 Organizations concerned about this case should monitor and alert on the
 relevant audit logs or minimize write access to repositories.
 
+### Policy Source and Status Context <!-- omit in toc -->
+
+By default, `policy-bot` loads the policy from the base branch of each pull
+request and appends the base branch name to the status context (e.g.
+`policy-bot: main`). This scopes trust to a branch: a status earned against
+one branch's policy cannot satisfy a required check configured for a branch
+with a different policy.
+
+The branch suffix means the status name changes when a pull request is
+retargeted. In particular, GitHub's stacked pull requests evaluate every pull
+request in a stack against the required checks of the stack's final target
+branch, so pull requests that target another pull request's head branch never
+receive the exact context the required check expects.
+
+The `options.policy_from_default_branch` server option supports these
+workflows. When enabled, `policy-bot` loads the policy from the repository's
+default branch for every pull request and posts statuses under the bare
+`status_check_context` with no branch suffix. Because all pull requests are
+evaluated against a single policy source, the branch suffix no longer carries
+a security property and the stable name can be used as a required check.
+
+Before enabling this option, consider the following:
+
+- Repositories can no longer define different policies for different base
+  branches. The `targets_branch` predicate can express some per-branch
+  behavior within a single policy, but not all configurations.
+
+- The default branch must be protected. Users who can push to the default
+  branch can change the policy that applies to every pull request (with the
+  default behavior, they can only change the policy of pull requests that
+  target branches they can push to).
+
+- Policies that use the `targets_branch` predicate or evaluate pull request
+  content are still sensitive to retargeting: statuses attach to commits, so
+  after a retarget the previous status remains until `policy-bot` processes
+  the edit event and re-evaluates. This window exists with the default
+  behavior as well, but with a stable context the stale status is one a
+  required check accepts.
+
 ### Comment Edits <!-- omit in toc -->
 
 GitHub users with sufficient permissions can edit the comments of other users,

--- a/README.md
+++ b/README.md
@@ -1181,12 +1181,11 @@ Before enabling this option, consider the following:
   default behavior, they can only change the policy of pull requests that
   target branches they can push to).
 
-- Policies that use the `targets_branch` predicate or evaluate pull request
-  content are still sensitive to retargeting: statuses attach to commits, so
-  after a retarget the previous status remains until `policy-bot` processes
-  the edit event and re-evaluates. This window exists with the default
-  behavior as well, but with a stable context the stale status is one a
-  required check accepts.
+- Statuses attach to commits, so after a base branch change the previous
+  status remains until `policy-bot` re-evaluates. With a stable context the
+  stale status is one a required check accepts, so `policy-bot` forces a full
+  re-evaluation whenever a pull request's base branch changes; the remaining
+  exposure is the delay between the retarget and the updated status.
 
 ### Comment Edits <!-- omit in toc -->
 

--- a/config/policy-bot.example.yml
+++ b/config/policy-bot.example.yml
@@ -122,6 +122,14 @@ sessions:
 #   # POLICYBOT_OPTIONS_STATUS_CHECK_CONTEXT environment variable.
 #   status_check_context: policy-bot
 #
+#   # If true, load the policy from the repository's default branch instead of
+#   # each pull request's base branch, and post statuses under the bare
+#   # status_check_context with no branch suffix. The stable status name is
+#   # required for stacked pull requests. This option has security
+#   # implications; see the README. Can also be set by the
+#   # POLICYBOT_OPTIONS_POLICY_FROM_DEFAULT_BRANCH environment variable.
+#   policy_from_default_branch: false
+#
 #   # If true, expand teams, organizations, and permissions in the detils UI to
 #   # a list of users. This option has security implications; see the README.
 #   # Can also be set by the POLICYBOT_OPTIONS_EXPAND_REQUIRED_REVIEWERS

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -79,7 +79,12 @@ func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pul
 	owner := prctx.RepositoryOwner()
 	repository := prctx.RepositoryName()
 
-	fetchedConfig := b.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	policyRef, err := b.policyRef(ctx, client, owner, repository, baseBranch, loc.Value.GetBase().GetRepo().GetDefaultBranch())
+	if err != nil {
+		return nil, err
+	}
+
+	fetchedConfig := b.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyRef)
 
 	return &EvalContext{
 		Client:   client,
@@ -91,6 +96,29 @@ func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pul
 		PullContext: prctx,
 		Config:      fetchedConfig,
 	}, nil
+}
+
+// policyRef returns the branch to load the policy from: the pull request's
+// base branch by default, or the repository's default branch when the
+// PolicyFromDefaultBranch option is enabled. Event payloads usually carry the
+// default branch; the API lookup covers locators built without a payload
+// value, such as details page requests.
+func (b *Base) policyRef(ctx context.Context, client *github.Client, owner, repo, baseBranch, defaultBranch string) (string, error) {
+	if !b.PullOpts.PolicyFromDefaultBranch {
+		return baseBranch, nil
+	}
+	if defaultBranch != "" {
+		return defaultBranch, nil
+	}
+
+	repository, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get repository %s/%s for default branch", owner, repo)
+	}
+	if branch := repository.GetDefaultBranch(); branch != "" {
+		return branch, nil
+	}
+	return "", errors.Errorf("repository %s/%s has no default branch", owner, repo)
 }
 
 func (b *Base) Evaluate(ctx context.Context, installationID int64, trigger common.Trigger, loc pull.Locator) error {

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -98,11 +98,10 @@ func (b *Base) NewEvalContext(ctx context.Context, installationID int64, loc pul
 	}, nil
 }
 
-// policyRef returns the branch to load the policy from: the pull request's
-// base branch by default, or the repository's default branch when the
-// PolicyFromDefaultBranch option is enabled. Event payloads usually carry the
-// default branch; the API lookup covers locators built without a payload
-// value, such as details page requests.
+// policyRef returns the branch to load the policy from. Most pull request
+// values carry the repository's default branch; the API lookup covers the
+// minimal pull request objects in check_run and workflow_run event payloads,
+// which omit it.
 func (b *Base) policyRef(ctx context.Context, client *github.Client, owner, repo, baseBranch, defaultBranch string) (string, error) {
 	if !b.PullOpts.PolicyFromDefaultBranch {
 		return baseBranch, nil

--- a/server/handler/base_test.go
+++ b/server/handler/base_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func repoClient(t *testing.T, body string) *github.Client {
+	client, err := github.NewClient(
+		github.WithTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			assert.Equal(t, "/repos/testorg/testrepo", req.URL.Path)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    req,
+			}, nil
+		})),
+	)
+	require.NoError(t, err, "failed to create github client")
+	return client
+}
+
+func TestPolicyRef(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		b := &Base{PullOpts: &PullEvaluationOptions{}}
+
+		ref, err := b.policyRef(context.Background(), nil, "testorg", "testrepo", "feature-base", "main")
+		require.NoError(t, err)
+		assert.Equal(t, "feature-base", ref)
+	})
+
+	b := &Base{PullOpts: &PullEvaluationOptions{PolicyFromDefaultBranch: true}}
+
+	t.Run("payloadDefaultBranch", func(t *testing.T) {
+		ref, err := b.policyRef(context.Background(), nil, "testorg", "testrepo", "feature-base", "main")
+		require.NoError(t, err)
+		assert.Equal(t, "main", ref, "uses the payload value without an API call")
+	})
+
+	t.Run("apiFallback", func(t *testing.T) {
+		client := repoClient(t, `{"id": 1, "default_branch": "develop"}`)
+
+		ref, err := b.policyRef(context.Background(), client, "testorg", "testrepo", "feature-base", "")
+		require.NoError(t, err)
+		assert.Equal(t, "develop", ref)
+	})
+
+	t.Run("noDefaultBranch", func(t *testing.T) {
+		client := repoClient(t, `{"id": 1}`)
+
+		_, err := b.policyRef(context.Background(), client, "testorg", "testrepo", "feature-base", "")
+		assert.Error(t, err)
+	})
+}

--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -194,7 +194,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 
 	status := github.RepoStatus{
 		State:       &state,
-		Context:     new(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
+		Context:     new(ec.Options.StatusContext(base)),
 		Description: &message,
 		TargetURL:   &detailsURL,
 	}
@@ -212,7 +212,7 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 	if err := PostStatus(ctx, ec.Client, owner, repo, sha, status); err != nil {
 		logger.Err(err).Msg("Failed to post repo status")
 	}
-	if ec.Options.PostInsecureStatusChecks {
+	if ec.Options.ShouldPostInsecureStatus() {
 		status.Context = new(ec.Options.StatusCheckContext)
 		if err := PostStatus(ctx, ec.Client, owner, repo, sha, status); err != nil {
 			logger.Err(err).Msg("Failed to post insecure repo status")

--- a/server/handler/eval_context_test.go
+++ b/server/handler/eval_context_test.go
@@ -46,6 +46,17 @@ func TestParseConfigPostsStatusForSeenPolicy(t *testing.T) {
 	assert.Equal(t, "Error loading policy from testorg/testrepo@main", ec.Status.GetDescription())
 }
 
+func TestParseConfigPostsBareContextForDefaultBranchPolicy(t *testing.T) {
+	ec := makeEvalContext(true)
+	ec.Options.PolicyFromDefaultBranch = true
+
+	evaluator, err := ec.ParseConfig(context.Background(), common.TriggerAll)
+	require.Error(t, err)
+	assert.Nil(t, evaluator)
+	require.NotNil(t, ec.Status)
+	assert.Equal(t, "policy-bot", ec.Status.GetContext())
+}
+
 func makeEvalContext(seenPolicy bool) *EvalContext {
 	return &EvalContext{
 		Options: &PullEvaluationOptions{

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"encoding"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -59,6 +60,15 @@ type PullEvaluationOptions struct {
 	// no templating. This is turned off by default. This is to support legacy workflows that depend on the original
 	// context behaviour, and will be removed in 2.0
 	PostInsecureStatusChecks bool `yaml:"post_insecure_status_checks"`
+
+	// PolicyFromDefaultBranch loads the policy from the repository's default
+	// branch instead of the pull request's base branch and posts the status
+	// using the bare StatusCheckContext, with no branch suffix. Because the
+	// policy source no longer depends on the base branch, the status name is
+	// stable across base branches, which required status checks need for
+	// stacked pull requests and other retargeting workflows. This is turned
+	// off by default; see the README for the security tradeoffs.
+	PolicyFromDefaultBranch bool `yaml:"policy_from_default_branch"`
 
 	// IgnoreEditedComments enables ignoring comments that have been edited when evaluating approval rules.
 	// This provides a server-side option to ignore edited comments across all rules.
@@ -109,6 +119,27 @@ func (p *PullEvaluationOptions) fillDefaults() {
 	}
 }
 
+// StatusContext returns the status check context for a pull request with the
+// given base branch. The context normally embeds the branch name so that a
+// status earned against one branch's policy cannot satisfy a required check
+// on a branch with a different policy. When PolicyFromDefaultBranch is
+// enabled every branch shares the default branch's policy, so the bare
+// context is used instead.
+func (p *PullEvaluationOptions) StatusContext(baseBranch string) string {
+	if p.PolicyFromDefaultBranch {
+		return p.StatusCheckContext
+	}
+	return fmt.Sprintf("%s: %s", p.StatusCheckContext, baseBranch)
+}
+
+// ShouldPostInsecureStatus reports whether a second status with the bare
+// StatusCheckContext should be posted after the primary status. It is
+// disabled when PolicyFromDefaultBranch is enabled because the primary
+// status already uses the bare context.
+func (p *PullEvaluationOptions) ShouldPostInsecureStatus() bool {
+	return p.PostInsecureStatusChecks && !p.PolicyFromDefaultBranch
+}
+
 func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setStringFromEnv("POLICY_PATH", prefix, &p.PolicyPath)
 	setStringPtrFromEnv("SHARED_REPOSITORY", prefix, &p.SharedRepository)
@@ -118,6 +149,7 @@ func (p *PullEvaluationOptions) SetValuesFromEnv(prefix string) {
 	setBoolFromEnv("EXPAND_REQUIRED_REVIEWERS", prefix, &p.ExpandRequiredReviewers)
 	setBoolFromEnv("STRICT_REVIEW_DISMISSAL", prefix, &p.StrictReviewDismissal)
 	setBoolFromEnv("POST_INSECURE_STATUS_CHECKS", prefix, &p.PostInsecureStatusChecks)
+	setBoolFromEnv("POLICY_FROM_DEFAULT_BRANCH", prefix, &p.PolicyFromDefaultBranch)
 	setBoolPtrFromEnv("IGNORE_EDITED_COMMENTS", prefix, &p.IgnoreEditedComments)
 
 	p.setApprovalDefaultsFromEnv(prefix + "APPROVAL_DEFAULTS_")

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -41,8 +41,8 @@ type PullEvaluationOptions struct {
 	// Ignore PolicyPath and use SharedRepository and SharedPolicyPath only.
 	ForceSharedPolicy bool `yaml:"force_shared_policy"`
 
-	// StatusCheckContext will be used to create the status context. It will be used in the following
-	// pattern: <StatusCheckContext>: <Base Branch Name>
+	// StatusCheckContext is the base name for status contexts. See the
+	// StatusContext method for how the posted context is derived from it.
 	StatusCheckContext string `yaml:"status_check_context"`
 
 	// ExpandRequiredReviewers enables a UI feature where the details page

--- a/server/handler/eval_options_test.go
+++ b/server/handler/eval_options_test.go
@@ -24,6 +24,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStatusContext(t *testing.T) {
+	opts := &PullEvaluationOptions{StatusCheckContext: "policy-bot"}
+	assert.Equal(t, "policy-bot: main", opts.StatusContext("main"))
+
+	opts.PolicyFromDefaultBranch = true
+	assert.Equal(t, "policy-bot", opts.StatusContext("feature-base"))
+}
+
+func TestShouldPostInsecureStatus(t *testing.T) {
+	assert.False(t, (&PullEvaluationOptions{}).ShouldPostInsecureStatus())
+	assert.True(t, (&PullEvaluationOptions{
+		PostInsecureStatusChecks: true,
+	}).ShouldPostInsecureStatus())
+	assert.False(t, (&PullEvaluationOptions{
+		PostInsecureStatusChecks: true,
+		PolicyFromDefaultBranch:  true,
+	}).ShouldPostInsecureStatus(), "the primary status already uses the bare context")
+}
+
 func TestPullEvaluationOptions_SetValuesFromEnv(t *testing.T) {
 	tests := map[string]struct {
 		Env         map[string]string
@@ -51,6 +70,12 @@ func TestPullEvaluationOptions_SetValuesFromEnv(t *testing.T) {
 			Env: map[string]string{"PEO_STATUS_CHECK_CONTEXT": "custom-policy-bot"},
 			SetExpected: func(opts *PullEvaluationOptions) {
 				opts.StatusCheckContext = "custom-policy-bot"
+			},
+		},
+		"PolicyFromDefaultBranch": {
+			Env: map[string]string{"PEO_POLICY_FROM_DEFAULT_BRANCH": "true"},
+			SetExpected: func(opts *PullEvaluationOptions) {
+				opts.PolicyFromDefaultBranch = true
 			},
 		},
 		"ForceSharedPolicy": {

--- a/server/handler/installation.go
+++ b/server/handler/installation.go
@@ -98,11 +98,11 @@ func (h *Installation) postRepoInstallationStatus(ctx context.Context, client *g
 	}
 
 	head := branch.GetCommit().GetSHA()
-	contextWithBranch := fmt.Sprintf("%s: %s", h.PullOpts.StatusCheckContext, defaultBranch)
+	statusContext := h.PullOpts.StatusContext(defaultBranch)
 	state := "success"
 	message := fmt.Sprintf("%s successfully installed.", h.AppName)
 	status := github.RepoStatus{
-		Context:     &contextWithBranch,
+		Context:     &statusContext,
 		State:       &state,
 		Description: &message,
 	}

--- a/server/handler/merge_group.go
+++ b/server/handler/merge_group.go
@@ -60,16 +60,20 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 
 	// If a PR is added to the merge queue, presumably the policy existed and was valid at the time of merge,
 	// so we're just checking for the existance of a policy here and don't care about its validity.
-	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	policyRef, err := h.policyRef(ctx, client, owner, repository, baseBranch, event.GetRepo().GetDefaultBranch())
+	if err != nil {
+		return err
+	}
+	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyRef)
 	if fetchedConfig.Config == nil {
 		return nil
 	}
 
-	contextWithBranch := fmt.Sprintf("%s: %s", h.PullOpts.StatusCheckContext, baseBranch)
+	statusContext := h.PullOpts.StatusContext(baseBranch)
 	state := "success"
 	message := fmt.Sprintf("%s previously approved original pull request.", h.AppName)
 	status := github.RepoStatus{
-		Context:     &contextWithBranch,
+		Context:     &statusContext,
 		State:       &state,
 		Description: &message,
 	}
@@ -78,7 +82,7 @@ func (h *MergeGroup) Handle(ctx context.Context, eventType, devlieryID string, p
 		logger.Err(errors.WithStack(err)).Msg("Failed to post status check for merge group")
 	}
 
-	if h.PullOpts.PostInsecureStatusChecks {
+	if h.PullOpts.ShouldPostInsecureStatus() {
 		status.Context = new(h.PullOpts.StatusCheckContext)
 		if err := PostStatus(ctx, client, owner, repository, headSHA, status); err != nil {
 			logger.Err(err).Msg("Failed to post insecure repo status")

--- a/server/handler/pull_request.go
+++ b/server/handler/pull_request.go
@@ -50,6 +50,11 @@ func (h *PullRequest) Handle(ctx context.Context, eventType, deliveryID string, 
 		t = common.TriggerCommit
 	case "edited":
 		t = common.TriggerPullRequest
+		if event.GetChanges().GetBase() != nil {
+			// A base change alters the diff and can change any rule's
+			// result, but only produces an "edited" event.
+			t = common.TriggerAll
+		}
 	case "labeled", "unlabeled":
 		t = common.TriggerLabel
 	default:

--- a/server/handler/simulate.go
+++ b/server/handler/simulate.go
@@ -169,7 +169,11 @@ func (h *Simulate) newSimulatedContext(ctx context.Context, installationID int64
 	baseBranch, _ := simulatedPRCtx.Branches()
 	owner := simulatedPRCtx.RepositoryOwner()
 	repository := simulatedPRCtx.RepositoryName()
-	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, baseBranch)
+	policyRef, err := h.policyRef(ctx, client, owner, repository, baseBranch, loc.Value.GetBase().GetRepo().GetDefaultBranch())
+	if err != nil {
+		return nil, nil, err
+	}
+	fetchedConfig := h.ConfigFetcher.ConfigForRepositoryBranch(ctx, client, owner, repository, policyRef)
 	return simulatedPRCtx, &fetchedConfig, nil
 }
 


### PR DESCRIPTION
## What this changes

Adds an opt-in `policy_from_default_branch` server setting to support GitHub's native stacked pull requests feature.

When enabled, Policy Bot loads policy from the repository's default branch for every pull request and reports the result under the bare `status_check_context` (for example, `policy-bot` instead of `policy-bot: main`). GitHub evaluates every PR in a native stack against the required checks of the stack's final target branch, so intermediate PRs need a stable check name even when they target another PR's branch.

The existing behavior remains the default. The setting is available as either:

- `options.policy_from_default_branch`
- `POLICYBOT_OPTIONS_POLICY_FROM_DEFAULT_BRANCH`

This also applies the same context naming to merge-queue and installation statuses, and avoids posting a duplicate bare status when `post_insecure_status_checks` is enabled.

This implements the approach @bluekeyes suggested in #1316. It builds on @juzsal's draft #1350, adding the README documentation of the tradeoffs, test coverage, and the retargeting fix below.

## Retargeting pull requests

GitHub sends an `edited` event when a PR's base branch changes. Policy Bot previously treated that as a pull-request-only trigger, so policies using commit or review triggers could keep a stale result until the next push.

This change runs a full evaluation when the base branch changes. That is especially important with a stable status context, since GitHub attaches statuses to commits and an old success could otherwise continue satisfying the required check after a retarget.

## Security considerations

Using one policy source means repositories can no longer maintain separate policy files per base branch. `targets_branch` can still handle branch-specific rules within the shared policy.

The default branch should be protected because its policy governs every pull request. There is also a short window after retargeting where the previous status remains attached to the commit, until the edited event is processed and the new evaluation is posted.

These tradeoffs are documented in the README.

## Testing

Ran:

```sh
go test ./server/... ./policy/... ./pull/...
```

Added coverage for policy source selection, API fallback behavior, status context naming, insecure-status handling, configuration parsing, environment variables, and base-branch retargeting.
